### PR TITLE
fix(compensation): guard against null wellness values from Intervals.icu API

### DIFF
--- a/magma_cycling/workflows/proactive_compensation.py
+++ b/magma_cycling/workflows/proactive_compensation.py
@@ -321,14 +321,18 @@ def _collect_compensation_context(
                 break
 
         # Extract metrics (avec fallback si wellness vide)
+        # Note: .get("key", 0) returns None when key exists with null value,
+        # so we use `or 0` to guard against both missing and null values.
         athlete_state = {
             "tsb": (
-                wellness_data.get("ctl", 0) - wellness_data.get("atl", 0) if wellness_data else 0
+                (wellness_data.get("ctl") or 0) - (wellness_data.get("atl") or 0)
+                if wellness_data
+                else 0
             ),
-            "sleep_hours": wellness_data.get("sleepSecs", 0) / 3600 if wellness_data else 0,
-            "hrv": wellness_data.get("hrv", 0) if wellness_data else 0,
-            "rpe": wellness_data.get("rpe", 0) if wellness_data else 0,
-            "weight": wellness_data.get("weight", 0) if wellness_data else 0,
+            "sleep_hours": (wellness_data.get("sleepSecs") or 0) / 3600 if wellness_data else 0,
+            "hrv": (wellness_data.get("hrv") or 0) if wellness_data else 0,
+            "rpe": (wellness_data.get("rpe") or 0) if wellness_data else 0,
+            "weight": (wellness_data.get("weight") or 0) if wellness_data else 0,
         }
 
         logger.debug(f"  TSB: {athlete_state['tsb']:+.1f}")

--- a/tests/workflows/test_proactive_compensation.py
+++ b/tests/workflows/test_proactive_compensation.py
@@ -290,6 +290,36 @@ def test_collect_compensation_context_complete(mock_client):
     assert context["deficit"] == 55
 
 
+def test_collect_compensation_context_wellness_null_values(mock_client):
+    """Wellness API returns null values for metrics — should not crash."""
+    mock_client.get_wellness.return_value = {
+        "ctl": None,
+        "atl": None,
+        "sleepSecs": None,
+        "hrv": None,
+        "rpe": None,
+        "weight": None,
+    }
+    planned_events = mock_client.get_events()
+    completed = mock_client.get_activities()
+
+    context = _collect_compensation_context(
+        week_id="S078",
+        check_date=date(2026, 1, 30),
+        deficit=55,
+        planned_events=planned_events,
+        completed_activities=completed,
+        client=mock_client,
+    )
+
+    state = context["athlete_state"]
+    assert state["tsb"] == 0
+    assert state["sleep_hours"] == 0
+    assert state["hrv"] == 0
+    assert state["rpe"] == 0
+    assert state["weight"] == 0
+
+
 def test_identify_cancelled_sessions_two_missed():
     """Détecte 2 séances manquées."""
     planned = [


### PR DESCRIPTION
## Summary
- `.get("key", 0)` returns `None` when the API returns `{"hrv": null}` — the default only applies for missing keys, not null values
- This caused `TypeError` on format strings like `f"{athlete['tsb']:+.1f}"` in `proactive_compensation.py`
- Fixed all 5 wellness metrics to use `(x or 0)` pattern
- Added test with all-null wellness values

## Test plan
- [x] New test `test_collect_compensation_context_wellness_null_values` passes
- [x] Full suite: 1809 passed
- [x] 15/15 pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)