### PR TITLE
feat(mcp): Add compare-intervals tool

### DIFF
--- a/cyclisme_training_logs/mcp_server.py
+++ b/cyclisme_training_logs/mcp_server.py
@@ -574,6 +574,43 @@ async def list_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="compare-intervals",
+            description="Compare interval data across multiple activities to track progression over time. Aligns intervals by label, calculates deltas and trends for metrics like power, HR, cadence, torque, decoupling.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "activity_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Explicit list of activity IDs to compare (e.g. ['i122793458', 'i126184461'])",
+                    },
+                    "name_pattern": {
+                        "type": "string",
+                        "description": "Search activities by name substring (case-insensitive, e.g. 'CadenceVariations')",
+                    },
+                    "weeks_back": {
+                        "type": "integer",
+                        "description": "Number of weeks to search back (default: 6, used with name_pattern)",
+                        "default": 6,
+                    },
+                    "label_filter": {
+                        "type": "string",
+                        "description": "Only keep intervals whose label contains this substring (case-insensitive, e.g. '95rpm')",
+                    },
+                    "type_filter": {
+                        "type": "string",
+                        "enum": ["WORK", "RECOVERY"],
+                        "description": "Only keep intervals of this type",
+                    },
+                    "metrics": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Metrics to include in comparison (default: all numeric metrics)",
+                    },
+                },
+            },
+        ),
+        Tool(
             name="apply-workout-intervals",
             description="Apply custom interval boundaries to an Intervals.icu activity. Auto mode: parses workout prescription to compute intervals. Manual mode: accepts explicit interval list. Always dry_run=true by default (preview only).",
             inputSchema={
@@ -1069,6 +1106,8 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
             return await handle_get_activity_details(arguments)
         elif name == "get-activity-intervals":
             return await handle_get_activity_intervals(arguments)
+        elif name == "compare-intervals":
+            return await handle_compare_intervals(arguments)
         elif name == "apply-workout-intervals":
             return await handle_apply_workout_intervals(arguments)
         elif name == "update-remote-session":
@@ -3074,6 +3113,259 @@ async def handle_get_activity_intervals(args: dict) -> list[TextContent]:
                         "error": f"Failed to get activity intervals: {str(e)}",
                         "activity_id": activity_id,
                     },
+                    indent=2,
+                ),
+            )
+        ]
+
+
+async def handle_compare_intervals(args: dict) -> list[TextContent]:
+    """Compare interval data across multiple activities to track progression."""
+    from cyclisme_training_logs.config import create_intervals_client
+
+    NUMERIC_METRICS = {
+        "elapsed_time",
+        "moving_time",
+        "distance",
+        "average_watts",
+        "weighted_average_watts",
+        "min_watts",
+        "max_watts",
+        "average_heartrate",
+        "min_heartrate",
+        "max_heartrate",
+        "average_cadence",
+        "intensity",
+        "training_load",
+        "decoupling",
+        "average_speed",
+        "total_elevation_gain",
+        "average_torque",
+        "min_torque",
+        "max_torque",
+        "avg_lr_balance",
+    }
+
+    activity_ids = args.get("activity_ids")
+    name_pattern = args.get("name_pattern")
+    weeks_back = args.get("weeks_back", 6)
+    label_filter = args.get("label_filter")
+    type_filter = args.get("type_filter")
+    requested_metrics = args.get("metrics")
+
+    # Validation: need at least one mode
+    if not activity_ids and not name_pattern:
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {
+                        "error": "Either 'activity_ids' or 'name_pattern' is required.",
+                    },
+                    indent=2,
+                ),
+            )
+        ]
+
+    # Validate metrics if provided
+    if requested_metrics:
+        invalid = [m for m in requested_metrics if m not in NUMERIC_METRICS]
+        if invalid:
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "error": f"Invalid metrics: {invalid}",
+                            "available_metrics": sorted(NUMERIC_METRICS),
+                        },
+                        indent=2,
+                    ),
+                )
+            ]
+
+    try:
+        with suppress_stdout_stderr():
+            client = create_intervals_client()
+
+        # Resolve activities
+        if activity_ids:
+            mode = "explicit"
+            resolved = []
+            for aid in activity_ids:
+                with suppress_stdout_stderr():
+                    act = client.get_activity(aid)
+                resolved.append(
+                    {
+                        "id": aid,
+                        "name": act.get("name", ""),
+                        "date": (act.get("start_date_local", "") or "")[:10],
+                    }
+                )
+        else:
+            mode = "search"
+            newest = date.today().isoformat()
+            oldest = (date.today() - timedelta(weeks=weeks_back)).isoformat()
+            with suppress_stdout_stderr():
+                all_activities = client.get_activities(oldest=oldest, newest=newest)
+            pattern_lower = name_pattern.lower()
+            resolved = [
+                {
+                    "id": a.get("id", ""),
+                    "name": a.get("name", ""),
+                    "date": (a.get("start_date_local", "") or "")[:10],
+                }
+                for a in all_activities
+                if pattern_lower in (a.get("name", "") or "").lower()
+            ]
+            resolved.sort(key=lambda x: x["date"])
+
+            if not resolved:
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "error": f"No activities matching '{name_pattern}' in the last {weeks_back} weeks.",
+                            },
+                            indent=2,
+                        ),
+                    )
+                ]
+
+        # Fetch intervals for each activity
+        activity_intervals = {}
+        for act_info in resolved:
+            aid = act_info["id"]
+            with suppress_stdout_stderr():
+                raw = client.get_activity_intervals(aid)
+            activity_intervals[aid] = raw
+
+        # Build metadata
+        activity_metadata = {a["id"]: {"name": a["name"], "date": a["date"]} for a in resolved}
+        intervals_per_activity = {aid: len(ivs) for aid, ivs in activity_intervals.items()}
+
+        # Filter intervals
+        metrics_to_use = set(requested_metrics) if requested_metrics else NUMERIC_METRICS
+
+        filtered_intervals = {}
+        for aid, raw_ivs in activity_intervals.items():
+            kept = []
+            for iv in raw_ivs:
+                # Skip gap intervals (auto-inserted by Intervals.icu)
+                if (iv.get("elapsed_time") or 0) <= 2:
+                    continue
+                if type_filter and iv.get("type") != type_filter:
+                    continue
+                if label_filter and label_filter.lower() not in (iv.get("label", "") or "").lower():
+                    continue
+                kept.append(iv)
+            filtered_intervals[aid] = kept
+
+        # Align by label
+        from collections import defaultdict
+
+        label_groups = defaultdict(lambda: defaultdict(list))
+        for aid, ivs in filtered_intervals.items():
+            for iv in ivs:
+                label = (iv.get("label", "") or "").strip().lower()
+                label_groups[label][aid].append(iv)
+
+        # Preserve original label casing from first occurrence
+        label_display = {}
+        for aid, ivs in filtered_intervals.items():
+            for iv in ivs:
+                norm = (iv.get("label", "") or "").strip().lower()
+                if norm not in label_display:
+                    label_display[norm] = (iv.get("label", "") or "").strip()
+
+        # Build comparison
+        ordered_ids = [a["id"] for a in resolved]
+        comparison = []
+        for norm_label in sorted(label_groups.keys()):
+            group = label_groups[norm_label]
+            activities_data = []
+            values_by_metric = defaultdict(list)
+
+            for aid in ordered_ids:
+                if aid not in group:
+                    activities_data.append(
+                        {
+                            "activity_id": aid,
+                            "date": activity_metadata[aid]["date"],
+                            "data": None,
+                        }
+                    )
+                    continue
+
+                ivs = group[aid]
+                # Aggregate: average if multiple intervals with same label
+                agg = {}
+                for metric in metrics_to_use:
+                    vals = [iv[metric] for iv in ivs if metric in iv and iv[metric] is not None]
+                    if vals:
+                        avg_val = sum(vals) / len(vals)
+                        agg[metric] = round(avg_val, 2) if avg_val != int(avg_val) else int(avg_val)
+
+                activities_data.append(
+                    {
+                        "activity_id": aid,
+                        "date": activity_metadata[aid]["date"],
+                        "data": agg if agg else None,
+                    }
+                )
+
+                # Collect for trends
+                for metric, val in agg.items():
+                    values_by_metric[metric].append(val)
+
+            # Calculate trends
+            trends = {}
+            for metric, vals in values_by_metric.items():
+                if len(vals) >= 2:
+                    first = vals[0]
+                    last = vals[-1]
+                    delta = round(last - first, 2)
+                    delta_pct = round((delta / first) * 100, 1) if first != 0 else None
+                    avg = round(sum(vals) / len(vals), 2)
+                    trends[metric] = {
+                        "first": first,
+                        "last": last,
+                        "delta": delta,
+                        "delta_pct": delta_pct,
+                        "avg": avg,
+                    }
+
+            comparison.append(
+                {
+                    "label": label_display.get(norm_label, norm_label),
+                    "activities": activities_data,
+                    "trends": trends,
+                }
+            )
+
+        result = {
+            "mode": mode,
+            "activities_compared": len(resolved),
+            "activity_ids": ordered_ids,
+            "activity_metadata": activity_metadata,
+            "intervals_per_activity": intervals_per_activity,
+            "filters_applied": {
+                "label_filter": label_filter,
+                "type_filter": type_filter,
+                "metrics": requested_metrics if requested_metrics else "all",
+            },
+            "comparison": comparison,
+        }
+
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
+    except Exception as e:
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(
+                    {"error": f"Failed to compare intervals: {str(e)}"},
                     indent=2,
                 ),
             )

--- a/tests/test_mcp_extra_handlers.py
+++ b/tests/test_mcp_extra_handlers.py
@@ -3,7 +3,8 @@ Additional MCP handler tests — push mcp_server.py from 50% to 60%.
 
 Focuses on: handle_update_session, handle_sync_week_to_intervals,
 handle_get_metrics, handle_withings_get_sleep, handle_withings_get_weight,
-handle_withings_get_readiness, handle_apply_workout_intervals.
+handle_withings_get_readiness, handle_apply_workout_intervals,
+handle_compare_intervals.
 """
 
 import json
@@ -1291,3 +1292,264 @@ Cooldown
         assert "error" in data
         assert "API timeout" in data["error"]
         assert data["activity_id"] == "i127869034"
+
+
+class TestHandleCompareIntervals:
+    """Tests for handle_compare_intervals."""
+
+    def _make_interval(self, label, type_="WORK", elapsed_time=300, **kwargs):
+        """Helper to build a mock interval dict."""
+        iv = {
+            "type": type_,
+            "label": label,
+            "start_index": 0,
+            "end_index": 999,
+            "elapsed_time": elapsed_time,
+            "average_watts": 150,
+            "average_heartrate": 130,
+            "average_cadence": 90,
+            "average_torque": 40.0,
+        }
+        iv.update(kwargs)
+        return iv
+
+    @pytest.mark.asyncio
+    async def test_explicit_ids_success(self):
+        """3 explicit IDs with common labels → comparison + trends."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        mock_client = Mock()
+        mock_client.get_activity.side_effect = [
+            {"name": "S079-03-CAD", "start_date_local": "2026-02-04T10:00:00"},
+            {"name": "S080-03-CAD", "start_date_local": "2026-02-11T10:00:00"},
+            {"name": "S081-03-CAD", "start_date_local": "2026-02-18T10:00:00"},
+        ]
+        mock_client.get_activity_intervals.side_effect = [
+            [self._make_interval("Set1 95rpm", average_cadence=94)],
+            [self._make_interval("Set1 95rpm", average_cadence=95)],
+            [self._make_interval("Set1 95rpm", average_cadence=96)],
+        ]
+
+        args = {"activity_ids": ["i100", "i200", "i300"]}
+        with patch(INTERVALS_PATCH, return_value=mock_client):
+            result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        assert data["mode"] == "explicit"
+        assert data["activities_compared"] == 3
+        assert len(data["comparison"]) == 1
+        assert data["comparison"][0]["label"] == "Set1 95rpm"
+        trends = data["comparison"][0]["trends"]
+        assert "average_cadence" in trends
+        assert trends["average_cadence"]["first"] == 94
+        assert trends["average_cadence"]["last"] == 96
+        assert trends["average_cadence"]["delta"] == 2
+
+    @pytest.mark.asyncio
+    async def test_search_mode_success(self):
+        """name_pattern + weeks_back → filters matching activities, mode='search'."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        mock_client = Mock()
+        mock_client.get_activities.return_value = [
+            {
+                "id": "i100",
+                "name": "S079-03-CadenceVariations",
+                "start_date_local": "2026-02-04T10:00:00",
+            },
+            {"id": "i200", "name": "S080-01-Endurance", "start_date_local": "2026-02-08T10:00:00"},
+            {
+                "id": "i300",
+                "name": "S081-03-CadenceVariations",
+                "start_date_local": "2026-02-18T10:00:00",
+            },
+        ]
+        mock_client.get_activity_intervals.side_effect = [
+            [self._make_interval("Set1")],
+            [self._make_interval("Set1")],
+        ]
+
+        args = {"name_pattern": "CadenceVariations", "weeks_back": 4}
+        with patch(INTERVALS_PATCH, return_value=mock_client):
+            result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        assert data["mode"] == "search"
+        assert data["activities_compared"] == 2
+        assert "i200" not in data["activity_ids"]
+        assert "i100" in data["activity_ids"]
+        assert "i300" in data["activity_ids"]
+
+    @pytest.mark.asyncio
+    async def test_no_matching_activities_search(self):
+        """Pattern that matches nothing → error."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        mock_client = Mock()
+        mock_client.get_activities.return_value = [
+            {"id": "i100", "name": "S079-01-Endurance", "start_date_local": "2026-02-04T10:00:00"},
+        ]
+
+        args = {"name_pattern": "NonExistentWorkout"}
+        with patch(INTERVALS_PATCH, return_value=mock_client):
+            result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        assert "error" in data
+        assert "NonExistentWorkout" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_both_params(self):
+        """Neither activity_ids nor name_pattern → error."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        args = {}
+        result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        assert "error" in data
+        assert "activity_ids" in data["error"]
+        assert "name_pattern" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_gap_intervals_filtered(self):
+        """Intervals with elapsed_time <= 2 are excluded."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        mock_client = Mock()
+        mock_client.get_activity.side_effect = [
+            {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
+        ]
+        mock_client.get_activity_intervals.return_value = [
+            self._make_interval("Set1", elapsed_time=300),
+            self._make_interval("Gap", elapsed_time=1),
+            self._make_interval("Set2", elapsed_time=300),
+        ]
+
+        args = {"activity_ids": ["i100"]}
+        with patch(INTERVALS_PATCH, return_value=mock_client):
+            result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        labels = [c["label"] for c in data["comparison"]]
+        assert "Set1" in labels
+        assert "Set2" in labels
+        assert "Gap" not in labels
+
+    @pytest.mark.asyncio
+    async def test_label_filter(self):
+        """label_filter='95rpm' → only 95rpm intervals kept."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        mock_client = Mock()
+        mock_client.get_activity.side_effect = [
+            {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
+        ]
+        mock_client.get_activity_intervals.return_value = [
+            self._make_interval("Set1 95rpm"),
+            self._make_interval("Set2 80rpm"),
+            self._make_interval("Set3 95rpm"),
+        ]
+
+        args = {"activity_ids": ["i100"], "label_filter": "95rpm"}
+        with patch(INTERVALS_PATCH, return_value=mock_client):
+            result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        labels = [c["label"] for c in data["comparison"]]
+        assert all("95rpm" in lbl for lbl in labels)
+        assert not any("80rpm" in lbl for lbl in labels)
+
+    @pytest.mark.asyncio
+    async def test_type_filter_work_only(self):
+        """type_filter='WORK' → only WORK intervals kept."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        mock_client = Mock()
+        mock_client.get_activity.side_effect = [
+            {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
+        ]
+        mock_client.get_activity_intervals.return_value = [
+            self._make_interval("Set1", type_="WORK"),
+            self._make_interval("Recovery", type_="RECOVERY"),
+        ]
+
+        args = {"activity_ids": ["i100"], "type_filter": "WORK"}
+        with patch(INTERVALS_PATCH, return_value=mock_client):
+            result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        labels = [c["label"] for c in data["comparison"]]
+        assert "Set1" in labels
+        assert "Recovery" not in labels
+
+    @pytest.mark.asyncio
+    async def test_metrics_selection(self):
+        """metrics=['average_watts','average_heartrate'] → only those 2 in data."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        mock_client = Mock()
+        mock_client.get_activity.side_effect = [
+            {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
+        ]
+        mock_client.get_activity_intervals.return_value = [
+            self._make_interval(
+                "Set1", average_watts=200, average_heartrate=140, average_cadence=95
+            ),
+        ]
+
+        args = {
+            "activity_ids": ["i100"],
+            "metrics": ["average_watts", "average_heartrate"],
+        }
+        with patch(INTERVALS_PATCH, return_value=mock_client):
+            result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        interval_data = data["comparison"][0]["activities"][0]["data"]
+        assert "average_watts" in interval_data
+        assert "average_heartrate" in interval_data
+        assert "average_cadence" not in interval_data
+
+    @pytest.mark.asyncio
+    async def test_invalid_metrics(self):
+        """metrics=['bogus'] → error with available_metrics list."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        args = {"activity_ids": ["i100"], "metrics": ["bogus"]}
+        result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        assert "error" in data
+        assert "bogus" in data["error"]
+        assert "available_metrics" in data
+
+    @pytest.mark.asyncio
+    async def test_label_mismatch_across_activities(self):
+        """A has Set1+Set2, B has Set1 only → Set2 data=null for B."""
+        from cyclisme_training_logs.mcp_server import handle_compare_intervals
+
+        mock_client = Mock()
+        mock_client.get_activity.side_effect = [
+            {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
+            {"name": "A2", "start_date_local": "2026-02-11T10:00:00"},
+        ]
+        mock_client.get_activity_intervals.side_effect = [
+            [
+                self._make_interval("Set1"),
+                self._make_interval("Set2"),
+            ],
+            [
+                self._make_interval("Set1"),
+            ],
+        ]
+
+        args = {"activity_ids": ["i100", "i200"]}
+        with patch(INTERVALS_PATCH, return_value=mock_client):
+            result = await handle_compare_intervals(args)
+
+        data = json.loads(result[0].text)
+        set2_entry = [c for c in data["comparison"] if c["label"] == "Set2"][0]
+        # First activity has data, second has null
+        assert set2_entry["activities"][0]["data"] is not None
+        assert set2_entry["activities"][1]["data"] is None


### PR DESCRIPTION
## Summary

- Add `compare-intervals` MCP tool for cross-activity progression tracking
- Aligns intervals by label across multiple activities, calculates deltas and trends (power, HR, cadence, torque, decoupling, etc.)
- Two modes: explicit activity IDs or name-pattern search with configurable `weeks_back`
- Filtering: `label_filter` (substring), `type_filter` (WORK/RECOVERY), `metrics` selection
- Gap intervals (≤2s auto-inserted by Intervals.icu) automatically excluded
- 10 unit tests covering both modes, filtering, metrics validation, and label mismatch handling

## Test plan

- [x] 10/10 `TestHandleCompareIntervals` tests pass
- [x] 138/138 regression tests pass (extra_handlers + new_handlers + workout_parser)
- [x] black + ruff clean
- [x] All 14 pre-commit hooks pass
- [ ] E2E: `compare-intervals name_pattern=CadenceVariations weeks_back=6`
- [ ] E2E: `compare-intervals activity_ids=[...] label_filter=95rpm metrics=[average_cadence,average_torque]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)