### PR TITLE
fix(daily-sync): replace eliminated thin wrappers with direct function calls

### DIFF
--- a/magma_cycling/daily_sync.py
+++ b/magma_cycling/daily_sync.py
@@ -63,7 +63,9 @@ from magma_cycling.planning.peaks_phases import (
     determine_training_phase,
     format_phase_recommendation,
 )
+from magma_cycling.planning.session_formatter import format_remaining_sessions_compact
 from magma_cycling.prepare_analysis import PromptGenerator
+from magma_cycling.utils.ai_response_parser import parse_ai_modifications
 from magma_cycling.utils.hot_reload import (
     hot_reload_if_needed,
     mark_modules_loaded,
@@ -972,7 +974,7 @@ class DailySync:
             feel_str = f"{metrics['feel']}/4" if metrics.get("feel") is not None else "Non fourni"
 
             # Generate servo prompt (same as workflow_coach)
-            planning_context = coach.format_remaining_sessions_compact(remaining_sessions)
+            planning_context = format_remaining_sessions_compact(remaining_sessions)
 
             servo_prompt = f"""# ASSERVISSEMENT PLANNING - Demande Coach AI.
 
@@ -1048,7 +1050,7 @@ Réponds maintenant."""
             print()
 
             # Parse modifications
-            modifications = coach.parse_ai_modifications(ai_response)
+            modifications = parse_ai_modifications(ai_response)
 
             result = {
                 "ai_response": ai_response,


### PR DESCRIPTION
## Summary
- `format_remaining_sessions_compact` and `parse_ai_modifications` were removed from `WorkflowCoach` in PR #52 (mixin decomposition) but `daily_sync.py` still called them via `coach.method()`
- Replaced with direct imports from `planning.session_formatter` and `utils.ai_response_parser`
- This caused `AttributeError` in auto-servo mode during daily-sync

## Test plan
- [x] 1809 tests pass
- [x] 15/15 pre-commit hooks
- [x] Manual daily-sync run confirms servo mode no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)