### PR TITLE
fix(mcp,monitor): NOTE conversion on skip/cancel + smart polling cutoff

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -221,6 +221,8 @@ async def handle_update_session(args: dict) -> list[TextContent]:
     session_type = None
     session_version = None
     session_description = None
+    session_tss = None
+    session_duration = None
 
     # Suppress all output to prevent JSON protocol pollution
     with suppress_stdout_stderr():
@@ -239,6 +241,8 @@ async def handle_update_session(args: dict) -> list[TextContent]:
                     session_type = session.session_type
                     session_version = session.version
                     session_description = session.description
+                    session_tss = session.tss_planned
+                    session_duration = session.duration_min
 
                     # PROTECTION: Never modify completed sessions in Intervals.icu
                     if sync_to_intervals and old_status == "completed":
@@ -264,56 +268,85 @@ async def handle_update_session(args: dict) -> list[TextContent]:
             try:
                 client = create_intervals_client()
 
-                # Prepare event data
-                # Determine start time based on day and session suffix
-                day_of_week = session_date.weekday()  # 0=Monday, 5=Saturday
-                session_day_part = session_id.split("-")[-1]  # e.g., "04" or "06a"
+                if new_status in ("skipped", "cancelled", "replaced", "modified"):
+                    # Delegate to CLI sync function which handles
+                    # NOTE conversion (skipped/cancelled/replaced)
+                    # and description update (modified) correctly.
+                    # print() calls are captured by suppress_stdout_stderr().
+                    from magma_cycling.update_session_status import (
+                        sync_with_intervals,
+                    )
 
-                # Check if session has letter suffix (double session)
-                session_suffix = session_day_part[-1] if session_day_part[-1].isalpha() else None
+                    session_info = {
+                        "name": session_name,
+                        "type": session_type,
+                        "version": session_version,
+                        "description": session_description,
+                        "tss_planned": session_tss,
+                        "duration_min": session_duration,
+                    }
 
-                # Double session (a/b)
-                if session_suffix == "a":
-                    start_time = "09:00:00"  # Morning
-                elif session_suffix == "b":
-                    start_time = "15:00:00"  # Afternoon
-                else:
-                    # Saturday → 09:00, other days → 17:00
-                    start_time = "09:00:00" if day_of_week == 5 else "17:00:00"
+                    sync_ok = sync_with_intervals(
+                        client=client,
+                        session_id=session_id,
+                        session_date=str(session_date),
+                        new_status=new_status,
+                        reason=reason,
+                        session_info=session_info,
+                    )
 
-                # Build Intervals.icu event name: S082-03-INT-SweetSpotBlocs-V001
-                intervals_name = f"{session_id}-{session_type}-{session_name}-{session_version}"
+                    status_label = {
+                        "skipped": "SAUTÉE",
+                        "cancelled": "ANNULÉE",
+                        "replaced": "REMPLACÉE",
+                        "modified": "modified",
+                    }.get(new_status, new_status)
 
-                event_data = {
-                    "category": "WORKOUT",
-                    "type": "VirtualRide",
-                    "name": intervals_name,
-                    "description": session_description,
-                    "start_date_local": f"{session_date}T{start_time}",
-                }
-
-                if intervals_id:
-                    # Update existing event
-                    client.update_event(intervals_id, event_data)
-                    sync_result = f"Updated Intervals.icu event {intervals_id}"
-                else:
-                    # Create new event
-                    created = client.create_event(event_data)
-                    if created and "id" in created:
-                        new_intervals_id = created["id"]
-                        # Save intervals_id back to planning
-                        with planning_tower.modify_week(
-                            week_id,
-                            requesting_script="mcp-server",
-                            reason=f"MCP: Save Intervals.icu ID {new_intervals_id} for {session_id}",
-                        ) as plan:
-                            for session in plan.planned_sessions:
-                                if session.session_id == session_id:
-                                    session.intervals_id = new_intervals_id
-                                    break
-                        sync_result = f"Created Intervals.icu event {new_intervals_id}"
+                    if sync_ok:
+                        sync_result = (
+                            f"Converted Intervals.icu event to NOTE "
+                            f"[{status_label}] for {session_id}"
+                        )
                     else:
-                        sync_result = "Failed to create Intervals.icu event"
+                        sync_result = f"Failed to convert Intervals.icu event " f"for {session_id}"
+
+                else:
+                    # For planned/uploaded/pending: WORKOUT create/update
+                    start_time = compute_start_time(session_date, session_id)
+                    intervals_name = (
+                        f"{session_id}-{session_type}-" f"{session_name}-{session_version}"
+                    )
+
+                    event_data = {
+                        "category": "WORKOUT",
+                        "type": "VirtualRide",
+                        "name": intervals_name,
+                        "description": session_description,
+                        "start_date_local": f"{session_date}T{start_time}",
+                    }
+
+                    if intervals_id:
+                        client.update_event(intervals_id, event_data)
+                        sync_result = f"Updated Intervals.icu event {intervals_id}"
+                    else:
+                        created = client.create_event(event_data)
+                        if created and "id" in created:
+                            new_intervals_id = created["id"]
+                            with planning_tower.modify_week(
+                                week_id,
+                                requesting_script="mcp-server",
+                                reason=(
+                                    f"MCP: Save Intervals.icu ID "
+                                    f"{new_intervals_id} for {session_id}"
+                                ),
+                            ) as plan:
+                                for session in plan.planned_sessions:
+                                    if session.session_id == session_id:
+                                        session.intervals_id = new_intervals_id
+                                        break
+                            sync_result = f"Created Intervals.icu event {new_intervals_id}"
+                        else:
+                            sync_result = "Failed to create Intervals.icu event"
 
             except Exception as e:
                 sync_result = f"Sync error: {str(e)}"

--- a/magma_cycling/session_monitor.py
+++ b/magma_cycling/session_monitor.py
@@ -51,6 +51,39 @@ def run_command(label: str, args: list[str]) -> bool:
         return False
 
 
+def _get_event_cutoff(client: object, session_ids: list[str], today_str: str) -> int | None:
+    """Get cutoff hour from the planned event's start time on Intervals.icu.
+
+    Looks up today's events, finds the one matching an actionable session,
+    parses start_date_local, and returns start_hour + 3 (buffer).
+
+    Returns None if no matching event or no parseable time (caller uses fallback).
+    """
+    try:
+        events = client.get_events(oldest=today_str, newest=today_str)
+        for event in events:
+            event_name = event.get("name", "")
+            if any(sid in event_name for sid in session_ids):
+                start_local = event.get("start_date_local", "")
+                if "T" in start_local:
+                    hour = int(start_local.split("T")[1].split(":")[0])
+                    return min(hour + 3, 23)  # cap at 23h
+        return None
+    except Exception:
+        return None
+
+
+def _fallback_cutoff(day_of_week: int) -> int:
+    """Static fallback cutoff when no event time is available.
+
+    Saturday/Sunday: 14h (morning sessions).
+    Weekdays: 21h (sessions between 17h-20h).
+    """
+    if day_of_week in (5, 6):
+        return 14
+    return 21
+
+
 def main() -> int:
     """Entry point."""
     now = datetime.now()
@@ -105,6 +138,19 @@ def main() -> int:
     # New activity = more activities on Intervals.icu than sessions marked completed
     if len(cycling) <= completed_count:
         waiting_ids = ", ".join(s.session_id for s in actionable)
+
+        # Smart cutoff: read planned event time from Intervals.icu, add 3h buffer
+        actionable_ids = [s.session_id for s in actionable]
+        cutoff = _get_event_cutoff(client, actionable_ids, date_str)
+        if cutoff is None:
+            cutoff = _fallback_cutoff(today.weekday())
+
+        if now.hour >= cutoff:
+            log(
+                f"{waiting_ids} no activity past cutoff ({cutoff}h), " f"stopping monitor for today"
+            )
+            return 0
+
         log(f"{waiting_ids} waiting ({len(cycling)} activities, {completed_count} completed)")
         return 0
 


### PR DESCRIPTION
## Summary

- **MCP handler**: `handle_update_session` now delegates skip/cancel/replaced/modified to `sync_with_intervals()` which correctly converts Intervals.icu events to NOTE with `[SAUTÉE]`/`[ANNULÉE]`/`[REMPLACÉE]` tags instead of erroneously creating WORKOUT events
- **Session-monitor**: reads the planned event start time from Intervals.icu and stops polling 3h after. Static fallback: weekdays 21h, weekends 14h. Prevents all-day polling (S083-01 was monitored for 13h on March 2)

## Root cause

Discovered via S083-01 debug:
1. MCP handler always created/updated WORKOUT events regardless of session status — skipped/cancelled sessions were not converted to NOTE
2. Session-monitor polled every 20 min from 6h to 23h with no awareness of the planned session time

## Test plan

- [x] `poetry run pytest tests/ -x` — 1875 passed
- [x] `poetry run pre-commit run --all-files` — all green
- [ ] Manual: skip a session via MCP with `sync=True` → verify Intervals.icu event becomes NOTE `[SAUTÉE]`
- [ ] Manual: verify session-monitor logs "past cutoff" instead of "waiting" after event time + 3h

🤖 Generated with [Claude Code](https://claude.com/claude-code)