### PR TITLE
fix(mcp): Swap session IDs along with dates in swap handler

### DIFF
--- a/cyclisme_training_logs/mcp_server.py
+++ b/cyclisme_training_logs/mcp_server.py
@@ -1935,11 +1935,27 @@ async def handle_swap_sessions(args: dict) -> list[TextContent]:
                 session_1.session_date = session_2.session_date
                 session_2.session_date = temp_date
 
-                # Capture data for remote update
+                # Swap session_ids so the day index matches the new date
+                # e.g., S082-04 (Thu) <-> S082-05 (Fri) → each keeps its
+                # workout content but gets the other's id+date slot
+                temp_id = session_1.session_id
+                session_1.session_id = session_2.session_id
+                session_2.session_id = temp_id
+
+                # Capture data for remote update (after id swap)
                 intervals_id_1 = session_1.intervals_id
                 intervals_id_2 = session_2.intervals_id
                 new_date_1 = session_1.session_date
                 new_date_2 = session_2.session_date
+                # Build new intervals_names with swapped session_ids
+                new_name_1 = (
+                    f"{session_1.session_id}-{session_1.session_type}"
+                    f"-{session_1.name}-{session_1.version}"
+                )
+                new_name_2 = (
+                    f"{session_2.session_id}-{session_2.session_type}"
+                    f"-{session_2.name}-{session_2.version}"
+                )
 
                 # Re-sort sessions
                 plan.planned_sessions.sort(key=lambda s: (s.session_date, s.session_id))
@@ -1948,16 +1964,22 @@ async def handle_swap_sessions(args: dict) -> list[TextContent]:
             remote_updated = False
             if intervals_id_1 and intervals_id_2:
                 client = create_intervals_client()
-                start_time_1 = _compute_start_time(new_date_1, session_id_1)
-                start_time_2 = _compute_start_time(new_date_2, session_id_2)
+                start_time_1 = _compute_start_time(new_date_1, session_1.session_id)
+                start_time_2 = _compute_start_time(new_date_2, session_2.session_id)
 
                 client.update_event(
                     intervals_id_1,
-                    {"start_date_local": f"{new_date_1}T{start_time_1}"},
+                    {
+                        "name": new_name_1,
+                        "start_date_local": f"{new_date_1}T{start_time_1}",
+                    },
                 )
                 client.update_event(
                     intervals_id_2,
-                    {"start_date_local": f"{new_date_2}T{start_time_2}"},
+                    {
+                        "name": new_name_2,
+                        "start_date_local": f"{new_date_2}T{start_time_2}",
+                    },
                 )
                 remote_updated = True
 

--- a/tests/test_mcp_new_handlers.py
+++ b/tests/test_mcp_new_handlers.py
@@ -567,7 +567,7 @@ class TestHandleSwapSessions:
 
     @pytest.mark.asyncio
     async def test_swap_updates_remote_events(self, mock_plan, mock_session, mock_session2):
-        """Enhancement: swap updates remote events when both sessions have intervals_id."""
+        """Enhancement: swap updates remote events with new name + date."""
         from cyclisme_training_logs.mcp_server import handle_swap_sessions
 
         mock_session.intervals_id = "evt1"
@@ -589,8 +589,33 @@ class TestHandleSwapSessions:
         assert data["status"] == "success"
         assert data["remote_updated"] is True
         assert set(data["swapped_session_ids"]) == {"S081-03", "S081-06"}
-        # Both remote events should have been updated
+        # Both remote events should have been updated with name + start_date_local
         assert mock_client.update_event.call_count == 2
+        for call in mock_client.update_event.call_args_list:
+            event_data = call[0][1]
+            assert "name" in event_data
+            assert "start_date_local" in event_data
+
+    @pytest.mark.asyncio
+    async def test_swap_session_ids_are_exchanged(self, mock_plan, mock_session, mock_session2):
+        """Session IDs are swapped so day index matches the new date."""
+        from cyclisme_training_logs.mcp_server import handle_swap_sessions
+
+        mock_plan.planned_sessions = [mock_session, mock_session2]
+        tower = make_tower(mock_plan)
+        args = {
+            "week_id": "S081",
+            "session_id_1": "S081-03",
+            "session_id_2": "S081-06",
+        }
+        with patch(TOWER_PATCH, tower):
+            result = await handle_swap_sessions(args)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        # After swap: session_1 (TempoCourt) should now have id S081-06
+        # and session_2 (EnduranceLongue) should now have id S081-03
+        assert mock_session.session_id == "S081-06"
+        assert mock_session2.session_id == "S081-03"
 
     @pytest.mark.asyncio
     async def test_swap_no_remote_update_without_intervals_ids(


### PR DESCRIPTION
## Summary
- When swapping sessions between days, the `session_id` (day index) is now also exchanged so it stays consistent with the new date
- Remote event names are updated with the corrected `intervals_name` (which includes the session_id)
- Before: `S082-05` on Thursday, `S082-04` on Friday (wrong indices)
- After: `S082-04` on Thursday, `S082-05` on Friday (correct)

## Test plan
- [x] 99 tests passing (+1 new: `test_swap_session_ids_are_exchanged`)
- [x] Pre-commit hooks all pass
- [ ] Manual MCP test on live week

🤖 Generated with [Claude Code](https://claude.com/claude-code)