### PR TITLE
fix(mcp): restore full workout description on event update

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -7,7 +7,12 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from magma_cycling._mcp._utils import compute_start_time, mcp_response, suppress_stdout_stderr
+from magma_cycling._mcp._utils import (
+    compute_start_time,
+    load_workout_descriptions,
+    mcp_response,
+    suppress_stdout_stderr,
+)
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
@@ -317,11 +322,16 @@ async def handle_update_session(args: dict) -> list[TextContent]:
                         f"{session_id}-{session_type}-" f"{session_name}-{session_version}"
                     )
 
+                    # Load full workout description from {week_id}_workouts.txt
+                    # Fallback to short session_description if not found
+                    full_descriptions = load_workout_descriptions(week_id)
+                    full_desc = full_descriptions.get(intervals_name, session_description)
+
                     event_data = {
                         "category": "WORKOUT",
                         "type": "VirtualRide",
                         "name": intervals_name,
-                        "description": session_description,
+                        "description": full_desc,
                         "start_date_local": f"{session_date}T{start_time}",
                     }
 


### PR DESCRIPTION
## Summary

- `handle_update_session` WORKOUT branch now loads the full workout description from `{week_id}_workouts.txt` via `load_workout_descriptions()` instead of using the short `session.description` from planning JSON
- Fallback to short description if workouts file not found

## Root cause

When restoring a session from `skipped` → `pending` with `sync=True`, the event description on Intervals.icu was overwritten with the short planning description (e.g. "Sweet Spot 3x12") instead of the full workout (warmup, main set, cooldown).

## Test plan

- [x] `poetry run pytest tests/ -x` — 1875 passed
- [x] `poetry run pre-commit run --all-files` — all green
- [x] Manual round-trip: skip S083-02 → NOTE `[SAUTÉE]` → restore pending → WORKOUT with full description confirmed on Intervals.icu

🤖 Generated with [Claude Code](https://claude.com/claude-code)