### PR TITLE
refactor(utils): centralize Intervals.icu Feel scale labels

### DIFF
--- a/magma_cycling/utils/intervals_scales.py
+++ b/magma_cycling/utils/intervals_scales.py
@@ -1,0 +1,41 @@
+"""Intervals.icu scale constants and formatters."""
+
+FEEL_LABELS: dict[int, str] = {
+    1: "Excellent",
+    2: "Bien",
+    3: "Moyen",
+    4: "Passable",
+    5: "Mauvais",
+}
+
+FEEL_EMOJIS: dict[int, str] = {
+    1: "\U0001f60a",
+    2: "\U0001f642",
+    3: "\U0001f610",
+    4: "\U0001f615",
+    5: "\U0001f623",
+}
+
+
+def format_feel(value: int | None, with_emoji: bool = False) -> str:
+    """Format Feel value (1-5 Intervals.icu scale).
+
+    Args:
+        value: Feel value 1-5 or None (1=Excellent, 5=Poor).
+        with_emoji: If True, prepend emoji and append (N/5).
+
+    Returns:
+        Formatted label string.
+    """
+    if value is None:
+        return "_Non renseigné_"
+
+    label = FEEL_LABELS.get(value)
+    if label is None:
+        return f"_Valeur inconnue: {value}_"
+
+    if with_emoji:
+        emoji = FEEL_EMOJIS.get(value, "")
+        return f"{emoji} {label} ({value}/5)"
+
+    return label

--- a/magma_cycling/workflows/prompt/metric_helpers.py
+++ b/magma_cycling/workflows/prompt/metric_helpers.py
@@ -1,5 +1,7 @@
 """Metric extraction and formatting helpers for PromptGenerator."""
 
+from magma_cycling.utils.intervals_scales import format_feel
+
 
 class MetricHelpersMixin:
     """Unit-level metric extraction and formatting."""
@@ -13,18 +15,7 @@ class MetricHelpersMixin:
         Returns:
             Formatted string with emoji
         """
-        if feel_value is None:
-            return "_Non renseigné_"
-
-        feel_map = {
-            1: "😊 Excellent (1/5)",
-            2: "🙂 Bien (2/5)",
-            3: "😐 Moyen (3/5)",
-            4: "😕 Passable (4/5)",
-            5: "😣 Mauvais (5/5)",
-        }
-
-        return feel_map.get(feel_value, f"_Valeur inconnue: {feel_value}_")
+        return format_feel(feel_value, with_emoji=True)
 
     def _format_athlete_notes(self, activity_description, wellness_comments):
         """Format athlete notes with wellness comments as fallback.

--- a/magma_cycling/workflows/sync/servo_evaluation.py
+++ b/magma_cycling/workflows/sync/servo_evaluation.py
@@ -2,6 +2,7 @@
 
 from magma_cycling.planning.session_formatter import format_remaining_sessions_compact
 from magma_cycling.utils.ai_response_parser import parse_ai_modifications
+from magma_cycling.utils.intervals_scales import format_feel
 
 
 class ServoEvaluationMixin:
@@ -164,14 +165,7 @@ class ServoEvaluationMixin:
         # Criterion 3: Feel (subjective) - Intervals.icu 1-5 scale
         if metrics.get("feel") is not None:
             if metrics["feel"] >= self.servo_criteria["feel_threshold"]:
-                feel_labels = {
-                    1: "Excellent",
-                    2: "Bien",
-                    3: "Moyen",
-                    4: "Passable",
-                    5: "Mauvais",
-                }
-                feel_label = feel_labels.get(metrics["feel"], "Unknown")
+                feel_label = format_feel(metrics["feel"])
                 reasons.append(f"Ressenti négatif ({feel_label} - {metrics['feel']}/5)")
 
         # Criterion 4: TSB

--- a/tests/utils/test_intervals_scales.py
+++ b/tests/utils/test_intervals_scales.py
@@ -1,0 +1,64 @@
+"""Tests for intervals_scales utility module."""
+
+import pytest
+
+from magma_cycling.utils.intervals_scales import FEEL_EMOJIS, FEEL_LABELS, format_feel
+
+
+class TestFeelLabels:
+    """Tests for FEEL_LABELS and FEEL_EMOJIS constants."""
+
+    def test_labels_cover_1_to_5(self):
+        assert set(FEEL_LABELS.keys()) == {1, 2, 3, 4, 5}
+
+    def test_emojis_cover_1_to_5(self):
+        assert set(FEEL_EMOJIS.keys()) == {1, 2, 3, 4, 5}
+
+
+class TestFormatFeel:
+    """Tests for format_feel function."""
+
+    def test_none_returns_non_renseigne(self):
+        assert format_feel(None) == "_Non renseigné_"
+
+    def test_none_with_emoji_returns_non_renseigne(self):
+        assert format_feel(None, with_emoji=True) == "_Non renseigné_"
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (1, "Excellent"),
+            (2, "Bien"),
+            (3, "Moyen"),
+            (4, "Passable"),
+            (5, "Mauvais"),
+        ],
+    )
+    def test_plain_labels(self, value, expected):
+        assert format_feel(value) == expected
+
+    @pytest.mark.parametrize(
+        "value,expected_label",
+        [
+            (1, "Excellent"),
+            (2, "Bien"),
+            (3, "Moyen"),
+            (4, "Passable"),
+            (5, "Mauvais"),
+        ],
+    )
+    def test_with_emoji_contains_label_and_fraction(self, value, expected_label):
+        result = format_feel(value, with_emoji=True)
+        assert expected_label in result
+        assert f"({value}/5)" in result
+
+    def test_with_emoji_starts_with_emoji(self):
+        result = format_feel(1, with_emoji=True)
+        # Should start with emoji character, not a letter
+        assert not result[0].isalpha()
+
+    def test_unknown_value_returns_valeur_inconnue(self):
+        assert format_feel(99) == "_Valeur inconnue: 99_"
+
+    def test_zero_returns_valeur_inconnue(self):
+        assert format_feel(0) == "_Valeur inconnue: 0_"


### PR DESCRIPTION
## Summary

- Extract duplicated Feel 1-5 scale mapping into shared `utils/intervals_scales.py` module
- `metric_helpers.py::_format_feel_value()` now delegates to `format_feel(value, with_emoji=True)`
- `servo_evaluation.py::should_trigger_servo()` replaces inline `feel_labels` dict with `format_feel()`
- 17 new tests covering all format_feel cases (None, 1-5, emoji, unknown values)

## Test plan

- [x] `poetry run pytest tests/utils/test_intervals_scales.py -v` — 17/17 passed
- [x] `poetry run pytest tests/test_prepare_analysis.py tests/test_daily_sync.py -v` — 209 passed (no regressions)
- [x] `poetry run pre-commit run --all-files` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)