### PR TITLE
feat(validator): Reject invalid durations and enforce ramp dash format

### DIFF
--- a/cyclisme_training_logs/intervals_format_validator.py
+++ b/cyclisme_training_logs/intervals_format_validator.py
@@ -70,6 +70,7 @@ class IntervalsFormatValidator:
     SECTION_WITH_REP_PATTERN = r"^(.*?)\s+(\d+x)\s*$"  # "Main set 3x"
     INTERVAL_PATTERN = r"^\s*-\s+\d+[msh].*$"  # "- 10m 90% 85rpm"
     MARKDOWN_PATTERN = r"\*\*|###|`|__|~~"  # Markdown interdit
+    INVALID_DURATION_PATTERN = r"\d+(?:min|sec|hr|hours?|mins|secs)\b"
 
     # Sections valides
     VALID_SECTIONS = ["Warmup", "Main set", "Cooldown", "Block"]
@@ -128,14 +129,14 @@ class IntervalsFormatValidator:
             # Détecter répétition seule (ex: "3x")
             if re.match(self.REPETITION_PATTERN, stripped):
                 self.errors.append(
-                    f"Ligne {i+1}: Répétition '{stripped}' seule. "
+                    f"Ligne {i + 1}: Répétition '{stripped}' seule. "
                     f"Doit être sur ligne section (ex: 'Main set 3x')"
                 )
 
             # Détecter répétition dans intervalle (ex: "- 3x 10m 90%")
             if stripped.startswith("-") and re.search(r"\b\d+x\b", stripped):
                 self.errors.append(
-                    f"Ligne {i+1}: Répétition dans intervalle '{stripped}'. "
+                    f"Ligne {i + 1}: Répétition dans intervalle '{stripped}'. "
                     f"Format incorrect. Utiliser 'Main set Nx' avant le bloc."
                 )
 
@@ -150,7 +151,7 @@ class IntervalsFormatValidator:
 
                 if not is_valid_section:
                     self.warnings.append(
-                        f"Ligne {i+1}: Section '{section_name} {repetition}' "
+                        f"Ligne {i + 1}: Section '{section_name} {repetition}' "
                         f"non standard. Sections valides: {', '.join(self.VALID_SECTIONS)}"
                     )
 
@@ -168,9 +169,25 @@ class IntervalsFormatValidator:
             if not stripped or not stripped.startswith("-"):
                 continue
 
+            # Vérifier suffixes de durée invalides (min, sec, hr, etc.)
+            invalid_match = re.search(self.INVALID_DURATION_PATTERN, stripped)
+            if invalid_match:
+                self.errors.append(
+                    f"Ligne {i + 1}: Durée invalide '{invalid_match.group()}'. "
+                    f"Utiliser s, m ou h (ex: 5m, 30s, 2h)"
+                )
+
+            # Vérifier format ramp (tiret obligatoire entre bornes)
+            if re.search(r"\bramp\b", stripped, re.IGNORECASE):
+                if not re.search(r"\bramp\s+\d+-\d+%", stripped, re.IGNORECASE):
+                    self.errors.append(
+                        f"Ligne {i + 1}: Format ramp invalide dans '{stripped}'. "
+                        f"Format attendu: 'ramp XX-YY%' (ex: 'ramp 50-65%')"
+                    )
+
             # Vérifier présence durée
             if not re.search(r"\d+[msh]", stripped):
-                self.warnings.append(f"Ligne {i+1}: Aucune durée détectée dans '{stripped}'")
+                self.warnings.append(f"Ligne {i + 1}: Aucune durée détectée dans '{stripped}'")
 
     def fix_repetition_format(self, workout_text: str) -> str:
         """
@@ -191,7 +208,7 @@ class IntervalsFormatValidator:
             # Détecter répétition dans intervalle
             if stripped.startswith("-") and re.search(r"\b(\d+)x\b", stripped):
                 errors_found.append(
-                    f"Ligne {i+1}: Impossible de corriger automatiquement "
+                    f"Ligne {i + 1}: Impossible de corriger automatiquement "
                     f"'{stripped}'. Restructurer manuellement."
                 )
                 corrected.append(line)
@@ -209,7 +226,7 @@ class IntervalsFormatValidator:
                 if not is_valid_section:
                     corrected_line = f"Main set {repetition}"
                     corrected.append(corrected_line)
-                    print(f"⚠️  Ligne {i+1} corrigée: " f"'{stripped}' → '{corrected_line}'")
+                    print(f"⚠️  Ligne {i + 1} corrigée: " f"'{stripped}' → '{corrected_line}'")
                     continue
 
             # Ligne OK

--- a/cyclisme_training_logs/mcp_server.py
+++ b/cyclisme_training_logs/mcp_server.py
@@ -2388,6 +2388,23 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
                     "start_date_local": f"{session.session_date}T{start_time}",
                 }
 
+                # Validate workout description before creating remote event
+                if full_description and full_description.strip():
+                    from cyclisme_training_logs.intervals_format_validator import (
+                        IntervalsFormatValidator,
+                    )
+
+                    validator = IntervalsFormatValidator()
+                    is_valid, val_errors, _val_warnings = validator.validate_workout(
+                        full_description
+                    )
+                    if not is_valid:
+                        errors.append(
+                            f"Session {session.session_id}: workout validation failed — {val_errors}. "
+                            f"Fix with validate-workout tool, then retry sync."
+                        )
+                        continue
+
                 if session.intervals_id:
                     # Check if event exists remotely
                     if session.intervals_id in remote_workouts:

--- a/tests/test_intervals_format_validator.py
+++ b/tests/test_intervals_format_validator.py
@@ -1,0 +1,67 @@
+"""Tests for IntervalsFormatValidator duration and ramp rules."""
+
+from cyclisme_training_logs.intervals_format_validator import IntervalsFormatValidator
+
+
+class TestDurationValidation:
+    """Tests for valid/invalid duration suffixes."""
+
+    def test_valid_durations_accepted(self):
+        """5m, 30s, 2h are valid Intervals.icu durations."""
+        validator = IntervalsFormatValidator()
+        workout = "Warmup\n- 5m 90%\n- 30s 80%\n- 2h 60%"
+        is_valid, errors, warnings = validator.validate_workout(workout)
+        assert is_valid
+        assert errors == []
+
+    def test_invalid_duration_min_rejected(self):
+        """'5min' is not a valid duration — must use '5m'."""
+        validator = IntervalsFormatValidator()
+        workout = "Main set\n- 5min 90%"
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert not is_valid
+        assert any("5min" in e for e in errors)
+
+    def test_invalid_duration_sec_rejected(self):
+        """'10sec' is not a valid duration — must use '10s'."""
+        validator = IntervalsFormatValidator()
+        workout = "Main set\n- 10sec 80%"
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert not is_valid
+        assert any("10sec" in e for e in errors)
+
+    def test_invalid_duration_hr_rejected(self):
+        """'1hr' is not a valid duration — must use '1h'."""
+        validator = IntervalsFormatValidator()
+        workout = "Main set\n- 1hr 60%"
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert not is_valid
+        assert any("1hr" in e for e in errors)
+
+
+class TestRampValidation:
+    """Tests for ramp format (dash required between bounds)."""
+
+    def test_ramp_with_dash_accepted(self):
+        """'ramp 50-65%' is valid ramp format."""
+        validator = IntervalsFormatValidator()
+        workout = "Warmup\n- 10m ramp 50-65%"
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert is_valid
+        assert errors == []
+
+    def test_ramp_without_dash_rejected(self):
+        """'ramp 40 50%' is invalid — must be 'ramp 40-50%'."""
+        validator = IntervalsFormatValidator()
+        workout = "Warmup\n- 10m ramp 40 50%"
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert not is_valid
+        assert any("ramp" in e.lower() for e in errors)
+
+    def test_ramp_missing_percent_rejected(self):
+        """'ramp 40-50' without % is invalid — must be 'ramp 40-50%'."""
+        validator = IntervalsFormatValidator()
+        workout = "Warmup\n- 10m ramp 40-50"
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert not is_valid
+        assert any("ramp" in e.lower() for e in errors)

--- a/tests/test_mcp_extra_handlers.py
+++ b/tests/test_mcp_extra_handlers.py
@@ -441,6 +441,80 @@ class TestHandleSyncWeekToIntervals:
 # =======================
 
 
+# =======================
+# TestSyncValidationGate
+# =======================
+
+
+class TestSyncValidationGate:
+    """Validation gate rejects invalid workout descriptions before sync."""
+
+    @pytest.mark.asyncio
+    async def test_sync_rejects_invalid_workout(self, mock_plan, mock_session):
+        """Session with '5min' duration → validation error, no API create."""
+        from cyclisme_training_logs.mcp_server import handle_sync_week_to_intervals
+
+        mock_session.intervals_id = None
+        mock_session.status = "pending"
+        mock_plan.planned_sessions = [mock_session]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+        mock_client.get_events.return_value = []
+
+        # Workout with invalid duration (5min instead of 5m)
+        invalid_workout = "Warmup\n- 5min ramp 50-65%\n\nMain set\n- 10m 90%"
+        workout_descriptions = {
+            f"{mock_session.session_id}-{mock_session.session_type}-{mock_session.name}-{mock_session.version}": invalid_workout,
+        }
+
+        args = {"week_id": "S081", "dry_run": False}
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                with patch(LOAD_WORKOUTS_PATCH, return_value=workout_descriptions):
+                    result = await handle_sync_week_to_intervals(args)
+        data = json.loads(result[0].text)
+        # Session should be rejected — no creation
+        assert data["summary"]["to_create"] == 0
+        assert data["summary"]["created"] == 0
+        assert len(data["errors"]) > 0
+        assert "validation failed" in data["errors"][0].lower()
+        mock_client.create_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_accepts_valid_workout(self, mock_plan, mock_session):
+        """Session with valid '5m' duration → create API called normally."""
+        from cyclisme_training_logs.mcp_server import handle_sync_week_to_intervals
+
+        mock_session.intervals_id = None
+        mock_session.status = "pending"
+        mock_plan.planned_sessions = [mock_session]
+        tower = make_tower(mock_plan)
+        mock_client = Mock()
+        mock_client.get_events.return_value = []
+        mock_client.create_event.return_value = {"id": "evt999"}
+
+        # Valid workout description
+        valid_workout = "Warmup\n- 5m ramp 50-65%\n\nMain set\n- 10m 90%"
+        workout_descriptions = {
+            f"{mock_session.session_id}-{mock_session.session_type}-{mock_session.name}-{mock_session.version}": valid_workout,
+        }
+
+        args = {"week_id": "S081", "dry_run": False}
+        with patch(TOWER_PATCH, tower):
+            with patch(INTERVALS_PATCH, return_value=mock_client):
+                with patch(LOAD_WORKOUTS_PATCH, return_value=workout_descriptions):
+                    result = await handle_sync_week_to_intervals(args)
+        data = json.loads(result[0].text)
+        assert data["summary"]["to_create"] == 1
+        assert data["summary"]["created"] == 1
+        mock_client.create_event.assert_called_once()
+
+
+# =======================
+# TestHandleGetMetrics
+# =======================
+
+
 class TestHandleGetMetrics:
     @pytest.mark.asyncio
     async def test_success_returns_wellness_data(self):


### PR DESCRIPTION
## Summary
- **Invalid durations**: `5min`, `10sec`, `1hr` now rejected as errors (only `s`, `m`, `h` valid for Intervals.icu)
- **Ramp format**: `ramp 40 50%` and `ramp 40-50` now rejected (must be `ramp XX-YY%`)
- **Sync validation gate**: `sync-week-to-intervals` validates workout descriptions before API create — invalid workouts blocked with actionable error message

## Test plan
- [x] 7 validator unit tests (4 duration + 3 ramp)
- [x] 2 sync gate tests (reject invalid / accept valid)
- [x] 127 total tests pass (full regression)
- [x] black + ruff + 14 pre-commit hooks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)