### PR TITLE
fix(docs): Force CI badge to show main branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cyclisme Training Logs
 
-[![CI](https://github.com/stephanejouve/cyclisme-training-logs/actions/workflows/ci.yml/badge.svg)](https://github.com/stephanejouve/cyclisme-training-logs/actions/workflows/ci.yml)
+[![CI](https://github.com/stephanejouve/cyclisme-training-logs/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/stephanejouve/cyclisme-training-logs/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/stephanejouve/cyclisme-training-logs/branch/main/graph/badge.svg)](https://codecov.io/gh/stephanejouve/cyclisme-training-logs)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Poetry](https://img.shields.io/badge/poetry-managed-blue)](https://python-poetry.org/)


### PR DESCRIPTION
Add `?branch=main` parameter to CI badge URL to bypass cache and ensure badge always reflects main branch status.

Fixes the "failing" badge issue even though all CI checks pass on main.