### PR TITLE
fix: Break circular import in upload_workouts.py

### DIFF
--- a/magma_cycling/upload_workouts.py
+++ b/magma_cycling/upload_workouts.py
@@ -65,8 +65,6 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from magma_cycling.planning.backup import auto_backup
-
 
 def calculate_week_start_date(week_id: str) -> datetime:
     """
@@ -660,6 +658,8 @@ def main():
     # 🔒 AUTOMATIC BACKUP before any upload
     if not args.dry_run:
         try:
+            from magma_cycling.planning.backup import auto_backup
+
             backups = auto_backup(args.week_id)
             if backups:
                 print("🔒 Backup créé:")


### PR DESCRIPTION
## Summary

- Move `from magma_cycling.planning.backup import auto_backup` from module level to inside `main()` where it's actually used
- Breaks the circular import chain: `upload_workouts` → `planning.backup` → `planning/__init__` → `planning.intervals_sync` → `upload_workouts`

## Test plan

- [x] `poetry run upload-workouts --help` works (was crashing with `ImportError`)
- [x] 1753 tests pass (18 more than before — `test_upload_workouts_full.py` was blocked by the circular import)
- [x] 14/14 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)