### PR TITLE
feat(mcp): _metadata systématique + fix get-metrics

### DIFF
--- a/magma_cycling/_mcp/_utils.py
+++ b/magma_cycling/_mcp/_utils.py
@@ -1,8 +1,12 @@
 """Shared utilities for MCP handlers."""
 
+import json
 import sys
 from contextlib import contextmanager
+from datetime import date, datetime
 from io import StringIO
+
+from mcp.types import TextContent
 
 
 @contextmanager
@@ -55,3 +59,14 @@ def load_workout_descriptions(week_id: str) -> dict[str, str]:
     from magma_cycling.workout_parser import load_workout_descriptions as _load
 
     return _load(week_id)
+
+
+def mcp_response(result: dict, **json_kwargs) -> list[TextContent]:
+    """Wrap a result dict with _metadata and return as MCP TextContent."""
+    now = datetime.now()
+    result["_metadata"] = {
+        "response_date": date.today().isoformat(),
+        "response_timestamp": now.isoformat(),
+    }
+    json_kwargs.setdefault("indent", 2)
+    return [TextContent(type="text", text=json.dumps(result, **json_kwargs))]

--- a/magma_cycling/_mcp/handlers/admin.py
+++ b/magma_cycling/_mcp/handlers/admin.py
@@ -1,8 +1,13 @@
 """Admin handlers."""
 
-import json
+from __future__ import annotations
 
-from mcp.types import TextContent
+from typing import TYPE_CHECKING
+
+from magma_cycling._mcp._utils import mcp_response
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
 
 __all__ = [
     "handle_reload_server",
@@ -49,18 +54,12 @@ async def handle_reload_server(args: dict) -> list[TextContent]:
             "note": "MCP server handlers NOT reloaded (requires watchdog auto-restart or manual restart)",
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Reload failed: {str(e)}",
-                        "message": "⚠️ Module reload error - may need full restart",
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        return mcp_response(
+            {
+                "error": f"Reload failed: {str(e)}",
+                "message": "⚠️ Module reload error - may need full restart",
+            }
+        )

--- a/magma_cycling/_mcp/handlers/analysis.py
+++ b/magma_cycling/_mcp/handlers/analysis.py
@@ -1,12 +1,16 @@
 """Analysis and backup handlers."""
 
+from __future__ import annotations
+
 import json
 from datetime import timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from mcp.types import TextContent
+from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
 
-from magma_cycling._mcp._utils import suppress_stdout_stderr
+if TYPE_CHECKING:
+    from mcp.types import TextContent
 
 __all__ = [
     "handle_validate_week_consistency",
@@ -83,18 +87,11 @@ async def handle_validate_week_consistency(args: dict) -> list[TextContent]:
                 ),
             }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {"error": f"Validation error: {str(e)}", "week_id": week_id},
-                    indent=2,
-                ),
-            )
-        ]
+        error = {"error": f"Validation error: {str(e)}", "week_id": week_id}
+        return mcp_response(error)
 
 
 async def handle_get_recommendations(args: dict) -> list[TextContent]:
@@ -127,18 +124,11 @@ async def handle_get_recommendations(args: dict) -> list[TextContent]:
                     "planning_notes": plan.notes if hasattr(plan, "notes") else None,
                 }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {"error": f"Failed to get recommendations: {str(e)}", "week_id": week_id},
-                    indent=2,
-                ),
-            )
-        ]
+        error = {"error": f"Failed to get recommendations: {str(e)}", "week_id": week_id}
+        return mcp_response(error)
 
 
 async def handle_analyze_session_adherence(args: dict) -> list[TextContent]:
@@ -162,15 +152,8 @@ async def handle_analyze_session_adherence(args: dict) -> list[TextContent]:
                     break
 
             if not planned_session:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"Session {session_id} not found in week {week_id}"},
-                            indent=2,
-                        ),
-                    )
-                ]
+                error = {"error": f"Session {session_id} not found in week {week_id}"}
+                return mcp_response(error)
 
             # Get completed activity
             client = create_intervals_client()
@@ -219,22 +202,15 @@ async def handle_analyze_session_adherence(args: dict) -> list[TextContent]:
                 "message": f"Adherence: {adherence_quality} (TSS: {tss_adherence:.1f}%, Duration: {duration_adherence:.1f}%)",
             }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Adherence analysis error: {str(e)}",
-                        "session_id": session_id,
-                        "activity_id": activity_id,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Adherence analysis error: {str(e)}",
+            "session_id": session_id,
+            "activity_id": activity_id,
+        }
+        return mcp_response(error)
 
 
 async def handle_get_training_statistics(args: dict) -> list[TextContent]:
@@ -291,22 +267,15 @@ async def handle_get_training_statistics(args: dict) -> list[TextContent]:
                 },
             }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Failed to get training statistics: {str(e)}",
-                        "start_date": start_date,
-                        "end_date": end_date,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Failed to get training statistics: {str(e)}",
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+        return mcp_response(error)
 
 
 async def handle_export_week_to_json(args: dict) -> list[TextContent]:
@@ -352,18 +321,11 @@ async def handle_export_week_to_json(args: dict) -> list[TextContent]:
                 "message": f"✅ Week {week_id} exported to {output_file}",
             }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {"error": f"Export error: {str(e)}", "week_id": week_id},
-                    indent=2,
-                ),
-            )
-        ]
+        error = {"error": f"Export error: {str(e)}", "week_id": week_id}
+        return mcp_response(error)
 
 
 async def handle_restore_week_from_backup(args: dict) -> list[TextContent]:
@@ -378,35 +340,21 @@ async def handle_restore_week_from_backup(args: dict) -> list[TextContent]:
     confirm = args.get("confirm", False)
 
     if not confirm:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": "Restore requires explicit confirmation",
-                        "week_id": week_id,
-                        "message": "Set confirm=true to proceed with restore",
-                        "warning": "This will OVERWRITE current planning",
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": "Restore requires explicit confirmation",
+            "week_id": week_id,
+            "message": "Set confirm=true to proceed with restore",
+            "warning": "This will OVERWRITE current planning",
+        }
+        return mcp_response(error)
 
     try:
         with suppress_stdout_stderr():
             # Read backup file
             backup_file = Path(backup_path)
             if not backup_file.exists():
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"Backup file not found: {backup_path}"},
-                            indent=2,
-                        ),
-                    )
-                ]
+                error = {"error": f"Backup file not found: {backup_path}"}
+                return mcp_response(error)
 
             backup_data = json.loads(backup_file.read_text())
 
@@ -451,18 +399,11 @@ async def handle_restore_week_from_backup(args: dict) -> list[TextContent]:
                 "message": f"✅ Week {week_id} restored from {backup_file.name}",
             }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {"error": f"Restore error: {str(e)}", "week_id": week_id},
-                    indent=2,
-                ),
-            )
-        ]
+        error = {"error": f"Restore error: {str(e)}", "week_id": week_id}
+        return mcp_response(error)
 
 
 async def handle_analyze_training_patterns(args: dict) -> list[TextContent]:
@@ -646,19 +587,12 @@ async def handle_analyze_training_patterns(args: dict) -> list[TextContent]:
             result["analysis_depth"] = depth
             result["message"] = f"✅ Loaded {depth} analysis data for {week_id}"
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Analysis error: {str(e)}",
-                        "week_id": week_id,
-                        "depth": depth,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Analysis error: {str(e)}",
+            "week_id": week_id,
+            "depth": depth,
+        }
+        return mcp_response(error)

--- a/magma_cycling/_mcp/handlers/athlete.py
+++ b/magma_cycling/_mcp/handlers/athlete.py
@@ -1,10 +1,13 @@
 """Athlete profile handlers."""
 
-import json
+from __future__ import annotations
 
-from mcp.types import TextContent
+from typing import TYPE_CHECKING
 
-from magma_cycling._mcp._utils import suppress_stdout_stderr
+from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
 
 __all__ = [
     "handle_get_athlete_profile",
@@ -59,15 +62,10 @@ async def handle_get_athlete_profile(args: dict) -> list[TextContent]:
                 "hr_zones": hr_zones,
             }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Failed to get athlete profile: {str(e)}"}, indent=2),
-            )
-        ]
+        return mcp_response({"error": f"Failed to get athlete profile: {str(e)}"})
 
 
 async def handle_update_athlete_profile(args: dict) -> list[TextContent]:
@@ -88,18 +86,12 @@ async def handle_update_athlete_profile(args: dict) -> list[TextContent]:
                 "current_values": {field: updated_athlete.get(field) for field in updates.keys()},
             }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Failed to update athlete profile: {str(e)}",
-                        "updates": updates,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        return mcp_response(
+            {
+                "error": f"Failed to update athlete profile: {str(e)}",
+                "updates": updates,
+            }
+        )

--- a/magma_cycling/_mcp/handlers/intervals.py
+++ b/magma_cycling/_mcp/handlers/intervals.py
@@ -1,17 +1,21 @@
 """Intervals.icu integration handlers."""
 
-import json
+from __future__ import annotations
+
 from collections import defaultdict
 from datetime import date, timedelta
-
-from mcp.types import TextContent
+from typing import TYPE_CHECKING
 
 from magma_cycling._mcp._utils import (
     SYNCABLE_STATUSES,
     compute_start_time,
     load_workout_descriptions,
+    mcp_response,
     suppress_stdout_stderr,
 )
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
 
 __all__ = [
     "handle_sync_week_to_intervals",
@@ -281,22 +285,14 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
             "message": f"Sync {'preview' if dry_run else 'completed'} for {week_id}",
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except FileNotFoundError:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Planning file not found for week {week_id}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Planning file not found for week {week_id}"}
+        return mcp_response(error)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Sync error: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Sync error: {str(e)}"}
+        return mcp_response(error)
 
 
 async def handle_delete_remote_session(args: dict) -> list[TextContent]:
@@ -308,20 +304,13 @@ async def handle_delete_remote_session(args: dict) -> list[TextContent]:
     confirm = args.get("confirm", False)
 
     if not confirm:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": "Deletion requires explicit confirmation",
-                        "event_id": event_id,
-                        "message": "Set confirm=true to proceed with deletion",
-                        "warning": "This action is PERMANENT and cannot be undone",
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": "Deletion requires explicit confirmation",
+            "event_id": event_id,
+            "message": "Set confirm=true to proceed with deletion",
+            "warning": "This action is PERMANENT and cannot be undone",
+        }
+        return mcp_response(error)
 
     try:
         with suppress_stdout_stderr():
@@ -337,23 +326,16 @@ async def handle_delete_remote_session(args: dict) -> list[TextContent]:
                         for session in plan.planned_sessions:
                             if session.intervals_id == event_id:
                                 if session.status == "completed":
-                                    return [
-                                        TextContent(
-                                            type="text",
-                                            text=json.dumps(
-                                                {
-                                                    "error": "Cannot delete completed session",
-                                                    "event_id": event_id,
-                                                    "session_id": session.session_id,
-                                                    "session_name": session.name,
-                                                    "status": session.status,
-                                                    "message": f"🛡️ PROTECTION: Session {session.session_id} is COMPLETED and cannot be deleted from Intervals.icu",
-                                                    "reason": "Completed sessions are protected to preserve training history",
-                                                },
-                                                indent=2,
-                                            ),
-                                        )
-                                    ]
+                                    error = {
+                                        "error": "Cannot delete completed session",
+                                        "event_id": event_id,
+                                        "session_id": session.session_id,
+                                        "session_name": session.name,
+                                        "status": session.status,
+                                        "message": f"🛡️ PROTECTION: Session {session.session_id} is COMPLETED and cannot be deleted from Intervals.icu",
+                                        "reason": "Completed sessions are protected to preserve training history",
+                                    }
+                                    return mcp_response(error)
                                 found_week_id = week_id
                                 found_session = session
                                 break
@@ -370,19 +352,12 @@ async def handle_delete_remote_session(args: dict) -> list[TextContent]:
             success = client.delete_event(event_id)
 
             if not success:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "success": False,
-                                "event_id": event_id,
-                                "message": f"❌ Failed to delete event {event_id} from Intervals.icu (check logs for details)",
-                            },
-                            indent=2,
-                        ),
-                    )
-                ]
+                error = {
+                    "success": False,
+                    "event_id": event_id,
+                    "message": f"❌ Failed to delete event {event_id} from Intervals.icu (check logs for details)",
+                }
+                return mcp_response(error)
 
             # WRITE-BACK: If we found a local session, update it via Control Tower
             local_update_status = None
@@ -429,26 +404,14 @@ async def handle_delete_remote_session(args: dict) -> list[TextContent]:
                 "local_planning_update": local_update_status,
             }
 
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(result, indent=2),
-            )
-        ]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Delete error: {str(e)}",
-                        "event_id": event_id,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Delete error: {str(e)}",
+            "event_id": event_id,
+        }
+        return mcp_response(error)
 
 
 async def handle_list_remote_events(args: dict) -> list[TextContent]:
@@ -489,27 +452,15 @@ async def handle_list_remote_events(args: dict) -> list[TextContent]:
             if category_filter:
                 result["filtered_by"] = category_filter
 
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(result, indent=2),
-            )
-        ]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Failed to list remote events: {str(e)}",
-                        "start_date": start_date_str,
-                        "end_date": end_date_str,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Failed to list remote events: {str(e)}",
+            "start_date": start_date_str,
+            "end_date": end_date_str,
+        }
+        return mcp_response(error)
 
 
 async def handle_get_activity_details(args: dict) -> list[TextContent]:
@@ -661,21 +612,14 @@ async def handle_get_activity_details(args: dict) -> list[TextContent]:
                     {"type": s["type"], "data_points": len(s["data"])} for s in streams
                 ]
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Failed to get activity details: {str(e)}",
-                        "activity_id": activity_id,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Failed to get activity details: {str(e)}",
+            "activity_id": activity_id,
+        }
+        return mcp_response(error)
 
 
 async def handle_get_activity_intervals(args: dict) -> list[TextContent]:
@@ -730,21 +674,14 @@ async def handle_get_activity_intervals(args: dict) -> list[TextContent]:
             "intervals": intervals,
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Failed to get activity intervals: {str(e)}",
-                        "activity_id": activity_id,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Failed to get activity intervals: {str(e)}",
+            "activity_id": activity_id,
+        }
+        return mcp_response(error)
 
 
 async def handle_get_activity_streams(args: dict) -> list[TextContent]:
@@ -762,18 +699,11 @@ async def handle_get_activity_streams(args: dict) -> list[TextContent]:
             streams = client.get_activity_streams(activity_id)
 
         if not streams:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(
-                        {
-                            "error": f"No stream data found for activity {activity_id}",
-                            "activity_id": activity_id,
-                        },
-                        indent=2,
-                    ),
-                )
-            ]
+            error = {
+                "error": f"No stream data found for activity {activity_id}",
+                "activity_id": activity_id,
+            }
+            return mcp_response(error)
 
         available_stream_types = [s["type"] for s in streams]
 
@@ -829,21 +759,14 @@ async def handle_get_activity_streams(args: dict) -> list[TextContent]:
         if missing_types:
             result["missing_types"] = missing_types
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Failed to get activity streams: {str(e)}",
-                        "activity_id": activity_id,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Failed to get activity streams: {str(e)}",
+            "activity_id": activity_id,
+        }
+        return mcp_response(error)
 
 
 async def handle_compare_intervals(args: dict) -> list[TextContent]:
@@ -881,33 +804,19 @@ async def handle_compare_intervals(args: dict) -> list[TextContent]:
     requested_metrics = args.get("metrics")
 
     if not activity_ids and not name_pattern:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": "Either 'activity_ids' or 'name_pattern' is required.",
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": "Either 'activity_ids' or 'name_pattern' is required.",
+        }
+        return mcp_response(error)
 
     if requested_metrics:
         invalid = [m for m in requested_metrics if m not in NUMERIC_METRICS]
         if invalid:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(
-                        {
-                            "error": f"Invalid metrics: {invalid}",
-                            "available_metrics": sorted(NUMERIC_METRICS),
-                        },
-                        indent=2,
-                    ),
-                )
-            ]
+            error = {
+                "error": f"Invalid metrics: {invalid}",
+                "available_metrics": sorted(NUMERIC_METRICS),
+            }
+            return mcp_response(error)
 
     try:
         with suppress_stdout_stderr():
@@ -946,17 +855,10 @@ async def handle_compare_intervals(args: dict) -> list[TextContent]:
             resolved.sort(key=lambda x: x["date"])
 
             if not resolved:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "error": f"No activities matching '{name_pattern}' in the last {weeks_back} weeks.",
-                            },
-                            indent=2,
-                        ),
-                    )
-                ]
+                error = {
+                    "error": f"No activities matching '{name_pattern}' in the last {weeks_back} weeks.",
+                }
+                return mcp_response(error)
 
         # Fetch intervals for each activity
         activity_intervals = {}
@@ -1078,18 +980,11 @@ async def handle_compare_intervals(args: dict) -> list[TextContent]:
             "comparison": comparison,
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {"error": f"Failed to compare intervals: {str(e)}"},
-                    indent=2,
-                ),
-            )
-        ]
+        error = {"error": f"Failed to compare intervals: {str(e)}"}
+        return mcp_response(error)
 
 
 async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
@@ -1115,39 +1010,25 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
         # --- Manual mode ---
         if manual_intervals is not None:
             if dry_run:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "mode": "manual",
-                                "dry_run": True,
-                                "activity_id": activity_id,
-                                "intervals_count": len(manual_intervals),
-                                "intervals": manual_intervals,
-                                "message": "Preview only. Set dry_run=false to apply.",
-                            },
-                            indent=2,
-                        ),
-                    )
-                ]
+                preview = {
+                    "mode": "manual",
+                    "dry_run": True,
+                    "activity_id": activity_id,
+                    "intervals_count": len(manual_intervals),
+                    "intervals": manual_intervals,
+                    "message": "Preview only. Set dry_run=false to apply.",
+                }
+                return mcp_response(preview)
             with suppress_stdout_stderr():
                 result = client.put_activity_intervals(activity_id, manual_intervals)
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(
-                        {
-                            "mode": "manual",
-                            "dry_run": False,
-                            "activity_id": activity_id,
-                            "applied": True,
-                            "result": result,
-                        },
-                        indent=2,
-                    ),
-                )
-            ]
+            applied = {
+                "mode": "manual",
+                "dry_run": False,
+                "activity_id": activity_id,
+                "applied": True,
+                "result": result,
+            }
+            return mcp_response(applied)
 
         # --- Auto mode ---
         session_id = args.get("session_id")
@@ -1157,18 +1038,11 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
             activity_name = activity.get("name", "")
             m = re.search(SESSION_ID_PATTERN, activity_name)
             if not m:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "error": f"Cannot extract session_id from activity name: '{activity_name}'",
-                                "hint": "Provide session_id parameter explicitly (e.g. S082-02)",
-                            },
-                            indent=2,
-                        ),
-                    )
-                ]
+                error = {
+                    "error": f"Cannot extract session_id from activity name: '{activity_name}'",
+                    "hint": "Provide session_id parameter explicitly (e.g. S082-02)",
+                }
+                return mcp_response(error)
             session_id = m.group()
 
         # Load workout description
@@ -1182,50 +1056,29 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
                 break
 
         if workout_text is None:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(
-                        {
-                            "error": f"No workout found for session {session_id} in {week_id}_workouts.txt",
-                            "available_workouts": list(descriptions.keys()),
-                        },
-                        indent=2,
-                    ),
-                )
-            ]
+            error = {
+                "error": f"No workout found for session {session_id} in {week_id}_workouts.txt",
+                "available_workouts": list(descriptions.keys()),
+            }
+            return mcp_response(error)
 
         # Parse workout
         blocks = parse_workout_text(workout_text)
         if not blocks:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(
-                        {
-                            "error": f"Workout {session_id} is a rest day (no blocks to apply)",
-                        },
-                        indent=2,
-                    ),
-                )
-            ]
+            error = {
+                "error": f"Workout {session_id} is a rest day (no blocks to apply)",
+            }
+            return mcp_response(error)
 
         # Get stream to determine total points
         with suppress_stdout_stderr():
             streams = client.get_activity_streams(activity_id)
 
         if not streams or not streams[0].get("data"):
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(
-                        {
-                            "error": f"No stream data found for activity {activity_id}",
-                        },
-                        indent=2,
-                    ),
-                )
-            ]
+            error = {
+                "error": f"No stream data found for activity {activity_id}",
+            }
+            return mcp_response(error)
         total_points = len(streams[0]["data"])
 
         # Compute intervals
@@ -1262,27 +1115,20 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
 
         if dry_run:
             summary["message"] = "Preview only. Set dry_run=false to apply."
-            return [TextContent(type="text", text=json.dumps(summary, indent=2))]
+            return mcp_response(summary)
 
         with suppress_stdout_stderr():
             result = client.put_activity_intervals(activity_id, interval_dicts)
         summary["applied"] = True
         summary["result"] = result
-        return [TextContent(type="text", text=json.dumps(summary, indent=2))]
+        return mcp_response(summary)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Failed to apply workout intervals: {str(e)}",
-                        "activity_id": activity_id,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Failed to apply workout intervals: {str(e)}",
+            "activity_id": activity_id,
+        }
+        return mcp_response(error)
 
 
 async def handle_update_remote_session(args: dict) -> list[TextContent]:
@@ -1309,20 +1155,13 @@ async def handle_update_remote_session(args: dict) -> list[TextContent]:
                         for session in plan.planned_sessions:
                             if session.intervals_id == event_id:
                                 if session.status == "completed":
-                                    return [
-                                        TextContent(
-                                            type="text",
-                                            text=json.dumps(
-                                                {
-                                                    "error": "Cannot update completed session",
-                                                    "event_id": event_id,
-                                                    "session_id": session.session_id,
-                                                    "message": f"🛡️ PROTECTION: Session {session.session_id} is COMPLETED",
-                                                },
-                                                indent=2,
-                                            ),
-                                        )
-                                    ]
+                                    error = {
+                                        "error": "Cannot update completed session",
+                                        "event_id": event_id,
+                                        "session_id": session.session_id,
+                                        "message": f"🛡️ PROTECTION: Session {session.session_id} is COMPLETED",
+                                    }
+                                    return mcp_response(error)
                                 target_week_id = week_id
                                 target_session = session
                                 break
@@ -1383,18 +1222,11 @@ async def handle_update_remote_session(args: dict) -> list[TextContent]:
                     "message": f"❌ Failed to update event {event_id}",
                 }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {"error": f"Update error: {str(e)}", "event_id": event_id},
-                    indent=2,
-                ),
-            )
-        ]
+        error = {"error": f"Update error: {str(e)}", "event_id": event_id}
+        return mcp_response(error)
 
 
 async def handle_create_remote_note(args: dict) -> list[TextContent]:
@@ -1411,20 +1243,13 @@ async def handle_create_remote_note(args: dict) -> list[TextContent]:
 
     ALLOWED_PREFIXES = ["[ANNULÉE]", "[SAUTÉE]", "[REMPLACÉE]"]
     if not any(name.startswith(prefix) for prefix in ALLOWED_PREFIXES):
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "success": False,
-                        "error": f"Invalid NOTE name. Name must start with one of: {', '.join(ALLOWED_PREFIXES)}",
-                        "provided_name": name,
-                        "allowed_prefixes": ALLOWED_PREFIXES,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "success": False,
+            "error": f"Invalid NOTE name. Name must start with one of: {', '.join(ALLOWED_PREFIXES)}",
+            "provided_name": name,
+            "allowed_prefixes": ALLOWED_PREFIXES,
+        }
+        return mcp_response(error)
 
     try:
         with suppress_stdout_stderr():
@@ -1499,22 +1324,15 @@ async def handle_create_remote_note(args: dict) -> list[TextContent]:
                     "message": "❌ Failed to create NOTE - no ID returned from Intervals.icu",
                 }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Failed to create NOTE: {str(e)}",
-                        "date": note_date,
-                        "name": name,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Failed to create NOTE: {str(e)}",
+            "date": note_date,
+            "name": name,
+        }
+        return mcp_response(error)
 
 
 async def handle_sync_remote_to_local(args: dict) -> list[TextContent]:
@@ -1568,25 +1386,13 @@ async def handle_sync_remote_to_local(args: dict) -> list[TextContent]:
 
             result["changes"] = changes
 
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(result, indent=2),
-                )
-            ]
+            return mcp_response(result)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": str(e),
-                        "week_id": args.get("week_id"),
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": str(e),
+            "week_id": args.get("week_id"),
+        }
+        return mcp_response(error)
 
 
 async def handle_backfill_activities(args: dict) -> list[TextContent]:
@@ -1607,15 +1413,8 @@ async def handle_backfill_activities(args: dict) -> list[TextContent]:
             planning_file = data_config.week_planning_dir / f"week_planning_{week_id}.json"
 
             if not planning_file.exists():
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {"error": f"Planning file not found for {week_id}"},
-                            indent=2,
-                        ),
-                    )
-                ]
+                error = {"error": f"Planning file not found for {week_id}"}
+                return mcp_response(error)
 
             plan = WeeklyPlan.from_json(planning_file)
             start_date_val = plan.start_date
@@ -1631,20 +1430,13 @@ async def handle_backfill_activities(args: dict) -> list[TextContent]:
         activities = client.get_activities(oldest=start_date_val, newest=end_date_val)
 
         if not activities:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps(
-                        {
-                            "message": f"No activities found for {date_source}",
-                            "start_date": str(start_date_val),
-                            "end_date": str(end_date_val),
-                            "activities_count": 0,
-                        },
-                        indent=2,
-                    ),
-                )
-            ]
+            info = {
+                "message": f"No activities found for {date_source}",
+                "start_date": str(start_date_val),
+                "end_date": str(end_date_val),
+                "activities_count": 0,
+            }
+            return mcp_response(info)
 
         data_config = get_data_config()
         tracking_file = data_config.data_repo_path / ".backfill_tracking.json"
@@ -1755,9 +1547,4 @@ async def handle_backfill_activities(args: dict) -> list[TextContent]:
                     }
                 )
 
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(result, indent=2),
-            )
-        ]
+        return mcp_response(result)

--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -1,12 +1,16 @@
 """Planning tool handlers."""
 
+from __future__ import annotations
+
 import json
 from datetime import date, datetime, timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from mcp.types import TextContent
+from magma_cycling._mcp._utils import compute_start_time, mcp_response, suppress_stdout_stderr
 
-from magma_cycling._mcp._utils import compute_start_time, suppress_stdout_stderr
+if TYPE_CHECKING:
+    from mcp.types import TextContent
 
 __all__ = [
     "handle_weekly_planner",
@@ -63,7 +67,7 @@ async def handle_weekly_planner(args: dict) -> list[TextContent]:
     if provider == "clipboard":
         result["prompt"] = prompt[:500] + "..." if len(prompt) > 500 else prompt
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_monthly_analysis(args: dict) -> list[TextContent]:
@@ -80,12 +84,8 @@ async def handle_monthly_analysis(args: dict) -> list[TextContent]:
         report = analyzer.run()
 
     if not report:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"No planning data found for {month}"}, indent=2),
-            )
-        ]
+        error = {"error": f"No planning data found for {month}"}
+        return mcp_response(error)
 
     # Extract key metrics from report
     result = {
@@ -94,7 +94,7 @@ async def handle_monthly_analysis(args: dict) -> list[TextContent]:
         "report": report,
     }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_daily_sync(args: dict) -> list[TextContent]:
@@ -198,7 +198,7 @@ async def handle_daily_sync(args: dict) -> list[TextContent]:
         "message": f"Sync completed for {check_date.isoformat()}",
     }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_update_session(args: dict) -> list[TextContent]:
@@ -328,7 +328,7 @@ async def handle_update_session(args: dict) -> list[TextContent]:
         "sync_result": sync_result if sync_to_intervals else None,
     }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_list_weeks(args: dict) -> list[TextContent]:
@@ -370,7 +370,7 @@ async def handle_list_weeks(args: dict) -> list[TextContent]:
         "weeks": weeks,
     }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_get_metrics(args: dict) -> list[TextContent]:
@@ -389,7 +389,7 @@ async def handle_get_metrics(args: dict) -> list[TextContent]:
     wellness_data = client.get_wellness(oldest=oldest, newest=newest)
 
     if wellness_data:
-        latest = wellness_data[0]  # Most recent
+        latest = wellness_data[-1]  # Most recent
         result = {
             "date": latest.get("id"),
             "ctl": latest.get("ctl"),
@@ -402,7 +402,7 @@ async def handle_get_metrics(args: dict) -> list[TextContent]:
     else:
         result = {"error": "No wellness data found"}
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_get_week_details(args: dict) -> list[TextContent]:
@@ -445,22 +445,14 @@ async def handle_get_week_details(args: dict) -> list[TextContent]:
             ],
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except FileNotFoundError:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Planning file not found for week {week_id}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Planning file not found for week {week_id}"}
+        return mcp_response(error)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error reading planning: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Error reading planning: {str(e)}"}
+        return mcp_response(error)
 
 
 async def handle_modify_session_details(args: dict) -> list[TextContent]:
@@ -537,29 +529,17 @@ async def handle_modify_session_details(args: dict) -> list[TextContent]:
             "message": f"Session {session_id} updated successfully",
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except FileNotFoundError:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Planning file not found for week {week_id}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Planning file not found for week {week_id}"}
+        return mcp_response(error)
     except ValueError as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": str(e)}, indent=2),
-            )
-        ]
+        error = {"error": str(e)}
+        return mcp_response(error)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error modifying session: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Error modifying session: {str(e)}"}
+        return mcp_response(error)
 
 
 async def handle_rename_session(args: dict) -> list[TextContent]:
@@ -575,34 +555,19 @@ async def handle_rename_session(args: dict) -> list[TextContent]:
 
     # Validate format
     if not SESSION_ID_REGEX.match(new_session_id):
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Invalid session_id format: '{new_session_id}'. "
-                        f"Expected: S###-##[a-z]"
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Invalid session_id format: '{new_session_id}'. " f"Expected: S###-##[a-z]"
+        }
+        return mcp_response(error)
 
     # Validate same week
     new_week = new_session_id.split("-")[0]
     if new_week != week_id:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "error": f"Cannot rename across weeks: "
-                        f"{session_id} ({week_id}) → {new_session_id} ({new_week})"
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        error = {
+            "error": f"Cannot rename across weeks: "
+            f"{session_id} ({week_id}) → {new_session_id} ({new_week})"
+        }
+        return mcp_response(error)
 
     remote_updated = False
     old_intervals_name = None
@@ -665,65 +630,36 @@ async def handle_rename_session(args: dict) -> list[TextContent]:
                 )
                 remote_updated = True
             except Exception as e:
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "status": "partial",
-                                "message": f"Session renamed locally but remote update failed: {e}",
-                                "week_id": week_id,
-                                "old_session_id": session_id,
-                                "new_session_id": new_session_id,
-                            },
-                            indent=2,
-                        ),
-                    )
-                ]
+                partial = {
+                    "status": "partial",
+                    "message": f"Session renamed locally but remote update failed: {e}",
+                    "week_id": week_id,
+                    "old_session_id": session_id,
+                    "new_session_id": new_session_id,
+                }
+                return mcp_response(partial)
 
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {
-                        "status": "success",
-                        "week_id": week_id,
-                        "old_session_id": session_id,
-                        "new_session_id": new_session_id,
-                        "old_intervals_name": old_intervals_name,
-                        "new_intervals_name": new_intervals_name,
-                        "remote_updated": remote_updated,
-                        "intervals_id": intervals_id,
-                    },
-                    indent=2,
-                ),
-            )
-        ]
+        result = {
+            "status": "success",
+            "week_id": week_id,
+            "old_session_id": session_id,
+            "new_session_id": new_session_id,
+            "old_intervals_name": old_intervals_name,
+            "new_intervals_name": new_intervals_name,
+            "remote_updated": remote_updated,
+            "intervals_id": intervals_id,
+        }
+        return mcp_response(result)
 
     except FileNotFoundError:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(
-                    {"error": f"Planning file not found for week {week_id}"},
-                    indent=2,
-                ),
-            )
-        ]
+        error = {"error": f"Planning file not found for week {week_id}"}
+        return mcp_response(error)
     except ValueError as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": str(e)}, indent=2),
-            )
-        ]
+        error = {"error": str(e)}
+        return mcp_response(error)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error renaming session: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Error renaming session: {str(e)}"}
+        return mcp_response(error)
 
 
 async def handle_create_session(args: dict) -> list[TextContent]:
@@ -811,22 +747,14 @@ async def handle_create_session(args: dict) -> list[TextContent]:
             "message": f"Session {session_id} created successfully",
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except FileNotFoundError:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Planning file not found for week {week_id}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Planning file not found for week {week_id}"}
+        return mcp_response(error)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error creating session: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Error creating session: {str(e)}"}
+        return mcp_response(error)
 
 
 async def handle_delete_session(args: dict) -> list[TextContent]:
@@ -879,26 +807,14 @@ async def handle_delete_session(args: dict) -> list[TextContent]:
             "message": f"Session {session_id} deleted successfully",
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except FileNotFoundError:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Planning file not found for week {week_id}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Planning file not found for week {week_id}"}
+        return mcp_response(error)
     except ValueError as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": str(e)}, indent=2),
-            )
-        ]
+        error = {"error": str(e)}
+        return mcp_response(error)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error deleting session: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Error deleting session: {str(e)}"}
+        return mcp_response(error)

--- a/magma_cycling/_mcp/handlers/sessions.py
+++ b/magma_cycling/_mcp/handlers/sessions.py
@@ -1,10 +1,13 @@
 """Session manipulation handlers (duplicate, swap, attach-workout)."""
 
-import json
+from __future__ import annotations
 
-from mcp.types import TextContent
+from typing import TYPE_CHECKING
 
-from magma_cycling._mcp._utils import compute_start_time, suppress_stdout_stderr
+from magma_cycling._mcp._utils import compute_start_time, mcp_response, suppress_stdout_stderr
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
 
 __all__ = [
     "handle_duplicate_session",
@@ -94,29 +97,17 @@ async def handle_duplicate_session(args: dict) -> list[TextContent]:
             "message": f"Session duplicated successfully: {source_session_id} -> {new_session_id}",
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except FileNotFoundError:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Planning file not found for week {week_id}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Planning file not found for week {week_id}"}
+        return mcp_response(error)
     except ValueError as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": str(e)}, indent=2),
-            )
-        ]
+        error = {"error": str(e)}
+        return mcp_response(error)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error duplicating session: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Error duplicating session: {str(e)}"}
+        return mcp_response(error)
 
 
 async def handle_swap_sessions(args: dict) -> list[TextContent]:
@@ -232,29 +223,17 @@ async def handle_swap_sessions(args: dict) -> list[TextContent]:
             + (" (+ remote events updated)" if remote_updated else ""),
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except FileNotFoundError:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Planning file not found for week {week_id}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Planning file not found for week {week_id}"}
+        return mcp_response(error)
     except ValueError as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": str(e)}, indent=2),
-            )
-        ]
+        error = {"error": str(e)}
+        return mcp_response(error)
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error swapping sessions: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Error swapping sessions: {str(e)}"}
+        return mcp_response(error)
 
 
 async def handle_attach_workout(args: dict) -> list[TextContent]:
@@ -291,12 +270,8 @@ async def handle_attach_workout(args: dict) -> list[TextContent]:
             "message": f"Workout attached successfully: {filename}",
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error attaching workout: {str(e)}"}, indent=2),
-            )
-        ]
+        error = {"error": f"Error attaching workout: {str(e)}"}
+        return mcp_response(error)

--- a/magma_cycling/_mcp/handlers/withings.py
+++ b/magma_cycling/_mcp/handlers/withings.py
@@ -1,11 +1,15 @@
 """Withings health data handlers."""
 
+from __future__ import annotations
+
 import json
 from datetime import date, timedelta
+from typing import TYPE_CHECKING
 
-from mcp.types import TextContent
+from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
 
-from magma_cycling._mcp._utils import suppress_stdout_stderr
+if TYPE_CHECKING:
+    from mcp.types import TextContent
 
 __all__ = [
     "handle_withings_auth_status",
@@ -59,7 +63,7 @@ async def handle_withings_auth_status(args: dict) -> list[TextContent]:
             except Exception:
                 pass
 
-    return [TextContent(type="text", text=json.dumps(status, indent=2))]
+    return mcp_response(status)
 
 
 async def handle_withings_authorize(args: dict) -> list[TextContent]:
@@ -103,7 +107,7 @@ async def handle_withings_authorize(args: dict) -> list[TextContent]:
             except Exception as e:
                 result = {"step": "authorization_failed", "status": "error", "error": str(e)}
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_withings_get_sleep(args: dict) -> list[TextContent]:
@@ -141,7 +145,7 @@ async def handle_withings_get_sleep(args: dict) -> list[TextContent]:
                 "count": len(sessions),
             }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+    return mcp_response(result, default=str)
 
 
 async def handle_withings_get_weight(args: dict) -> list[TextContent]:
@@ -179,7 +183,7 @@ async def handle_withings_get_weight(args: dict) -> list[TextContent]:
                 "count": len(measurements),
             }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+    return mcp_response(result, default=str)
 
 
 async def handle_withings_get_readiness(args: dict) -> list[TextContent]:
@@ -207,7 +211,7 @@ async def handle_withings_get_readiness(args: dict) -> list[TextContent]:
                 "readiness": readiness.model_dump(),
             }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+    return mcp_response(result, default=str)
 
 
 async def handle_withings_sync_to_intervals(args: dict) -> list[TextContent]:
@@ -295,7 +299,7 @@ async def handle_withings_sync_to_intervals(args: dict) -> list[TextContent]:
             "status": "success" if not errors else "partial_success",
         }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_withings_analyze_trends(args: dict) -> list[TextContent]:
@@ -322,7 +326,7 @@ async def handle_withings_analyze_trends(args: dict) -> list[TextContent]:
                     "error": "start_date and end_date required for custom period",
                     "status": "error",
                 }
-                return [TextContent(type="text", text=json.dumps(result, indent=2))]
+                return mcp_response(result)
 
             start_date_val = date.fromisoformat(start_date_str)
             end_date_val = date.fromisoformat(end_date_str)
@@ -405,7 +409,7 @@ async def handle_withings_analyze_trends(args: dict) -> list[TextContent]:
             "alerts": alerts,
         }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)
 
 
 async def handle_withings_enrich_session(args: dict) -> list[TextContent]:
@@ -436,7 +440,7 @@ async def handle_withings_enrich_session(args: dict) -> list[TextContent]:
                     "error": f"Session {session_id} not found in week {week_id}",
                     "status": "error",
                 }
-                return [TextContent(type="text", text=json.dumps(result, indent=2))]
+                return mcp_response(result)
 
             # Get session date
             session_date = session.session_date
@@ -480,4 +484,4 @@ async def handle_withings_enrich_session(args: dict) -> list[TextContent]:
                 "status": "success",
             }
 
-    return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    return mcp_response(result)

--- a/magma_cycling/_mcp/handlers/workouts.py
+++ b/magma_cycling/_mcp/handlers/workouts.py
@@ -1,10 +1,13 @@
 """Workout handlers."""
 
-import json
+from __future__ import annotations
 
-from mcp.types import TextContent
+from typing import TYPE_CHECKING
 
-from magma_cycling._mcp._utils import suppress_stdout_stderr
+from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
 
 __all__ = [
     "handle_get_workout",
@@ -44,38 +47,25 @@ async def handle_get_workout(args: dict) -> list[TextContent]:
                 except Exception:
                     pass
 
-                return [
-                    TextContent(
-                        type="text",
-                        text=json.dumps(
-                            {
-                                "found": False,
-                                "session_id": session_id,
-                                "structured_file": None,
-                                "message": "No structured workout file (.zwo) found. "
-                                "Session is defined via text description in the planning.",
-                                "session_definition": (
-                                    {
-                                        "name": session_def.name if session_def else None,
-                                        "type": (session_def.session_type if session_def else None),
-                                        "description": (
-                                            session_def.description if session_def else None
-                                        ),
-                                        "tss_planned": (
-                                            session_def.tss_planned if session_def else None
-                                        ),
-                                        "duration_min": (
-                                            session_def.duration_min if session_def else None
-                                        ),
-                                    }
-                                    if session_def
-                                    else None
-                                ),
-                            },
-                            indent=2,
-                        ),
-                    )
-                ]
+                result = {
+                    "found": False,
+                    "session_id": session_id,
+                    "structured_file": None,
+                    "message": "No structured workout file (.zwo) found. "
+                    "Session is defined via text description in the planning.",
+                    "session_definition": (
+                        {
+                            "name": session_def.name if session_def else None,
+                            "type": (session_def.session_type if session_def else None),
+                            "description": (session_def.description if session_def else None),
+                            "tss_planned": (session_def.tss_planned if session_def else None),
+                            "duration_min": (session_def.duration_min if session_def else None),
+                        }
+                        if session_def
+                        else None
+                    ),
+                }
+                return mcp_response(result)
 
             # If multiple files, return the first one (or could return all)
             workout_file = workout_files[0]
@@ -92,15 +82,10 @@ async def handle_get_workout(args: dict) -> list[TextContent]:
             "message": f"Workout retrieved: {workout_file.name}",
         }
 
-        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Error retrieving workout: {str(e)}"}, indent=2),
-            )
-        ]
+        return mcp_response({"error": f"Error retrieving workout: {str(e)}"})
 
 
 async def handle_validate_workout(args: dict) -> list[TextContent]:
@@ -152,17 +137,7 @@ async def handle_validate_workout(args: dict) -> list[TextContent]:
                         "Workout format has errors (use auto_fix:true to attempt automatic correction)"
                     )
 
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(result, indent=2),
-            )
-        ]
+        return mcp_response(result)
 
     except Exception as e:
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps({"error": f"Validation error: {str(e)}"}, indent=2),
-            )
-        ]
+        return mcp_response({"error": f"Validation error: {str(e)}"})

--- a/tests/test_mcp_handlers.py
+++ b/tests/test_mcp_handlers.py
@@ -19,6 +19,51 @@ from magma_cycling.planning.models import Session, WeeklyPlan
 pytest_plugins = ("pytest_asyncio",)
 
 
+# ---------------------------------------------------------------------------
+# Tests: mcp_response() utility
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_response_basic():
+    """mcp_response wraps a dict with _metadata and returns TextContent list."""
+    from magma_cycling._mcp._utils import mcp_response
+
+    result = mcp_response({"key": "value"})
+
+    assert len(result) == 1
+    payload = json.loads(result[0].text)
+    assert payload["key"] == "value"
+    assert "_metadata" in payload
+    assert "response_date" in payload["_metadata"]
+    assert "response_timestamp" in payload["_metadata"]
+    # Date is ISO format YYYY-MM-DD
+    date.fromisoformat(payload["_metadata"]["response_date"])
+    # Timestamp is ISO datetime
+    datetime.fromisoformat(payload["_metadata"]["response_timestamp"])
+
+
+def test_mcp_response_default_str():
+    """mcp_response forwards default=str for non-serializable values."""
+    from magma_cycling._mcp._utils import mcp_response
+
+    result = mcp_response({"d": date(2026, 3, 1)}, default=str)
+
+    payload = json.loads(result[0].text)
+    assert payload["d"] == "2026-03-01"
+    assert "_metadata" in payload
+
+
+def test_mcp_response_error():
+    """mcp_response works with error payloads too."""
+    from magma_cycling._mcp._utils import mcp_response
+
+    result = mcp_response({"error": "something went wrong"})
+
+    payload = json.loads(result[0].text)
+    assert payload["error"] == "something went wrong"
+    assert "_metadata" in payload
+
+
 # Fixtures
 
 


### PR DESCRIPTION
## Summary
- Add `mcp_response()` utility that injects `_metadata.response_date` + `_metadata.response_timestamp` into every MCP response, so Claude Desktop knows data freshness
- Fix `get-metrics` bug: `wellness_data[0]` → `wellness_data[-1]` (was returning oldest instead of most recent CTL/ATL/TSB)
- Migrate all 46 handlers across 9 files to use `mcp_response()`, removing direct `json.dumps`/`TextContent` boilerplate (-358 lines net)

## Test plan
- [x] 3 new unit tests for `mcp_response()` (basic, default=str, error)
- [x] Full test suite: 1875 passed
- [x] Pre-commit hooks: all green
- [ ] Manual verification via Claude Desktop: check `_metadata` appears in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)