### PR TITLE
fix(monthly-analysis): use actual TSS from Intervals.icu instead of planned TSS

### DIFF
--- a/magma_cycling/monthly_analysis.py
+++ b/magma_cycling/monthly_analysis.py
@@ -127,9 +127,16 @@ class MonthlyAnalyzer:
 
         return weekly_data
 
-    def aggregate_statistics(self, weekly_data: list[dict]) -> dict:
-        """
-        Aggregate monthly statistics from weekly data.
+    def aggregate_statistics(
+        self, weekly_data: list[dict], actual_tss_map: dict | None = None
+    ) -> dict:
+        """Aggregate monthly statistics from weekly data.
+
+        Args:
+            weekly_data: List of weekly planning dicts.
+            actual_tss_map: Optional mapping {intervals_id: actual_tss} from
+                Intervals.icu. When provided, completed/modified sessions with
+                an intervals_id use real TSS instead of tss_planned.
 
         Returns:
             Dictionary with monthly metrics.
@@ -142,7 +149,7 @@ class MonthlyAnalyzer:
             "cancelled": 0,
             "modified": 0,
             "rest_days": 0,
-            "tss_planned": 0,
+            "tss_realized": 0,
             "tss_target_total": 0,
             "sessions_by_type": defaultdict(int),
             "sessions_by_status": defaultdict(int),
@@ -166,14 +173,21 @@ class MonthlyAnalyzer:
                 stats["total_sessions"] += 1
                 status = session.get("status", "unknown")
                 session_type = session.get("type", "unknown")
-                tss = session.get("tss_planned", 0)
+
+                tss_planned = session.get("tss_planned", 0)
+                intervals_id = session.get("intervals_id")
+                # Use actual TSS for completed/modified sessions when available
+                if intervals_id and actual_tss_map and f"i{intervals_id}" in actual_tss_map:
+                    tss = actual_tss_map[f"i{intervals_id}"]
+                else:
+                    tss = tss_planned
 
                 # Count by status
                 stats["sessions_by_status"][status] += 1
 
                 if status == "completed":
                     stats["completed"] += 1
-                    stats["tss_planned"] += tss
+                    stats["tss_realized"] += tss
                     week_stats["tss_actual"] += tss
                 elif status == "skipped":
                     stats["skipped"] += 1
@@ -181,7 +195,7 @@ class MonthlyAnalyzer:
                     stats["cancelled"] += 1
                 elif status == "modified":
                     stats["modified"] += 1
-                    stats["tss_planned"] += tss
+                    stats["tss_realized"] += tss
                     week_stats["tss_actual"] += tss
                 elif status == "rest_day":
                     stats["rest_days"] += 1
@@ -204,7 +218,7 @@ class MonthlyAnalyzer:
 
         # Calculate TSS achievement rate
         if stats["tss_target_total"] > 0:
-            stats["tss_achievement_rate"] = stats["tss_planned"] / stats["tss_target_total"] * 100
+            stats["tss_achievement_rate"] = stats["tss_realized"] / stats["tss_target_total"] * 100
         else:
             stats["tss_achievement_rate"] = 0
 
@@ -223,7 +237,7 @@ class MonthlyAnalyzer:
 
 ### Charge d'Entraînement (TSS)
 - **TSS Cible :** {stats['tss_target_total']}
-- **TSS Réalisé :** {stats['tss_planned']}
+- **TSS Réalisé :** {stats['tss_realized']}
 - **Taux de réalisation :** {stats['tss_achievement_rate']:.1f}%
 
 ### Sessions
@@ -293,7 +307,7 @@ class MonthlyAnalyzer:
 📊 DONNÉES MENSUELLES :
 - {stats['total_weeks']} semaines analysées
 - TSS Cible : {stats['tss_target_total']}
-- TSS Réalisé : {stats['tss_planned']} ({stats['tss_achievement_rate']:.1f}%)
+- TSS Réalisé : {stats['tss_realized']} ({stats['tss_achievement_rate']:.1f}%)
 - Taux d'adhérence : {stats['adherence_rate']:.1f}%
 - Sessions complétées : {stats['completed']}/{stats['total_sessions']}
 - Sessions sautées : {stats['skipped']}
@@ -339,6 +353,26 @@ ANALYSE DEMANDÉE (format markdown) :
 Sois concret, direct et orienté action. Utilise des emojis pour la lisibilité.
 """
         return prompt
+
+    def _fetch_actual_tss(self, weekly_data: list[dict]) -> dict[str, int]:
+        """Fetch actual TSS from Intervals.icu for completed activities.
+
+        Returns:
+            Mapping {intervals_id: actual_tss} for all activities in the month.
+            Empty dict on failure (graceful degradation → fallback to tss_planned).
+        """
+        try:
+            from magma_cycling.config import create_intervals_client
+
+            start = min(w["start_date"] for w in weekly_data)
+            end = max(w["end_date"] for w in weekly_data)
+            client = create_intervals_client()
+            activities = client.get_activities(oldest=start, newest=end)
+
+            return {a["id"]: a.get("icu_training_load", 0) or 0 for a in activities}
+        except Exception:
+            logger.warning("Could not fetch activities from Intervals.icu, using planned TSS")
+            return {}
 
     def _load_current_metrics(self) -> dict:
         """Load current athlete metrics for prompt enrichment.
@@ -400,12 +434,20 @@ Sois concret, direct et orienté action. Utilise des emojis pour la lisibilité.
         weekly_data = self.load_weekly_data(week_files)
         print(f"✅ {len(weekly_data)} semaine(s) chargée(s)")
 
+        # Fetch actual TSS from Intervals.icu
+        print("\n📡 Récupération TSS réels (Intervals.icu)...")
+        actual_tss_map = self._fetch_actual_tss(weekly_data)
+        if actual_tss_map:
+            print(f"✅ {len(actual_tss_map)} activités trouvées")
+        else:
+            print("⚠️  Fallback sur TSS planifiés")
+
         # Aggregate statistics
         print("\n📊 Calcul des statistiques...")
-        stats = self.aggregate_statistics(weekly_data)
+        stats = self.aggregate_statistics(weekly_data, actual_tss_map)
         print("✅ Statistiques calculées")
         print(
-            f"   - TSS : {stats['tss_planned']}/{stats['tss_target_total']} ({stats['tss_achievement_rate']:.1f}%)"
+            f"   - TSS : {stats['tss_realized']}/{stats['tss_target_total']} ({stats['tss_achievement_rate']:.1f}%)"
         )
         print(
             f"   - Sessions : {stats['completed']}/{stats['total_sessions']} ({stats['adherence_rate']:.1f}%)"

--- a/tests/test_monthly_analysis.py
+++ b/tests/test_monthly_analysis.py
@@ -1,0 +1,226 @@
+"""Tests for monthly_analysis.py — actual TSS from Intervals.icu."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.monthly_analysis import MonthlyAnalyzer
+
+
+@pytest.fixture
+def analyzer():
+    """Create analyzer with mocked config dependencies."""
+    with (
+        patch("magma_cycling.monthly_analysis.get_data_config") as mock_dc,
+        patch("magma_cycling.monthly_analysis.get_ai_config"),
+    ):
+        mock_dc.return_value.data_repo_path = MagicMock()
+        yield MonthlyAnalyzer(month="2026-02", no_ai=True)
+
+
+@pytest.fixture
+def weekly_data():
+    """Sample weekly data with sessions."""
+    return [
+        {
+            "week_id": "S081",
+            "start_date": "2026-02-02",
+            "end_date": "2026-02-08",
+            "tss_target": 400,
+            "planned_sessions": [
+                {
+                    "session_id": "S081-01",
+                    "type": "END",
+                    "status": "completed",
+                    "tss_planned": 50,
+                    "intervals_id": 126184461,
+                },
+                {
+                    "session_id": "S081-02",
+                    "type": "INT",
+                    "status": "completed",
+                    "tss_planned": 0,
+                    "intervals_id": 126200000,
+                },
+                {
+                    "session_id": "S081-03",
+                    "type": "REC",
+                    "status": "skipped",
+                    "tss_planned": 30,
+                    "intervals_id": None,
+                },
+                {
+                    "session_id": "S081-04",
+                    "type": "END",
+                    "status": "modified",
+                    "tss_planned": 60,
+                    "intervals_id": 126300000,
+                },
+            ],
+        },
+    ]
+
+
+class TestFetchActualTss:
+    """Tests for _fetch_actual_tss()."""
+
+    def test_success(self, analyzer, weekly_data):
+        """Successful API call returns {id: tss} mapping."""
+        mock_client = MagicMock()
+        mock_client.get_activities.return_value = [
+            {"id": "i126184461", "icu_training_load": 120},
+            {"id": "i126200000", "icu_training_load": 356},
+            {"id": "i999999999", "icu_training_load": 45},
+        ]
+
+        with patch(
+            "magma_cycling.config.create_intervals_client",
+            return_value=mock_client,
+        ):
+            result = analyzer._fetch_actual_tss(weekly_data)
+
+        assert result == {
+            "i126184461": 120,
+            "i126200000": 356,
+            "i999999999": 45,
+        }
+        mock_client.get_activities.assert_called_once_with(oldest="2026-02-02", newest="2026-02-08")
+
+    def test_api_failure_returns_empty_dict(self, analyzer, weekly_data):
+        """API failure returns empty dict for graceful degradation."""
+        with patch(
+            "magma_cycling.config.create_intervals_client",
+            side_effect=Exception("connection refused"),
+        ):
+            result = analyzer._fetch_actual_tss(weekly_data)
+
+        assert result == {}
+
+    def test_null_training_load_treated_as_zero(self, analyzer, weekly_data):
+        """Activities with null icu_training_load get TSS=0."""
+        mock_client = MagicMock()
+        mock_client.get_activities.return_value = [
+            {"id": "i126184461", "icu_training_load": None},
+        ]
+
+        with patch(
+            "magma_cycling.config.create_intervals_client",
+            return_value=mock_client,
+        ):
+            result = analyzer._fetch_actual_tss(weekly_data)
+
+        assert result["i126184461"] == 0
+
+
+class TestAggregateStatisticsActualTss:
+    """Tests for aggregate_statistics() with actual TSS map."""
+
+    def test_uses_actual_tss_when_available(self, analyzer, weekly_data):
+        """Completed session with intervals_id uses actual TSS from map."""
+        actual_tss_map = {
+            "i126184461": 120,
+            "i126200000": 356,
+            "i126300000": 200,
+        }
+
+        stats = analyzer.aggregate_statistics(weekly_data, actual_tss_map)
+
+        # S081-01: actual 120, S081-02: actual 356, S081-04 (modified): actual 200
+        assert stats["tss_realized"] == 120 + 356 + 200
+
+    def test_falls_back_to_planned_when_no_map(self, analyzer, weekly_data):
+        """Without actual_tss_map, uses tss_planned."""
+        stats = analyzer.aggregate_statistics(weekly_data, None)
+
+        # S081-01: planned 50, S081-02: planned 0, S081-04 (modified): planned 60
+        assert stats["tss_realized"] == 50 + 0 + 60
+
+    def test_falls_back_when_id_not_in_map(self, analyzer, weekly_data):
+        """Session with intervals_id not in map falls back to tss_planned."""
+        # Only one activity in map — others fall back
+        actual_tss_map = {"i126184461": 120}
+
+        stats = analyzer.aggregate_statistics(weekly_data, actual_tss_map)
+
+        # S081-01: actual 120, S081-02: planned 0 (not in map), S081-04: planned 60
+        assert stats["tss_realized"] == 120 + 0 + 60
+
+    def test_skipped_session_not_counted(self, analyzer, weekly_data):
+        """Skipped sessions contribute 0 TSS regardless of map."""
+        actual_tss_map = {"i126184461": 120, "i126200000": 356, "i126300000": 200}
+
+        stats = analyzer.aggregate_statistics(weekly_data, actual_tss_map)
+
+        # S081-03 is skipped — not in tss_realized
+        assert stats["skipped"] == 1
+        # Total = completed + modified only
+        assert stats["tss_realized"] == 120 + 356 + 200
+
+    def test_backward_compat_no_map(self, analyzer, weekly_data):
+        """Calling without actual_tss_map (old signature) still works."""
+        stats = analyzer.aggregate_statistics(weekly_data)
+
+        assert stats["tss_realized"] == 50 + 0 + 60
+        assert stats["completed"] == 2
+        assert stats["modified"] == 1
+        assert stats["skipped"] == 1
+
+    def test_intervals_id_format_prefix(self, analyzer):
+        """Verifies the 'i' prefix is correctly used for ID lookup."""
+        data = [
+            {
+                "week_id": "S090",
+                "start_date": "2026-03-01",
+                "end_date": "2026-03-07",
+                "tss_target": 300,
+                "planned_sessions": [
+                    {
+                        "session_id": "S090-01",
+                        "type": "END",
+                        "status": "completed",
+                        "tss_planned": 40,
+                        "intervals_id": 999,
+                    },
+                ],
+            },
+        ]
+
+        # Key WITHOUT "i" prefix — should NOT match
+        stats_no_match = analyzer.aggregate_statistics(data, {"999": 200})
+        assert stats_no_match["tss_realized"] == 40  # fallback to planned
+
+        # Key WITH "i" prefix — should match
+        stats_match = analyzer.aggregate_statistics(data, {"i999": 200})
+        assert stats_match["tss_realized"] == 200
+
+    def test_empty_actual_tss_map(self, analyzer, weekly_data):
+        """Empty map behaves same as None — uses tss_planned."""
+        stats = analyzer.aggregate_statistics(weekly_data, {})
+
+        assert stats["tss_realized"] == 50 + 0 + 60
+
+
+class TestStatsFieldRename:
+    """Verify tss_planned is replaced by tss_realized in stats output."""
+
+    def test_stats_has_tss_realized(self, analyzer, weekly_data):
+        """Stats dict uses tss_realized, not tss_planned."""
+        stats = analyzer.aggregate_statistics(weekly_data)
+
+        assert "tss_realized" in stats
+        assert "tss_planned" not in stats
+
+    def test_report_uses_tss_realized(self, analyzer, weekly_data):
+        """generate_report() reads tss_realized without KeyError."""
+        stats = analyzer.aggregate_statistics(weekly_data)
+        report = analyzer.generate_report(stats)
+
+        assert "TSS Réalisé" in report
+        assert str(stats["tss_realized"]) in report
+
+    def test_ai_prompt_uses_tss_realized(self, analyzer, weekly_data):
+        """generate_ai_prompt() reads tss_realized without KeyError."""
+        stats = analyzer.aggregate_statistics(weekly_data)
+        prompt = analyzer.generate_ai_prompt(stats)
+
+        assert str(stats["tss_realized"]) in prompt


### PR DESCRIPTION
## Summary

- **Fix TSS accuracy**: `aggregate_statistics()` now uses real TSS from Intervals.icu (`icu_training_load`) for completed/modified sessions instead of `tss_planned` from local planning files
- **New `_fetch_actual_tss()` method**: fetches activities via `get_activities()` for the month's date range, returns `{intervals_id: actual_tss}` mapping with graceful degradation (empty dict on failure)
- **Renamed stats key**: `tss_planned` → `tss_realized` — accurately reflects what the field contains

**Root cause**: many sessions had `tss_planned=0` locally (backfill corrected statuses but not TSS values). Example: S081 showed 121 TSS instead of 356 real, causing the AI to wrongly diagnose "insufficient load".

## Test plan

- [x] 13 new tests in `tests/test_monthly_analysis.py`
- [x] `_fetch_actual_tss()`: success, API failure graceful degradation, null training load
- [x] `aggregate_statistics()`: actual TSS used, fallback scenarios (no map, empty map, ID not in map), skipped sessions excluded, backward compat, ID prefix format
- [x] Stats field rename: report and AI prompt use `tss_realized` without KeyError
- [x] Full suite: 1872 passed, 15/15 pre-commit hooks
- [ ] E2E: `poetry run monthly-analysis --month 2026-02 --no-ai` — verify S081 shows ~356 TSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)