### PR TITLE
fix: Escape % in argparse help string for check-workout-adherence

### DIFF
--- a/scripts/monitoring/check_workout_adherence.py
+++ b/scripts/monitoring/check_workout_adherence.py
@@ -480,7 +480,7 @@ def main():
     parser.add_argument(
         "--weekly-alert",
         action="store_true",
-        help="Check weekly adherence and send alerts if <85% (Sprint R10)",
+        help="Check weekly adherence and send alerts if <85%% (Sprint R10)",
     )
     parser.add_argument("--dry-run", action="store_true", help="Dry-run mode (no notifications)")
 


### PR DESCRIPTION
## Summary

- Escape `%` as `%%` in `--weekly-alert` help string to fix `ValueError` on `--help`
- Argparse uses `%`-formatting internally on help strings, so the literal `<85%` before `(Sprint R10)` was interpreted as a format specifier `%(` → crash

## Test plan

- [x] `poetry run check-workout-adherence --help` works (was crashing with `ValueError`)
- [x] 14/14 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)