### PR TITLE
fix(docs): Mock MCP imports for Sphinx autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,9 @@ napoleon_use_rtype = True
 napoleon_use_keyword = True
 napoleon_custom_sections = [("Metadata", "params_style")]
 
+# Mock imports that fail at import time (MCP, HTTP transport)
+autodoc_mock_imports = ["mcp", "mcp_http_transport"]
+
 # Autodoc settings
 autodoc_default_options = {
     "members": True,


### PR DESCRIPTION
## Summary

- Add `autodoc_mock_imports = ["mcp", "mcp_http_transport"]` to `docs/conf.py`
- Sphinx `automodule` failed to import `mcp_server.py` due to MCP dependencies — page was 5.5KB (empty)
- After fix: 79.5KB with full module documentation (all handlers including `handle_rename_session`)

## Test plan

- [x] `sphinx-build` succeeds, no import error for `mcp_server`
- [x] `mcp_server` page fully rendered in `docs/_build/html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)