### PR TITLE
fix(mcp): Fix sync & swap — 4 bugs + remote swap enhancement

### DIFF
--- a/cyclisme_training_logs/mcp_server.py
+++ b/cyclisme_training_logs/mcp_server.py
@@ -466,6 +466,11 @@ async def list_tools() -> list[Tool]:
                         "description": "Force update all sessions even if unchanged (default: false)",
                         "default": False,
                     },
+                    "session_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional: only sync these session IDs (e.g., ['S081-03', 'S081-06'])",
+                    },
                 },
                 "required": ["week_id"],
             },
@@ -1875,7 +1880,8 @@ async def handle_duplicate_session(args: dict) -> list[TextContent]:
 
 
 async def handle_swap_sessions(args: dict) -> list[TextContent]:
-    """Swap the dates of two sessions."""
+    """Swap the dates of two sessions and update remote events if synced."""
+    from cyclisme_training_logs.config import create_intervals_client
     from cyclisme_training_logs.planning.control_tower import planning_tower
 
     week_id = args["week_id"]
@@ -1883,6 +1889,12 @@ async def handle_swap_sessions(args: dict) -> list[TextContent]:
     session_id_2 = args["session_id_2"]
 
     try:
+        # Track session data for remote update after local swap
+        intervals_id_1 = None
+        intervals_id_2 = None
+        new_date_1 = None
+        new_date_2 = None
+
         # Suppress all output to prevent JSON protocol pollution
         with suppress_stdout_stderr():
             # Modify via Control Tower
@@ -1923,15 +1935,41 @@ async def handle_swap_sessions(args: dict) -> list[TextContent]:
                 session_1.session_date = session_2.session_date
                 session_2.session_date = temp_date
 
+                # Capture data for remote update
+                intervals_id_1 = session_1.intervals_id
+                intervals_id_2 = session_2.intervals_id
+                new_date_1 = session_1.session_date
+                new_date_2 = session_2.session_date
+
                 # Re-sort sessions
                 plan.planned_sessions.sort(key=lambda s: (s.session_date, s.session_id))
+
+            # Update remote events if both sessions are synced
+            remote_updated = False
+            if intervals_id_1 and intervals_id_2:
+                client = create_intervals_client()
+                start_time_1 = _compute_start_time(new_date_1, session_id_1)
+                start_time_2 = _compute_start_time(new_date_2, session_id_2)
+
+                client.update_event(
+                    intervals_id_1,
+                    {"start_date_local": f"{new_date_1}T{start_time_1}"},
+                )
+                client.update_event(
+                    intervals_id_2,
+                    {"start_date_local": f"{new_date_2}T{start_time_2}"},
+                )
+                remote_updated = True
 
         result = {
             "status": "success",
             "week_id": week_id,
             "session_id_1": session_id_1,
             "session_id_2": session_id_2,
-            "message": f"Sessions swapped successfully: {session_id_1} <-> {session_id_2}",
+            "swapped_session_ids": [session_id_1, session_id_2],
+            "remote_updated": remote_updated,
+            "message": f"Sessions swapped successfully: {session_id_1} <-> {session_id_2}"
+            + (" (+ remote events updated)" if remote_updated else ""),
         }
 
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
@@ -2095,6 +2133,66 @@ async def handle_get_workout(args: dict) -> list[TextContent]:
         ]
 
 
+# Statuses that should be synced to Intervals.icu.
+# Any other status (completed, skipped, cancelled, rest_day, replaced) is protected.
+SYNCABLE_STATUSES = {"pending", "planned", "uploaded", "modified"}
+
+
+def _compute_start_time(session_date, session_id: str) -> str:
+    """Compute start time for an Intervals.icu event.
+
+    Args:
+        session_date: Date of the session (date object with .weekday()).
+        session_id: Session ID (e.g., "S081-04", "S081-06a", "S081-06b").
+
+    Returns:
+        Time string like "09:00:00" or "17:00:00".
+    """
+    day_of_week = session_date.weekday()  # 0=Monday, 5=Saturday
+    session_day_part = session_id.split("-")[-1]  # e.g., "04" or "06a"
+    session_suffix = session_day_part[-1] if session_day_part[-1].isalpha() else None
+
+    if session_suffix == "a":
+        return "09:00:00"  # Morning
+    elif session_suffix == "b":
+        return "15:00:00"  # Afternoon
+    else:
+        # Saturday → 09:00, other days → 17:00
+        return "09:00:00" if day_of_week == 5 else "17:00:00"
+
+
+def _load_workout_descriptions(week_id: str) -> dict[str, str]:
+    """Load full workout descriptions from {week_id}_workouts.txt.
+
+    Parses the === WORKOUT ... === / === FIN WORKOUT === delimited file
+    and returns a dict mapping intervals_name → full description.
+
+    Args:
+        week_id: Week ID (e.g., "S081").
+
+    Returns:
+        Dict {intervals_name: full_description}. Empty dict if file not found.
+    """
+    import re
+
+    from cyclisme_training_logs.planning.control_tower import planning_tower
+
+    workouts_file = planning_tower.planning_dir / f"{week_id}_workouts.txt"
+    if not workouts_file.exists():
+        return {}
+
+    content = workouts_file.read_text(encoding="utf-8")
+    pattern = r"=== WORKOUT (.*?) ===\n(.*?)\n=== FIN WORKOUT ==="
+    matches = re.findall(pattern, content, re.DOTALL)
+
+    descriptions = {}
+    for workout_name, workout_content in matches:
+        name = workout_name.strip()
+        descriptions[name] = workout_content.strip()
+
+    return descriptions
+
+
 async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
     """Synchronize week planning to Intervals.icu."""
     from cyclisme_training_logs.config import create_intervals_client
@@ -2103,6 +2201,7 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
     week_id = args["week_id"]
     dry_run = args.get("dry_run", False)
     force_update = args.get("force_update", False)
+    session_ids = args.get("session_ids")
 
     try:
         # Suppress all output to prevent JSON protocol pollution
@@ -2121,53 +2220,54 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
             # Filter to workouts only
             remote_workouts = {e["id"]: e for e in remote_events if e.get("category") == "WORKOUT"}
 
+            # Load full workout descriptions from workouts.txt
+            workout_descriptions = _load_workout_descriptions(week_id)
+
             # Track changes
             to_create = []
             to_update = []
-            to_skip_completed = []
+            to_skip_protected = []
             warnings = []
             errors = []
 
+            # Determine sessions to process (selective sync support)
+            sessions_to_process = plan.planned_sessions
+            if session_ids:
+                session_ids_set = set(session_ids)
+                sessions_to_process = [
+                    s for s in plan.planned_sessions if s.session_id in session_ids_set
+                ]
+
             # Process each session
-            for session in plan.planned_sessions:
-                # PROTECTION: Never modify completed sessions
-                if session.status == "completed":
-                    to_skip_completed.append(
+            for session in sessions_to_process:
+                # PROTECTION: Only sync sessions with syncable statuses
+                if session.status not in SYNCABLE_STATUSES:
+                    to_skip_protected.append(
                         {
                             "session_id": session.session_id,
                             "name": session.name,
-                            "reason": "Session completed - protected from sync",
+                            "status": session.status,
+                            "reason": f"Session {session.status} - protected from sync",
                         }
                     )
                     continue
 
-                # Prepare event data
-                # Determine start time based on day and session suffix
-                day_of_week = session.session_date.weekday()  # 0=Monday, 5=Saturday
-                session_day_part = session.session_id.split("-")[-1]  # e.g., "04" or "06a"
-
-                # Check if session has letter suffix (double session)
-                session_suffix = session_day_part[-1] if session_day_part[-1].isalpha() else None
-
-                # Double session (a/b)
-                if session_suffix == "a":
-                    start_time = "09:00:00"  # Morning
-                elif session_suffix == "b":
-                    start_time = "15:00:00"  # Afternoon
-                else:
-                    # Saturday → 09:00, other days → 17:00
-                    start_time = "09:00:00" if day_of_week == 5 else "17:00:00"
+                # Compute start time using shared helper
+                start_time = _compute_start_time(session.session_date, session.session_id)
 
                 # Build Intervals.icu event name: S082-03-INT-SweetSpotBlocs-V001
                 intervals_name = (
                     f"{session.session_id}-{session.session_type}-{session.name}-{session.version}"
                 )
 
+                # Use full workout description from workouts.txt if available
+                full_description = workout_descriptions.get(intervals_name, session.description)
+
                 event_data = {
                     "category": "WORKOUT",
                     "type": "VirtualRide",
                     "name": intervals_name,
-                    "description": session.description,
+                    "description": full_description,
                     "start_date_local": f"{session.session_date}T{start_time}",
                 }
 
@@ -2178,12 +2278,14 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
                         remote_event = remote_workouts[session.intervals_id]
 
                         # 🛡️ VALIDATION: Detect if remote was manually modified
+                        # Compare full intervals_name (not short session.name) and date
                         remote_name = remote_event.get("name", "")
-                        remote_desc = remote_event.get("description", "")
-                        local_name = session.name
-                        local_desc = session.description
+                        remote_start = remote_event.get("start_date_local", "")
+                        local_start = f"{session.session_date}T{start_time}"
 
-                        has_remote_changes = remote_name != local_name or remote_desc != local_desc
+                        has_remote_changes = (
+                            remote_name != intervals_name or remote_start != local_start
+                        )
 
                         if has_remote_changes and not force_update:
                             # Remote has been manually modified - warn about conflict
@@ -2193,7 +2295,7 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
                                     "intervals_id": session.intervals_id,
                                     "type": "remote_modification_detected",
                                     "message": f"⚠️ Remote event {session.intervals_id} has been manually modified in Intervals.icu",
-                                    "local_name": local_name,
+                                    "local_name": intervals_name,
                                     "remote_name": remote_name,
                                     "suggestion": "Use force_update=true to overwrite remote changes",
                                 }
@@ -2205,12 +2307,18 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
                         needs_update = force_update or has_remote_changes
 
                         if needs_update:
+                            # For updates: only send name + start_date_local,
+                            # NOT description (remote is source of truth for workout content)
+                            update_data = {
+                                "name": intervals_name,
+                                "start_date_local": f"{session.session_date}T{start_time}",
+                            }
                             to_update.append(
                                 {
                                     "session_id": session.session_id,
                                     "intervals_id": session.intervals_id,
                                     "name": session.name,
-                                    "event_data": event_data,
+                                    "event_data": update_data,
                                 }
                             )
                     else:
@@ -2302,7 +2410,7 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
             "summary": {
                 "to_create": len(to_create),
                 "to_update": len(to_update),
-                "skipped_completed": len(to_skip_completed),
+                "skipped_protected": len(to_skip_protected),
                 "warnings": len(warnings),
                 "created": created_count if not dry_run else 0,
                 "updated": updated_count if not dry_run else 0,
@@ -2320,7 +2428,7 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
                     }
                     for item in to_update
                 ],
-                "skipped_completed": to_skip_completed,
+                "skipped_protected": to_skip_protected,
             },
             "warnings": warnings if warnings else None,
             "errors": errors if errors else None,

--- a/tests/test_mcp_extra_handlers.py
+++ b/tests/test_mcp_extra_handlers.py
@@ -164,6 +164,9 @@ class TestHandleUpdateSession:
 # =======================
 
 
+LOAD_WORKOUTS_PATCH = "cyclisme_training_logs.mcp_server._load_workout_descriptions"
+
+
 class TestHandleSyncWeekToIntervals:
     @pytest.mark.asyncio
     async def test_dry_run_no_api_calls(self, mock_plan, mock_session):
@@ -179,7 +182,8 @@ class TestHandleSyncWeekToIntervals:
         args = {"week_id": "S081", "dry_run": True}
         with patch(TOWER_PATCH, tower):
             with patch(INTERVALS_PATCH, return_value=mock_client):
-                result = await handle_sync_week_to_intervals(args)
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
         data = json.loads(result[0].text)
         assert data["dry_run"] is True
         assert data["summary"]["to_create"] == 1
@@ -201,9 +205,10 @@ class TestHandleSyncWeekToIntervals:
         args = {"week_id": "S081", "dry_run": True}
         with patch(TOWER_PATCH, tower):
             with patch(INTERVALS_PATCH, return_value=mock_client):
-                result = await handle_sync_week_to_intervals(args)
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
         data = json.loads(result[0].text)
-        assert data["summary"]["skipped_completed"] == 1
+        assert data["summary"]["skipped_protected"] == 1
         assert data["summary"]["to_create"] == 0
 
     @pytest.mark.asyncio
@@ -227,18 +232,18 @@ class TestHandleSyncWeekToIntervals:
 
         mock_session.intervals_id = "evt123"
         mock_session.status = "pending"
-        mock_session.name = "SameName"
-        mock_session.description = "Same description"
+        mock_session.name = "TempoCourt"
+        mock_session.description = "Tempo 3x10min"
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
         mock_client = Mock()
-        # Remote event with same name/description (no conflict)
+        # Remote event with full intervals_name and matching start_date (no conflict)
         mock_client.get_events.return_value = [
             {
                 "id": "evt123",
                 "category": "WORKOUT",
-                "name": "SameName",
-                "description": "Same description",
+                "name": "S081-03-INT-TempoCourt-V001",
+                "start_date_local": "2026-02-19T17:00:00",
             },
         ]
         mock_client.update_event.return_value = True
@@ -246,9 +251,10 @@ class TestHandleSyncWeekToIntervals:
         args = {"week_id": "S081", "dry_run": True, "force_update": False}
         with patch(TOWER_PATCH, tower):
             with patch(INTERVALS_PATCH, return_value=mock_client):
-                result = await handle_sync_week_to_intervals(args)
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
         data = json.loads(result[0].text)
-        # No changes needed (same name/desc)
+        # No changes needed (same name and date)
         assert data["summary"]["to_update"] == 0
 
     @pytest.mark.asyncio
@@ -258,28 +264,175 @@ class TestHandleSyncWeekToIntervals:
 
         mock_session.intervals_id = "evt123"
         mock_session.status = "pending"
-        mock_session.name = "LocalName"
-        mock_session.description = "Local desc"
+        mock_session.name = "TempoCourt"
+        mock_session.description = "Tempo 3x10min"
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
         mock_client = Mock()
-        # Remote event has different name (manually modified)
+        # Remote event has different name (manually modified in Intervals.icu)
         mock_client.get_events.return_value = [
             {
                 "id": "evt123",
                 "category": "WORKOUT",
-                "name": "RemoteName",
-                "description": "Remote desc",
+                "name": "ManuallyRenamedWorkout",
+                "start_date_local": "2026-02-19T17:00:00",
             },
         ]
 
         args = {"week_id": "S081", "dry_run": True, "force_update": False}
         with patch(TOWER_PATCH, tower):
             with patch(INTERVALS_PATCH, return_value=mock_client):
-                result = await handle_sync_week_to_intervals(args)
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
         data = json.loads(result[0].text)
         assert data["summary"]["warnings"] == 1
         assert data["status"] == "success_with_warnings"
+
+    @pytest.mark.asyncio
+    async def test_skipped_session_not_synced(self, mock_plan, mock_session):
+        """Skipped sessions are protected — not synced to Intervals.icu."""
+        from cyclisme_training_logs.mcp_server import handle_sync_week_to_intervals
+
+        mock_session.status = "skipped"
+        mock_session.intervals_id = None
+        mock_plan.planned_sessions = [mock_session]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+        mock_client.get_events.return_value = []
+
+        args = {"week_id": "S081", "dry_run": True}
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
+        data = json.loads(result[0].text)
+        assert data["summary"]["skipped_protected"] == 1
+        assert data["summary"]["to_create"] == 0
+        assert data["details"]["skipped_protected"][0]["status"] == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_rest_day_session_not_synced(self, mock_plan, mock_session):
+        """Rest day sessions are protected — not synced to Intervals.icu."""
+        from cyclisme_training_logs.mcp_server import handle_sync_week_to_intervals
+
+        mock_session.status = "rest_day"
+        mock_session.intervals_id = None
+        mock_plan.planned_sessions = [mock_session]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+        mock_client.get_events.return_value = []
+
+        args = {"week_id": "S081", "dry_run": True}
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
+        data = json.loads(result[0].text)
+        assert data["summary"]["skipped_protected"] == 1
+        assert data["summary"]["to_create"] == 0
+        assert data["details"]["skipped_protected"][0]["status"] == "rest_day"
+
+    @pytest.mark.asyncio
+    async def test_name_comparison_uses_full_intervals_name(self, mock_plan, mock_session):
+        """Bug 2: Comparison uses full intervals_name, not short session.name."""
+        from cyclisme_training_logs.mcp_server import handle_sync_week_to_intervals
+
+        mock_session.intervals_id = "evt123"
+        mock_session.status = "pending"
+        mock_session.name = "TempoCourt"
+        mock_session.session_type = "INT"
+        mock_session.version = "V001"
+        mock_plan.planned_sessions = [mock_session]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+        # Remote has short name (old bug would match wrongly)
+        mock_client.get_events.return_value = [
+            {
+                "id": "evt123",
+                "category": "WORKOUT",
+                "name": "TempoCourt",  # Short name, NOT full intervals_name
+                "start_date_local": "2026-02-19T17:00:00",
+            },
+        ]
+
+        args = {"week_id": "S081", "dry_run": True, "force_update": False}
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
+        data = json.loads(result[0].text)
+        # Short name != full intervals_name → conflict detected
+        assert data["summary"]["warnings"] == 1
+
+    @pytest.mark.asyncio
+    async def test_update_payload_excludes_description(self, mock_plan, mock_session):
+        """Bug 3: Update payload sends only name + start_date_local, not description."""
+        from cyclisme_training_logs.mcp_server import handle_sync_week_to_intervals
+
+        mock_session.intervals_id = "evt123"
+        mock_session.status = "pending"
+        mock_session.name = "TempoCourt"
+        mock_session.session_type = "INT"
+        mock_session.version = "V001"
+        mock_session.description = "Short desc"
+        mock_plan.planned_sessions = [mock_session]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+        # Remote has different date (triggers update)
+        mock_client.get_events.return_value = [
+            {
+                "id": "evt123",
+                "category": "WORKOUT",
+                "name": "S081-03-INT-TempoCourt-V001",
+                "start_date_local": "2026-02-20T17:00:00",  # Wrong date
+            },
+        ]
+        mock_client.update_event.return_value = True
+
+        args = {"week_id": "S081", "dry_run": False, "force_update": True}
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
+        data = json.loads(result[0].text)
+        assert data["summary"]["updated"] == 1
+        # Verify the update_event was called without description
+        update_call = mock_client.update_event.call_args
+        event_data = update_call[0][1]
+        assert "description" not in event_data
+        assert "name" in event_data
+        assert "start_date_local" in event_data
+
+    @pytest.mark.asyncio
+    async def test_session_ids_filter(self, mock_plan, mock_session):
+        """Bug 4: session_ids parameter filters which sessions are synced."""
+        from cyclisme_training_logs.mcp_server import handle_sync_week_to_intervals
+
+        # Add a second session
+        session2 = Mock()
+        session2.session_id = "S081-06"
+        session2.session_date = date(2026, 2, 22)
+        session2.name = "EnduranceLongue"
+        session2.session_type = "END"
+        session2.version = "V001"
+        session2.description = "90min endurance"
+        session2.status = "pending"
+        session2.intervals_id = None
+        mock_session.intervals_id = None
+        mock_plan.planned_sessions = [mock_session, session2]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+        mock_client.get_events.return_value = []
+
+        # Only sync session2
+        args = {"week_id": "S081", "dry_run": True, "session_ids": ["S081-06"]}
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                with patch(LOAD_WORKOUTS_PATCH, return_value={}):
+                    result = await handle_sync_week_to_intervals(args)
+        data = json.loads(result[0].text)
+        assert data["summary"]["to_create"] == 1
+        assert data["details"]["to_create"][0]["session_id"] == "S081-06"
 
 
 # =======================

--- a/tests/test_mcp_new_handlers.py
+++ b/tests/test_mcp_new_handlers.py
@@ -565,6 +565,59 @@ class TestHandleSwapSessions:
         data = json.loads(result[0].text)
         assert "error" in data
 
+    @pytest.mark.asyncio
+    async def test_swap_updates_remote_events(self, mock_plan, mock_session, mock_session2):
+        """Enhancement: swap updates remote events when both sessions have intervals_id."""
+        from cyclisme_training_logs.mcp_server import handle_swap_sessions
+
+        mock_session.intervals_id = "evt1"
+        mock_session2.intervals_id = "evt2"
+        mock_plan.planned_sessions = [mock_session, mock_session2]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+        mock_client.update_event.return_value = True
+
+        args = {
+            "week_id": "S081",
+            "session_id_1": "S081-03",
+            "session_id_2": "S081-06",
+        }
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                result = await handle_swap_sessions(args)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["remote_updated"] is True
+        assert set(data["swapped_session_ids"]) == {"S081-03", "S081-06"}
+        # Both remote events should have been updated
+        assert mock_client.update_event.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_swap_no_remote_update_without_intervals_ids(
+        self, mock_plan, mock_session, mock_session2
+    ):
+        """No remote update when sessions lack intervals_id."""
+        from cyclisme_training_logs.mcp_server import handle_swap_sessions
+
+        mock_session.intervals_id = None
+        mock_session2.intervals_id = "evt2"  # Only one has id
+        mock_plan.planned_sessions = [mock_session, mock_session2]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+
+        args = {
+            "week_id": "S081",
+            "session_id_1": "S081-03",
+            "session_id_2": "S081-06",
+        }
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                result = await handle_swap_sessions(args)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["remote_updated"] is False
+        mock_client.update_event.assert_not_called()
+
 
 # =======================
 # TestHandleAttachWorkout


### PR DESCRIPTION
## Summary
- **Bug 1**: Protect skipped/cancelled/rest_day/replaced sessions from sync (was only filtering `completed`, creating WORKOUT duplicates)
- **Bug 2**: Compare full `intervals_name` + `start_date_local` instead of short `session.name` + `description` (false conflict detection)
- **Bug 3**: Use full workout descriptions from `workouts.txt` for creates; exclude description from update payloads (remote = source of truth)
- **Bug 4**: Add optional `session_ids` parameter for selective sync
- **Enhancement**: `swap_sessions` now updates remote Intervals.icu events directly (no need for sync after swap)

## Test plan
- [x] 98 tests passing (3 updated + 7 new)
- [x] Pre-commit hooks (black, ruff, isort, pydocstyle) all pass
- [ ] Manual test: MCP swap + sync on live week

🤖 Generated with [Claude Code](https://claude.com/claude-code)