### PR TITLE
feat(infra): Add GitHub branch protection automation scripts

### DIFF
--- a/scripts/setup_branch_protection.py
+++ b/scripts/setup_branch_protection.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Setup GitHub branch protection rules for main branch.
+
+Requires: GITHUB_TOKEN environment variable with repo admin access
+"""
+
+import os
+import sys
+
+import requests
+
+
+def setup_branch_protection():
+    """Configure branch protection for main branch."""
+    # Get GitHub token
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("❌ GITHUB_TOKEN environment variable not set")
+        print("\n📝 To create a token:")
+        print("1. Go to https://github.com/settings/tokens")
+        print("2. Click 'Generate new token (classic)'")
+        print("3. Select scopes: 'repo' (full control)")
+        print("4. Copy the token and run:")
+        print("   export GITHUB_TOKEN='your_token_here'")
+        print("   python scripts/setup_branch_protection.py")
+        sys.exit(1)
+
+    # Repository info
+    owner = "stephanejouve"
+    repo = "cyclisme-training-logs"
+    branch = "main"
+
+    # API endpoint
+    url = f"https://api.github.com/repos/{owner}/{repo}/branches/{branch}/protection"
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    # Branch protection configuration
+    protection_config = {
+        "required_status_checks": {
+            "strict": True,  # Require branches to be up to date before merging
+            "contexts": [
+                "lint",
+                "test (3.11)",
+                "test (3.12)",
+                "test (3.13)",
+                "mcp-validation",
+                "status",
+            ],
+        },
+        "enforce_admins": False,  # Allow admins to bypass (useful for emergency fixes)
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": True,
+            "require_code_owner_reviews": False,
+            "required_approving_review_count": 0,  # No review required (CI is enough)
+        },
+        "restrictions": None,  # No push restrictions
+        "required_linear_history": False,
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+        "block_creations": False,
+        "required_conversation_resolution": True,  # Require PR conversations resolved
+        "lock_branch": False,
+    }
+
+    print(f"🔒 Setting up branch protection for {owner}/{repo}:{branch}")
+    print("\nConfiguration:")
+    print(
+        f"  ✅ Require status checks: {', '.join(protection_config['required_status_checks']['contexts'])}"
+    )
+    print(
+        f"  ✅ Require branches up to date: {protection_config['required_status_checks']['strict']}"
+    )
+    print(
+        f"  ✅ Require conversation resolution: {protection_config['required_conversation_resolution']}"
+    )
+    print(f"  ✅ Block force pushes: {not protection_config['allow_force_pushes']}")
+    print(f"  ✅ Block deletions: {not protection_config['allow_deletions']}")
+
+    # Apply protection
+    response = requests.put(url, headers=headers, json=protection_config)
+
+    if response.status_code == 200:
+        print("\n✅ Branch protection successfully configured!")
+        print(f"\n🔗 View settings: https://github.com/{owner}/{repo}/settings/branches")
+        print("\n📋 Protected branch rules:")
+        print("  • All CI checks must pass before merge")
+        print("  • Branch must be up to date with main")
+        print("  • All PR conversations must be resolved")
+        print("  • Force pushes and deletions are blocked")
+        print("\n🎉 main branch is now protected!")
+        return True
+    elif response.status_code == 401:
+        print("\n❌ Authentication failed")
+        print("Check that your GITHUB_TOKEN has 'repo' scope")
+        return False
+    elif response.status_code == 403:
+        print("\n❌ Permission denied")
+        print("Your token needs admin access to the repository")
+        return False
+    elif response.status_code == 404:
+        print("\n❌ Repository or branch not found")
+        print(f"Check that {owner}/{repo}:{branch} exists")
+        return False
+    else:
+        print("\n❌ Failed to configure branch protection")
+        print(f"Status code: {response.status_code}")
+        print(f"Response: {response.text}")
+        return False
+
+
+def check_existing_protection():
+    """Check if branch protection already exists."""
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        return False
+
+    owner = "stephanejouve"
+    repo = "cyclisme-training-logs"
+    branch = "main"
+
+    url = f"https://api.github.com/repos/{owner}/{repo}/branches/{branch}/protection"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+
+    response = requests.get(url, headers=headers)
+
+    if response.status_code == 200:
+        print("ℹ️  Branch protection already exists. It will be updated.")
+        return True
+    elif response.status_code == 404:
+        print("ℹ️  No existing branch protection found. Creating new rules.")
+        return False
+    return False
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("GitHub Branch Protection Setup")
+    print("=" * 60)
+    print()
+
+    check_existing_protection()
+    print()
+
+    if setup_branch_protection():
+        print("\n🚀 Next steps:")
+        print("  1. Try to push directly to main → Should be blocked!")
+        print("  2. Create a PR → CI must pass before merge")
+        print("  3. Never debug in production again! 🎊")
+    else:
+        print("\n⚠️  Setup failed. See instructions above.")
+        sys.exit(1)

--- a/scripts/setup_branch_protection.sh
+++ b/scripts/setup_branch_protection.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+set -e
+
+echo "============================================================"
+echo "GitHub Branch Protection Setup"
+echo "============================================================"
+echo
+
+KEYCHAIN_SERVICE="github-api-token"
+KEYCHAIN_ACCOUNT="stephanejouve"
+
+# Try to get token from keychain
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "🔐 Récupération du token depuis Keychain..."
+    GITHUB_TOKEN=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w 2>/dev/null || true)
+fi
+
+# If still no token, ask for it
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo
+    echo "📝 Token GitHub requis (première utilisation)"
+    echo
+    echo "Pour créer un token:"
+    echo "  1. https://github.com/settings/tokens"
+    echo "  2. 'Generate new token (classic)'"
+    echo "  3. Name: 'CLI Access'"
+    echo "  4. Scopes: ✓ repo"
+    echo "  5. Generate"
+    echo
+    read -sp "Colle ton token (masqué): " GITHUB_TOKEN
+    echo
+    echo
+
+    if [ -z "$GITHUB_TOKEN" ]; then
+        echo "❌ Token vide"
+        exit 1
+    fi
+
+    # Save to keychain
+    echo "💾 Sauvegarde dans Keychain..."
+    security add-generic-password \
+        -s "$KEYCHAIN_SERVICE" \
+        -a "$KEYCHAIN_ACCOUNT" \
+        -w "$GITHUB_TOKEN" \
+        -U 2>/dev/null || \
+    security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" 2>/dev/null && \
+    security add-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w "$GITHUB_TOKEN"
+
+    echo "✅ Token sauvegardé (réutilisable)"
+    echo
+fi
+
+# Config
+OWNER="stephanejouve"
+REPO="cyclisme-training-logs"
+BRANCH="main"
+API_URL="https://api.github.com/repos/$OWNER/$REPO/branches/$BRANCH/protection"
+
+echo "🔒 Configuration de $OWNER/$REPO:$BRANCH"
+echo
+
+# Protection rules
+PROTECTION_CONFIG=$(cat <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "lint",
+      "test (3.11)",
+      "test (3.12)",
+      "test (3.13)",
+      "mcp-validation",
+      "status"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+)
+
+echo "📋 Règles:"
+echo "  ✅ CI obligatoire (6 checks)"
+echo "  ✅ Branche à jour"
+echo "  ✅ Conversations résolues"
+echo "  ✅ Force push bloqué"
+echo
+
+read -p "Appliquer? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 0
+fi
+
+echo "🚀 Application..."
+RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -d "$PROTECTION_CONFIG" \
+  "$API_URL")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+
+case $HTTP_CODE in
+    200)
+        echo
+        echo "✅ Protection activée!"
+        echo
+        echo "🔗 https://github.com/$OWNER/$REPO/settings/branches"
+        echo
+        echo "🎉 Main protégée:"
+        echo "  • Push direct impossible"
+        echo "  • PR + CI obligatoires"
+        echo "  • Force push bloqué"
+        ;;
+    401)
+        echo "❌ Token invalide"
+        echo "Supprime: security delete-generic-password -s '$KEYCHAIN_SERVICE' -a '$KEYCHAIN_ACCOUNT'"
+        exit 1
+        ;;
+    403)
+        echo "❌ Permissions insuffisantes (admin requis)"
+        exit 1
+        ;;
+    404)
+        echo "❌ Repo/branche introuvable"
+        exit 1
+        ;;
+    *)
+        echo "❌ Erreur HTTP $HTTP_CODE"
+        exit 1
+        ;;
+esac

--- a/scripts/setup_branch_ruleset.sh
+++ b/scripts/setup_branch_ruleset.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+set -e
+
+echo "============================================================"
+echo "GitHub Branch Ruleset Setup (Free for private repos)"
+echo "============================================================"
+echo
+
+KEYCHAIN_SERVICE="github-api-token"
+KEYCHAIN_ACCOUNT="stephanejouve"
+
+# Try to get token from keychain
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "🔐 Récupération du token depuis Keychain..."
+    GITHUB_TOKEN=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w 2>/dev/null || true)
+fi
+
+# If still no token, ask for it
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo
+    echo "📝 Token GitHub requis (première utilisation)"
+    echo
+    echo "Pour créer un token:"
+    echo "  1. https://github.com/settings/tokens"
+    echo "  2. 'Generate new token (classic)'"
+    echo "  3. Name: 'CLI Access'"
+    echo "  4. Scopes: ✓ repo"
+    echo "  5. Generate"
+    echo
+    read -sp "Colle ton token (masqué): " GITHUB_TOKEN
+    echo
+    echo
+
+    if [ -z "$GITHUB_TOKEN" ]; then
+        echo "❌ Token vide"
+        exit 1
+    fi
+
+    # Save to keychain
+    echo "💾 Sauvegarde dans Keychain..."
+    security add-generic-password \
+        -s "$KEYCHAIN_SERVICE" \
+        -a "$KEYCHAIN_ACCOUNT" \
+        -w "$GITHUB_TOKEN" \
+        -U 2>/dev/null || \
+    security delete-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" 2>/dev/null && \
+    security add-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w "$GITHUB_TOKEN"
+
+    echo "✅ Token sauvegardé (réutilisable)"
+    echo
+fi
+
+# Config
+OWNER="stephanejouve"
+REPO="cyclisme-training-logs"
+API_URL="https://api.github.com/repos/$OWNER/$REPO/rulesets"
+
+echo "🔒 Configuration du ruleset pour $OWNER/$REPO:main"
+echo
+
+# Ruleset configuration
+RULESET_CONFIG=$(cat <<'JSON'
+{
+  "name": "Protect main branch",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "lint",
+            "integration_id": null
+          },
+          {
+            "context": "test (3.11)",
+            "integration_id": null
+          },
+          {
+            "context": "test (3.12)",
+            "integration_id": null
+          },
+          {
+            "context": "test (3.13)",
+            "integration_id": null
+          },
+          {
+            "context": "mcp-validation",
+            "integration_id": null
+          },
+          {
+            "context": "status",
+            "integration_id": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "deletion"
+    }
+  ]
+}
+JSON
+)
+
+echo "📋 Règles:"
+echo "  ✅ CI obligatoire (6 checks)"
+echo "  ✅ Branche à jour"
+echo "  ✅ PR avec conversations résolues"
+echo "  ✅ Force push bloqué"
+echo "  ✅ Suppression bloquée"
+echo
+
+read -p "Appliquer? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 0
+fi
+
+echo "🚀 Application..."
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -d "$RULESET_CONFIG" \
+  "$API_URL")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+
+case $HTTP_CODE in
+    201)
+        echo
+        echo "✅ Ruleset créé avec succès!"
+        echo
+        echo "🔗 https://github.com/$OWNER/$REPO/settings/rules"
+        echo
+        echo "🎉 Main protégée:"
+        echo "  • Push direct impossible sans CI"
+        echo "  • PR + CI obligatoires"
+        echo "  • Force push bloqué"
+        echo "  • Suppression bloquée"
+        ;;
+    401)
+        echo "❌ Token invalide"
+        echo "Supprime: security delete-generic-password -s '$KEYCHAIN_SERVICE' -a '$KEYCHAIN_ACCOUNT'"
+        exit 1
+        ;;
+    403)
+        echo "❌ Permissions insuffisantes (admin requis)"
+        exit 1
+        ;;
+    404)
+        echo "❌ Repo introuvable"
+        exit 1
+        ;;
+    422)
+        echo "⚠️ Ruleset déjà existant ou conflit"
+        echo "Vérifie: https://github.com/$OWNER/$REPO/settings/rules"
+        BODY=$(echo "$RESPONSE" | head -n -1)
+        echo "$BODY" | python3 -m json.tool 2>/dev/null || echo "$BODY"
+        exit 1
+        ;;
+    *)
+        echo "❌ Erreur HTTP $HTTP_CODE"
+        BODY=$(echo "$RESPONSE" | head -n -1)
+        echo "$BODY" | python3 -m json.tool 2>/dev/null || echo "$BODY"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Add automation scripts to configure GitHub branch protection with macOS Keychain integration for secure token storage.

Three scripts included:
- **setup_branch_protection.py**: Python implementation with detailed documentation
- **setup_branch_protection.sh**: Bash script using classic branch protection API
- **setup_branch_ruleset.sh**: Modern rulesets API (✅ used for main protection)

## Changes

**Security Features:**
- macOS Keychain integration for secure GitHub token storage
- Interactive token setup on first run with automatic save
- Token reuse across script executions

**Protection Rules Applied:**
- ✅ Required CI checks: lint, test (3.11, 3.12, 3.13), mcp-validation, status
- ✅ Branch must be up to date before merge
- ✅ PR conversation resolution required
- ✅ Force push blocked
- ✅ Branch deletion blocked

**Active Ruleset:** #13080217 successfully applied to main branch

## Test Plan

- [x] GitHub Pro subscription activated
- [x] Ruleset creation script executed successfully
- [x] Main branch protection verified (ruleset ID: 13080217)
- [x] Token stored in macOS Keychain
- [x] Scripts formatted and linted (pre-commit hooks passed)
- [ ] Verify CI checks run on this PR
- [ ] Confirm main branch protection blocks direct push

## Impact

**Before:**
- No branch protection on main
- Direct pushes allowed without CI validation
- Risk of breaking changes reaching production

**After:**
- Strict branch protection enforced via GitHub Rulesets
- All changes require PR + CI validation
- Force push and deletion blocked
- Automated setup scripts for future repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)