### PR TITLE
feat(health): add Withings pre-sync before daily-sync

### DIFF
--- a/magma_cycling/_mcp/handlers/withings.py
+++ b/magma_cycling/_mcp/handlers/withings.py
@@ -23,6 +23,7 @@ __all__ = [
     "handle_withings_sync_to_intervals",
     "handle_withings_analyze_trends",
     "handle_withings_enrich_session",
+    "sync_withings_to_intervals",
 ]
 
 
@@ -297,121 +298,134 @@ def _put_wellness_defensive(
     return None
 
 
+def sync_withings_to_intervals(
+    start_date: date,
+    end_date: date | None = None,
+    data_types: list[str] | None = None,
+) -> dict:
+    """Synchronize Withings health data to Intervals.icu wellness fields.
+
+    Reusable synchronous function. Fetches data via HealthProvider, transforms,
+    and PUTs to Intervals.icu with defensive 422/429 handling.
+
+    Returns a result dict with synced_dates, errors, and status.
+    """
+    from magma_cycling.config import create_intervals_client
+    from magma_cycling.health import create_health_provider
+
+    provider = create_health_provider()
+    intervals_client = create_intervals_client()
+
+    end_date_val = end_date if end_date is not None else date.today()
+    types = data_types or ["all"]
+
+    sync_sleep = "all" in types or "sleep" in types
+    sync_weight = "all" in types or "weight" in types
+    sync_bp = "all" in types or "blood_pressure" in types
+
+    synced_dates: list[str] = []
+    errors: list[dict] = []
+
+    # Fetch data via provider
+    sleep_data_list = []
+    weight_data_list = []
+    bp_data_list = []
+
+    if sync_sleep:
+        sleep_data_list = [
+            s.model_dump() for s in provider.get_sleep_range(start_date, end_date_val)
+        ]
+
+    if sync_weight:
+        weight_data_list = [
+            m.model_dump() for m in provider.get_body_composition_range(start_date, end_date_val)
+        ]
+
+    if sync_bp:
+        bp_data_list = [
+            bp.model_dump() for bp in provider.get_blood_pressure_range(start_date, end_date_val)
+        ]
+
+    # Create lookup dictionaries
+    sleep_by_date = {str(s["date"]): s for s in sleep_data_list}
+    weight_by_date = {str(w["date"]): w for w in weight_data_list}
+    bp_by_date = {str(bp["date"]): bp for bp in bp_data_list}
+
+    # Iterate through each date and sync
+    current_date = start_date
+    while current_date <= end_date_val:
+        date_str = current_date.isoformat()
+        has_data = False
+
+        try:
+            wellness: dict[str, Any] = {}
+
+            # Update with sleep data
+            if sync_sleep and date_str in sleep_by_date:
+                sleep_info = sleep_by_date[date_str]
+                wellness["sleepSecs"] = int(sleep_info["total_sleep_hours"] * 3600)
+                quality = _sleep_score_to_quality(sleep_info.get("sleep_score"))
+                if quality is not None:
+                    wellness["sleepQuality"] = quality
+                if sleep_info.get("hr_min"):
+                    wellness["restingHR"] = sleep_info["hr_min"]
+                has_data = True
+
+            # Update with weight data
+            if sync_weight and date_str in weight_by_date:
+                weight_info = weight_by_date[date_str]
+                wellness["weight"] = weight_info["weight_kg"]
+                if weight_info.get("muscle_mass_kg"):
+                    wellness["muscleMass"] = weight_info["muscle_mass_kg"]
+                if weight_info.get("bone_mass_kg"):
+                    wellness["boneMass"] = weight_info["bone_mass_kg"]
+                if weight_info.get("body_water_kg"):
+                    wellness["bodyWater"] = weight_info["body_water_kg"]
+                has_data = True
+
+            # Update with blood pressure data
+            if sync_bp and date_str in bp_by_date:
+                bp_info = bp_by_date[date_str]
+                wellness["systolic"] = bp_info["systolic"]
+                wellness["diastolic"] = bp_info["diastolic"]
+                has_data = True
+
+            # Only update if we have data to sync
+            if has_data:
+                diag = _put_wellness_defensive(intervals_client, date_str, wellness)
+                if diag is not None:
+                    errors.append({"date": date_str, **diag})
+                else:
+                    synced_dates.append(date_str)
+
+                # Throttle: avoid saturating Intervals.icu API
+                time.sleep(1)
+
+        except Exception as e:
+            errors.append({"date": date_str, "error": str(e), "payload": wellness})
+
+        current_date = current_date + timedelta(days=1)
+
+    return {
+        "start_date": start_date.isoformat(),
+        "end_date": end_date_val.isoformat(),
+        "data_types": types,
+        "synced_dates": synced_dates,
+        "synced_count": len(synced_dates),
+        "errors": errors,
+        "status": "success" if not errors else "partial_success",
+    }
+
+
 async def handle_withings_sync_to_intervals(args: dict) -> list[TextContent]:
     """Synchronize health data to Intervals.icu wellness via HealthProvider."""
     with suppress_stdout_stderr():
-        from magma_cycling.config import create_intervals_client
-        from magma_cycling.health import create_health_provider
-
-        provider = create_health_provider()
-        intervals_client = create_intervals_client()
-
-        start_date_str = args["start_date"]
+        start_date_val = date.fromisoformat(args["start_date"])
         end_date_str = args.get("end_date")
+        end_date_val = date.fromisoformat(end_date_str) if end_date_str else None
         data_types = args.get("data_types", ["all"])
 
-        start_date_val = date.fromisoformat(start_date_str)
-        end_date_val = date.fromisoformat(end_date_str) if end_date_str else date.today()
-
-        # Determine what to sync
-        sync_sleep = "all" in data_types or "sleep" in data_types
-        sync_weight = "all" in data_types or "weight" in data_types
-        sync_bp = "all" in data_types or "blood_pressure" in data_types
-
-        synced_dates = []
-        errors = []
-
-        # Fetch data via provider
-        sleep_data_list = []
-        weight_data_list = []
-        bp_data_list = []
-
-        if sync_sleep:
-            sleep_data_list = [
-                s.model_dump() for s in provider.get_sleep_range(start_date_val, end_date_val)
-            ]
-
-        if sync_weight:
-            weight_data_list = [
-                m.model_dump()
-                for m in provider.get_body_composition_range(start_date_val, end_date_val)
-            ]
-
-        if sync_bp:
-            bp_data_list = [
-                bp.model_dump()
-                for bp in provider.get_blood_pressure_range(start_date_val, end_date_val)
-            ]
-
-        # Create lookup dictionaries
-        sleep_by_date = {str(s["date"]): s for s in sleep_data_list}
-        weight_by_date = {str(w["date"]): w for w in weight_data_list}
-        bp_by_date = {str(bp["date"]): bp for bp in bp_data_list}
-
-        # Iterate through each date and sync
-        current_date = start_date_val
-        while current_date <= end_date_val:
-            date_str = current_date.isoformat()
-            has_data = False
-
-            try:
-                wellness: dict[str, Any] = {}
-
-                # Update with sleep data
-                if sync_sleep and date_str in sleep_by_date:
-                    sleep_info = sleep_by_date[date_str]
-                    wellness["sleepSecs"] = int(sleep_info["total_sleep_hours"] * 3600)
-                    quality = _sleep_score_to_quality(sleep_info.get("sleep_score"))
-                    if quality is not None:
-                        wellness["sleepQuality"] = quality
-                    if sleep_info.get("hr_min"):
-                        wellness["restingHR"] = sleep_info["hr_min"]
-                    has_data = True
-
-                # Update with weight data
-                if sync_weight and date_str in weight_by_date:
-                    weight_info = weight_by_date[date_str]
-                    wellness["weight"] = weight_info["weight_kg"]
-                    if weight_info.get("muscle_mass_kg"):
-                        wellness["muscleMass"] = weight_info["muscle_mass_kg"]
-                    if weight_info.get("bone_mass_kg"):
-                        wellness["boneMass"] = weight_info["bone_mass_kg"]
-                    if weight_info.get("body_water_kg"):
-                        wellness["bodyWater"] = weight_info["body_water_kg"]
-                    has_data = True
-
-                # Update with blood pressure data
-                if sync_bp and date_str in bp_by_date:
-                    bp_info = bp_by_date[date_str]
-                    wellness["systolic"] = bp_info["systolic"]
-                    wellness["diastolic"] = bp_info["diastolic"]
-                    has_data = True
-
-                # Only update if we have data to sync
-                if has_data:
-                    diag = _put_wellness_defensive(intervals_client, date_str, wellness)
-                    if diag is not None:
-                        errors.append({"date": date_str, **diag})
-                    else:
-                        synced_dates.append(date_str)
-
-                    # Throttle: avoid saturating Intervals.icu API
-                    time.sleep(1)
-
-            except Exception as e:
-                errors.append({"date": date_str, "error": str(e), "payload": wellness})
-
-            current_date = current_date + timedelta(days=1)
-
-        result = {
-            "start_date": start_date_val.isoformat(),
-            "end_date": end_date_val.isoformat(),
-            "data_types": data_types,
-            "synced_dates": synced_dates,
-            "synced_count": len(synced_dates),
-            "errors": errors,
-            "status": "success" if not errors else "partial_success",
-        }
+        result = sync_withings_to_intervals(start_date_val, end_date_val, data_types)
 
     return mcp_response(result)
 

--- a/magma_cycling/scripts/withings_presync.py
+++ b/magma_cycling/scripts/withings_presync.py
@@ -1,0 +1,63 @@
+"""Pre-sync Withings health data to Intervals.icu wellness fields.
+
+Standalone script for LaunchAgent (21h00, 30 min before daily-sync).
+Also called by session_monitor before triggering daily-sync.
+
+Exit 0 in all cases — LaunchAgent should not retry on its own.
+"""
+
+import sys
+from datetime import date, datetime, timedelta
+
+PREFIX = "[withings-presync]"
+
+
+def log(msg: str) -> None:
+    """Print a timestamped log line."""
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+    print(f"{PREFIX} {ts} - {msg}")
+
+
+def main() -> int:
+    """Entry point."""
+    try:
+        from magma_cycling.config import get_withings_config
+
+        config = get_withings_config()
+        if not config.is_configured() or not config.has_valid_credentials():
+            log("Withings not configured or no credentials, skip")
+            return 0
+    except Exception as e:
+        log(f"Config check failed: {e}, skip")
+        return 0
+
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+
+    log(f"Syncing {yesterday} → {today} (sleep, weight)")
+
+    try:
+        from magma_cycling._mcp.handlers.withings import sync_withings_to_intervals
+
+        result = sync_withings_to_intervals(
+            start_date=yesterday,
+            end_date=today,
+            data_types=["sleep", "weight"],
+        )
+
+        synced = result.get("synced_count", 0)
+        errors = result.get("errors", [])
+        log(f"Done: {synced} date(s) synced, {len(errors)} error(s)")
+
+        if errors:
+            for err in errors:
+                log(f"  error: {err}")
+
+    except Exception as e:
+        log(f"Sync failed: {e}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/magma_cycling/session_monitor.py
+++ b/magma_cycling/session_monitor.py
@@ -158,6 +158,9 @@ def main() -> int:
     activity_id = new_activity.get("id", "?")
     log(f"Activity {activity_id} detected ({len(cycling)} activities, {completed_count} completed)")
 
+    # Step 6: Pre-sync Withings → Intervals.icu
+    run_command("withings-presync", [POETRY, "run", "withings-presync"])
+
     # Step 7a: Trigger daily-sync
     try:
         run_command(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ session-monitor = "magma_cycling.session_monitor:main"
 check-workout-adherence = "scripts.monitoring.check_workout_adherence:main"
 pid-daily-evaluation = "magma_cycling.scripts.pid_daily_evaluation:main"
 
+# === Health ===
+withings-presync = "magma_cycling.scripts.withings_presync:main"
+
 # === Analysis ===
 analyze-baseline = "magma_cycling.analysis.baseline_preliminary:main"
 


### PR DESCRIPTION
## Summary
- Extract `sync_withings_to_intervals()` as reusable synchronous function from MCP handler (no code duplication)
- Add `withings-presync` standalone script + entry point for LaunchAgent and CLI usage
- Add LaunchAgent `com.cyclisme.health.08-withings-presync-21h` (21h00, 30 min before daily-sync 21h30)
- Integrate pre-sync step in `session_monitor.py` before daily-sync trigger

## Motivation
The daily-sync (21h30) fetches wellness data from Intervals.icu, but that data must be pushed from Withings first. Previously this was manual (MCP `withings-sync-to-intervals`). Now automated:
- **LaunchAgent**: runs at 21h00 daily (safety net for rest days)
- **Session monitor**: runs before daily-sync when activity detected (covers early sessions)

## Test plan
- [x] `poetry run withings-presync` — 2 dates synced, 0 errors
- [x] `pytest tests/ -x` — 1879 passed
- [x] `pre-commit run --all-files` — all passed
- [x] `launchctl load` — LaunchAgent loaded OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)