### PR TITLE
fix(withings): auth-status false negative when access token expired

### DIFF
--- a/magma_cycling/_mcp/handlers/withings.py
+++ b/magma_cycling/_mcp/handlers/withings.py
@@ -46,6 +46,19 @@ async def handle_withings_auth_status(args: dict) -> list[TextContent]:
             status["message"] = "Authenticated and ready"
             status["credentials_path"] = str(config.credentials_path)
 
+            # Add token expiry info for diagnostics
+            import time
+
+            try:
+                with open(config.credentials_path, encoding="utf-8") as f:
+                    creds = json.load(f)
+                token_expiry = creds.get("token_expiry", 0)
+                now = time.time()
+                status["access_token_expired"] = token_expiry <= now
+                status["auto_refresh"] = "refresh_token present, auto-refresh on next API call"
+            except Exception:
+                pass
+
     return [TextContent(type="text", text=json.dumps(status, indent=2))]
 
 

--- a/magma_cycling/config/config_base.py
+++ b/magma_cycling/config/config_base.py
@@ -1018,11 +1018,8 @@ class WithingsConfig:
             if not all(k in creds for k in ["access_token", "refresh_token", "token_expiry"]):
                 return False
 
-            # Check if token is expired (within 5 minutes buffer)
-            import time
-
-            token_expiry = creds.get("token_expiry", 0)
-            return token_expiry > (time.time() + 300)
+            # A refresh_token is sufficient — the client refreshes automatically
+            return True
 
         except Exception:
             return False

--- a/tests/config/test_withings_config.py
+++ b/tests/config/test_withings_config.py
@@ -151,12 +151,12 @@ class TestWithingsConfigValidation:
 
             assert config.has_valid_credentials() is True
 
-    def test_has_valid_credentials_with_expired_token(self, monkeypatch, tmp_path):
-        """Should return False when token is expired."""
+    def test_has_valid_credentials_with_expired_token_but_refresh(self, monkeypatch, tmp_path):
+        """Should return True when access token expired but refresh_token exists."""
         monkeypatch.setenv("WITHINGS_CLIENT_ID", "test_client_id")
         monkeypatch.setenv("WITHINGS_CLIENT_SECRET", "test_secret")
 
-        # Create expired credentials file
+        # Create expired credentials file (refresh_token present → still valid)
         creds_file = tmp_path / ".withings_credentials.json"
         creds_data = {
             "access_token": "expired_token",
@@ -172,7 +172,7 @@ class TestWithingsConfigValidation:
             reset_withings_config()
             config = get_withings_config()
 
-            assert config.has_valid_credentials() is False
+            assert config.has_valid_credentials() is True
 
     def test_has_valid_credentials_missing_fields(self, monkeypatch, tmp_path):
         """Should return False when credentials file is missing required fields."""


### PR DESCRIPTION
## Summary
- `has_valid_credentials()` returned `False` when access token was expired, even though `refresh_token` (never expires) enables auto-refresh
- Caused `withings-auth-status` to report "Not authenticated" while `withings-get-sleep` worked fine
- Fix: return `True` as long as credentials file has required fields (access_token, refresh_token, token_expiry)
- Auth status handler now reports `access_token_expired` for diagnostics

## Test plan
- [x] `pytest tests/config/test_withings_config.py tests/api/test_withings_client.py tests/health/test_withings_provider.py` — 67/67 pass
- [x] `pytest tests/ -x` — 1872 passed, 5 skipped
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)