### PR TITLE
refactor(sync): extract shared event sync decision logic

### DIFF
--- a/magma_cycling/_mcp/_utils.py
+++ b/magma_cycling/_mcp/_utils.py
@@ -8,6 +8,8 @@ from io import StringIO
 
 from mcp.types import TextContent
 
+from magma_cycling.utils.event_sync import compute_start_time  # noqa: F401 — re-export
+
 
 @contextmanager
 def suppress_stdout_stderr():
@@ -26,29 +28,6 @@ def suppress_stdout_stderr():
 # Statuses that should be synced to Intervals.icu.
 # Any other status (completed, skipped, cancelled, rest_day, replaced) is protected.
 SYNCABLE_STATUSES = {"pending", "planned", "uploaded", "modified"}
-
-
-def compute_start_time(session_date, session_id: str) -> str:
-    """Compute start time for an Intervals.icu event.
-
-    Args:
-        session_date: Date of the session (date object with .weekday()).
-        session_id: Session ID (e.g., "S081-04", "S081-06a", "S081-06b").
-
-    Returns:
-        Time string like "09:00:00" or "17:00:00".
-    """
-    day_of_week = session_date.weekday()  # 0=Monday, 5=Saturday
-    session_day_part = session_id.split("-")[-1]  # e.g., "04" or "06a"
-    session_suffix = session_day_part[-1] if session_day_part[-1].isalpha() else None
-
-    if session_suffix == "a":
-        return "09:00:00"  # Morning
-    elif session_suffix == "b":
-        return "15:00:00"  # Afternoon
-    else:
-        # Saturday → 09:00, other days → 17:00
-        return "09:00:00" if day_of_week == 5 else "17:00:00"
 
 
 def load_workout_descriptions(week_id: str) -> dict[str, str]:

--- a/magma_cycling/_mcp/handlers/intervals.py
+++ b/magma_cycling/_mcp/handlers/intervals.py
@@ -13,6 +13,7 @@ from magma_cycling._mcp._utils import (
     mcp_response,
     suppress_stdout_stderr,
 )
+from magma_cycling.utils.event_sync import evaluate_sync
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
@@ -128,68 +129,65 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
                         )
                         continue
 
-                if session.intervals_id:
-                    # Check if event exists remotely
-                    if session.intervals_id in remote_workouts:
-                        # Event exists - check for conflicts
-                        remote_event = remote_workouts[session.intervals_id]
+                # Find existing remote event (if any)
+                existing_event = None
+                if session.intervals_id and session.intervals_id in remote_workouts:
+                    existing_event = remote_workouts[session.intervals_id]
 
-                        # VALIDATION: Detect if remote was manually modified
-                        remote_name = remote_event.get("name", "")
-                        remote_start = remote_event.get("start_date_local", "")
-                        local_start = f"{session.session_date}T{start_time}"
+                decision = evaluate_sync(event_data, existing_event, force_update=force_update)
 
-                        has_remote_changes = (
-                            remote_name != intervals_name or remote_start != local_start
-                        )
+                if decision.action == "skip":
+                    to_skip_protected.append(
+                        {
+                            "session_id": session.session_id,
+                            "name": session.name,
+                            "status": "remote_protected",
+                            "reason": decision.reason,
+                        }
+                    )
+                    continue
 
-                        if has_remote_changes and not force_update:
-                            warnings.append(
-                                {
-                                    "session_id": session.session_id,
-                                    "intervals_id": session.intervals_id,
-                                    "type": "remote_modification_detected",
-                                    "message": f"⚠️ Remote event {session.intervals_id} has been manually modified in Intervals.icu",
-                                    "local_name": intervals_name,
-                                    "remote_name": remote_name,
-                                    "suggestion": "Use force_update=true to overwrite remote changes",
-                                }
-                            )
-                            continue
-
-                        # Check if update needed
-                        needs_update = force_update or has_remote_changes
-
-                        if needs_update:
-                            update_data = {
-                                "name": intervals_name,
-                                "description": full_description,
-                                "start_date_local": f"{session.session_date}T{start_time}",
-                            }
-                            to_update.append(
-                                {
-                                    "session_id": session.session_id,
-                                    "intervals_id": session.intervals_id,
-                                    "name": session.name,
-                                    "event_data": update_data,
-                                }
-                            )
-                    else:
-                        # intervals_id set but event doesn't exist remotely
-                        to_create.append(
+                # Post-check: warn if remote was manually modified (MCP-specific)
+                if decision.action == "update" and existing_event and not force_update:
+                    remote_name = existing_event.get("name", "")
+                    remote_start = existing_event.get("start_date_local", "")
+                    if (
+                        remote_name != intervals_name
+                        or remote_start != event_data["start_date_local"]
+                    ):
+                        warnings.append(
                             {
                                 "session_id": session.session_id,
-                                "name": session.name,
-                                "event_data": event_data,
+                                "intervals_id": session.intervals_id,
+                                "type": "remote_modification_detected",
+                                "message": f"⚠️ Remote event {session.intervals_id} has been manually modified in Intervals.icu",
+                                "local_name": intervals_name,
+                                "remote_name": remote_name,
+                                "suggestion": "Use force_update=true to overwrite remote changes",
                             }
                         )
-                else:
-                    # No intervals_id - create new event
+                        continue
+
+                if decision.action == "create":
                     to_create.append(
                         {
                             "session_id": session.session_id,
                             "name": session.name,
                             "event_data": event_data,
+                        }
+                    )
+                elif decision.action == "update":
+                    update_data = {
+                        "name": intervals_name,
+                        "description": full_description,
+                        "start_date_local": f"{session.session_date}T{start_time}",
+                    }
+                    to_update.append(
+                        {
+                            "session_id": session.session_id,
+                            "intervals_id": decision.existing_event_id,
+                            "name": session.name,
+                            "event_data": update_data,
                         }
                     )
 

--- a/magma_cycling/upload_workouts.py
+++ b/magma_cycling/upload_workouts.py
@@ -59,11 +59,11 @@ Metadata:
     Version: v2
 """
 import argparse
-import hashlib
 import sys
 from datetime import datetime
 from pathlib import Path
 
+from magma_cycling.utils.event_sync import calculate_description_hash  # noqa: F401 — re-export
 from magma_cycling.workflows.uploader.parsing import ParsingMixin
 from magma_cycling.workflows.uploader.upload import UploadMixin
 from magma_cycling.workflows.uploader.validation import ValidationMixin
@@ -104,19 +104,6 @@ def calculate_week_start_date(week_id: str) -> datetime:
         raise ValueError(f"Calculated date {target_monday} is not a Monday")
 
     return target_monday
-
-
-def calculate_description_hash(description: str) -> str:
-    """
-    Calculate SHA256 hash of workout description for change detection.
-
-    Args:
-        description: Workout description text
-
-    Returns:
-        16-character hex hash of description (first 16 chars of SHA256)
-    """
-    return hashlib.sha256(description.encode("utf-8")).hexdigest()[:16]
 
 
 class WorkoutUploader(

--- a/magma_cycling/utils/event_sync.py
+++ b/magma_cycling/utils/event_sync.py
@@ -1,0 +1,105 @@
+"""Shared event sync decision logic for Intervals.icu."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import date
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class SyncDecision:
+    """Result of evaluate_sync: action to take and reason."""
+
+    action: Literal["create", "update", "skip"]
+    reason: str
+    existing_event_id: str | None = None
+
+
+def calculate_description_hash(description: str) -> str:
+    """Calculate SHA256 hash of workout description for change detection.
+
+    Args:
+        description: Workout description text.
+
+    Returns:
+        16-character hex hash (first 16 chars of SHA256).
+    """
+    return hashlib.sha256(description.encode("utf-8")).hexdigest()[:16]
+
+
+def compute_start_time(session_date: date, session_id: str) -> str:
+    """Compute start time for an Intervals.icu event.
+
+    Args:
+        session_date: Date of the session (date object with .weekday()).
+        session_id: Session ID (e.g., "S081-04", "S081-06a", "S081-06b").
+
+    Returns:
+        Time string like "09:00:00" or "17:00:00".
+    """
+    day_of_week = session_date.weekday()  # 0=Monday, 5=Saturday
+    session_day_part = session_id.split("-")[-1]  # e.g., "04" or "06a"
+    session_suffix = session_day_part[-1] if session_day_part[-1].isalpha() else None
+
+    if session_suffix == "a":
+        return "09:00:00"  # Morning
+    elif session_suffix == "b":
+        return "15:00:00"  # Afternoon
+    else:
+        # Saturday → 09:00, other days → 17:00
+        return "09:00:00" if day_of_week == 5 else "17:00:00"
+
+
+def evaluate_sync(
+    event_data: dict,
+    existing_event: dict | None,
+    force_update: bool = False,
+) -> SyncDecision:
+    """Decide whether to create, update, or skip an event sync.
+
+    Decision logic:
+        1. No existing event → create
+        2. paired_activity_id present → skip (protected, already executed)
+        3. force_update → update
+        4. Hash identical + name/start identical → skip
+        5. Otherwise → update
+
+    Args:
+        event_data: Local event data to sync (must have name, description,
+            start_date_local keys).
+        existing_event: Remote event dict from Intervals.icu, or None.
+        force_update: If True, force update even if content matches.
+
+    Returns:
+        SyncDecision with action, reason, and optional existing_event_id.
+    """
+    if existing_event is None:
+        return SyncDecision(action="create", reason="no existing event")
+
+    event_id = existing_event.get("id")
+
+    # Protection: never overwrite a completed workout
+    if existing_event.get("paired_activity_id"):
+        return SyncDecision(
+            action="skip",
+            reason=f"protected (paired_activity_id: {existing_event['paired_activity_id']})",
+            existing_event_id=event_id,
+        )
+
+    if force_update:
+        return SyncDecision(action="update", reason="force_update", existing_event_id=event_id)
+
+    # Compare content hash
+    new_hash = calculate_description_hash(event_data.get("description", ""))
+    existing_hash = calculate_description_hash(existing_event.get("description", ""))
+
+    # Compare name and start_date_local
+    name_match = event_data.get("name") == existing_event.get("name")
+    start_match = event_data.get("start_date_local") == existing_event.get("start_date_local")
+
+    if new_hash == existing_hash and name_match and start_match:
+        return SyncDecision(action="skip", reason="identical content", existing_event_id=event_id)
+
+    return SyncDecision(action="update", reason="content changed", existing_event_id=event_id)

--- a/magma_cycling/workflows/uploader/upload.py
+++ b/magma_cycling/workflows/uploader/upload.py
@@ -1,12 +1,45 @@
 """Upload mixin for WorkoutUploader."""
 
-import hashlib
 from datetime import datetime, timedelta
 
+from magma_cycling.utils.event_sync import (
+    calculate_description_hash,
+    compute_start_time,
+    evaluate_sync,
+)
 
-def _calculate_description_hash(description: str) -> str:
-    """Calculate SHA256 hash of workout description for change detection."""
-    return hashlib.sha256(description.encode("utf-8")).hexdigest()[:16]
+
+def _find_matching_event(
+    existing_events: list[dict], workout_name: str, suffix: str
+) -> dict | None:
+    """Find an existing WORKOUT event matching the given workout.
+
+    For double sessions (suffix a/b), match by exact name.
+    For single sessions, match by session_id prefix (SXXX-NN).
+
+    Args:
+        existing_events: List of remote events for the date.
+        workout_name: Local workout name.
+        suffix: Session suffix ("a", "b", or "").
+
+    Returns:
+        Matching remote event dict, or None.
+    """
+    session_id = "-".join(workout_name.split("-")[:2])
+
+    for event in existing_events:
+        if event.get("category") != "WORKOUT":
+            continue
+        event_name = event.get("name", "")
+        if suffix:
+            if event_name == workout_name:
+                return event
+        else:
+            event_session_id = "-".join(event_name.split("-")[:2])
+            if event_session_id == session_id:
+                return event
+
+    return None
 
 
 class UploadMixin:
@@ -15,19 +48,17 @@ class UploadMixin:
     def upload_workout(self, workout: dict) -> bool:
         """Upload un workout sur Intervals.icu with duplicate detection."""
         try:
-            # Déterminer l'heure de début selon le jour de la semaine et le suffixe
+            # Build session_id for compute_start_time
             workout_date = datetime.strptime(workout["date"], "%Y-%m-%d")
-            day_of_week = workout_date.weekday()  # 0=Lundi, 5=Samedi, 6=Dimanche
+            workout_name = workout["name"]
+            session_id = "-".join(workout_name.split("-")[:2])
             suffix = workout.get("suffix", "")
-
-            # Gestion double séance (a/b)
-            if suffix == "a":
-                start_time = "09:00:00"  # Matin
-            elif suffix == "b":
-                start_time = "15:00:00"  # Après-midi
+            if suffix:
+                session_id_full = f"{session_id}{suffix}"
             else:
-                # Samedi (5) → 09:00, autres jours → 17:00
-                start_time = "09:00:00" if day_of_week == 5 else "17:00:00"
+                session_id_full = session_id
+
+            start_time = compute_start_time(workout_date, session_id_full)
 
             if self.api is None:
                 print("  ❌ Erreur : API non initialisée")
@@ -35,28 +66,7 @@ class UploadMixin:
 
             # Check for existing workout on this date (duplicate detection)
             existing_events = self.api.get_events(oldest=workout["date"], newest=workout["date"])
-
-            # Look for existing WORKOUT on same date
-            # Pour doubles séances (a/b), matcher le nom exact
-            # Pour séances simples, matcher le préfixe semaine+jour (ex: S081-05)
-            workout_name = workout["name"]
-            session_id = "-".join(workout_name.split("-")[:2])  # Ex: S081-06a → S081-06a
-
-            existing_workout = None
-            for event in existing_events:
-                if event.get("category") == "WORKOUT":
-                    event_name = event.get("name", "")
-                    # Matcher le nom exact pour les doubles séances
-                    if suffix:
-                        if event_name == workout_name:
-                            existing_workout = event
-                            break
-                    else:
-                        # Pour séances simples, matcher le session_id (SXXX-NN)
-                        event_session_id = "-".join(event_name.split("-")[:2])
-                        if event_session_id == session_id:
-                            existing_workout = event
-                            break
+            existing_workout = _find_matching_event(existing_events, workout_name, suffix)
 
             event_data = {
                 "category": "WORKOUT",
@@ -66,53 +76,44 @@ class UploadMixin:
                 "start_date_local": f"{workout['date']}T{start_time}",
             }
 
-            # Calculate hash for comparison
-            new_hash = _calculate_description_hash(workout["description"])
+            decision = evaluate_sync(event_data, existing_workout)
+            new_hash = calculate_description_hash(workout["description"])
 
-            if existing_workout:
-                # PROTECTION: Ne jamais écraser un workout déjà réalisé
-                if existing_workout.get("paired_activity_id"):
-                    activity_id = existing_workout.get("paired_activity_id")
-                    print(
-                        f"  🔒 Protégé (réalisé) : {workout['name']} ({workout['date']}) [Activity: {activity_id}]"
-                    )
-                    workout["description_hash"] = _calculate_description_hash(
-                        existing_workout.get("description", "")
-                    )
-                    workout["intervals_id"] = existing_workout.get("id")
-                    return True
-
-                existing_hash = _calculate_description_hash(existing_workout.get("description", ""))
-
-                if existing_hash == new_hash:
-                    # Identical content - skip
-                    print(f"  ⏭️  Ignoré (identique) : {workout['name']} ({workout['date']})")
-                    workout["description_hash"] = new_hash
-                    workout["intervals_id"] = existing_workout.get("id")
-                    return True
-                else:
-                    # Different content - update
-                    response = self.api.update_event(existing_workout.get("id"), event_data)
-                    if response:
-                        workout["description_hash"] = new_hash
-                        workout["intervals_id"] = response.get("id")
-                        print(f"  🔄 Mis à jour : {workout['name']} ({workout['date']})")
-                        return True
-                    else:
-                        print(f"  ❌ Échec mise à jour : {workout['name']}")
-                        return False
-            else:
-                # No existing workout - create new
+            if decision.action == "create":
                 response = self.api.create_event(event_data)
-
                 if response:
-                    # Store hash and event_id for sync tracking
                     workout["description_hash"] = new_hash
                     workout["intervals_id"] = response.get("id")
                     print(f"  ✅ Créé : {workout['name']} ({workout['date']})")
                     return True
                 else:
                     print(f"  ❌ Échec création : {workout['name']}")
+                    return False
+
+            elif decision.action == "skip":
+                if "protected" in decision.reason:
+                    activity_id = existing_workout.get("paired_activity_id")
+                    print(
+                        f"  🔒 Protégé (réalisé) : {workout['name']} ({workout['date']}) [Activity: {activity_id}]"
+                    )
+                    workout["description_hash"] = calculate_description_hash(
+                        existing_workout.get("description", "")
+                    )
+                else:
+                    print(f"  ⏭️  Ignoré (identique) : {workout['name']} ({workout['date']})")
+                    workout["description_hash"] = new_hash
+                workout["intervals_id"] = decision.existing_event_id
+                return True
+
+            else:  # update
+                response = self.api.update_event(decision.existing_event_id, event_data)
+                if response:
+                    workout["description_hash"] = new_hash
+                    workout["intervals_id"] = response.get("id")
+                    print(f"  🔄 Mis à jour : {workout['name']} ({workout['date']})")
+                    return True
+                else:
+                    print(f"  ❌ Échec mise à jour : {workout['name']}")
                     return False
 
         except Exception as e:

--- a/tests/test_mcp_extra_handlers.py
+++ b/tests/test_mcp_extra_handlers.py
@@ -237,12 +237,13 @@ class TestHandleSyncWeekToIntervals:
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
         mock_client = Mock()
-        # Remote event with full intervals_name and matching start_date (no conflict)
+        # Remote event with full intervals_name, matching start_date and description (no conflict)
         mock_client.get_events.return_value = [
             {
                 "id": "evt123",
                 "category": "WORKOUT",
                 "name": "S081-03-INT-TempoCourt-V001",
+                "description": "Tempo 3x10min",
                 "start_date_local": "2026-02-19T17:00:00",
             },
         ]

--- a/tests/utils/test_event_sync.py
+++ b/tests/utils/test_event_sync.py
@@ -1,0 +1,168 @@
+"""Tests for event_sync utility module."""
+
+from datetime import date
+
+import pytest
+
+from magma_cycling.utils.event_sync import (
+    SyncDecision,
+    calculate_description_hash,
+    compute_start_time,
+    evaluate_sync,
+)
+
+
+class TestCalculateDescriptionHash:
+    """Tests for calculate_description_hash."""
+
+    def test_returns_16_char_hex(self):
+        h = calculate_description_hash("some workout description")
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_same_input_same_hash(self):
+        assert calculate_description_hash("abc") == calculate_description_hash("abc")
+
+    def test_different_input_different_hash(self):
+        assert calculate_description_hash("abc") != calculate_description_hash("xyz")
+
+    def test_empty_string(self):
+        h = calculate_description_hash("")
+        assert len(h) == 16
+
+
+class TestComputeStartTime:
+    """Tests for compute_start_time."""
+
+    def test_weekday_single_session(self):
+        # Wednesday (weekday=2) → 17:00
+        assert compute_start_time(date(2026, 3, 4), "S083-03") == "17:00:00"
+
+    def test_saturday_single_session(self):
+        # Saturday (weekday=5) → 09:00
+        assert compute_start_time(date(2026, 3, 7), "S083-06") == "09:00:00"
+
+    def test_double_session_morning(self):
+        # Suffix "a" → 09:00 regardless of day
+        assert compute_start_time(date(2026, 3, 4), "S083-03a") == "09:00:00"
+
+    def test_double_session_afternoon(self):
+        # Suffix "b" → 15:00 regardless of day
+        assert compute_start_time(date(2026, 3, 4), "S083-03b") == "15:00:00"
+
+    def test_sunday(self):
+        # Sunday (weekday=6) → 17:00
+        assert compute_start_time(date(2026, 3, 8), "S083-07") == "17:00:00"
+
+    def test_monday(self):
+        # Monday (weekday=0) → 17:00
+        assert compute_start_time(date(2026, 3, 2), "S083-01") == "17:00:00"
+
+
+class TestEvaluateSync:
+    """Tests for evaluate_sync."""
+
+    def _make_event_data(self, name="S083-03-INT-Test-V001", desc="workout content"):
+        return {
+            "category": "WORKOUT",
+            "type": "VirtualRide",
+            "name": name,
+            "description": desc,
+            "start_date_local": "2026-03-04T17:00:00",
+        }
+
+    def test_create_when_no_existing(self):
+        decision = evaluate_sync(self._make_event_data(), None)
+        assert decision.action == "create"
+        assert decision.existing_event_id is None
+
+    def test_skip_when_paired_activity_id(self):
+        existing = {
+            "id": "evt-123",
+            "paired_activity_id": "act-456",
+            "name": "S083-03-INT-Test-V001",
+            "description": "old content",
+            "start_date_local": "2026-03-04T17:00:00",
+        }
+        decision = evaluate_sync(self._make_event_data(), existing)
+        assert decision.action == "skip"
+        assert "protected" in decision.reason
+        assert "act-456" in decision.reason
+        assert decision.existing_event_id == "evt-123"
+
+    def test_skip_when_paired_activity_id_even_with_force(self):
+        existing = {
+            "id": "evt-123",
+            "paired_activity_id": "act-456",
+            "name": "old-name",
+            "description": "old content",
+            "start_date_local": "2026-03-04T17:00:00",
+        }
+        decision = evaluate_sync(self._make_event_data(), existing, force_update=True)
+        assert decision.action == "skip"
+        assert "protected" in decision.reason
+
+    def test_skip_when_identical_content(self):
+        event_data = self._make_event_data()
+        existing = {
+            "id": "evt-123",
+            "name": event_data["name"],
+            "description": event_data["description"],
+            "start_date_local": event_data["start_date_local"],
+        }
+        decision = evaluate_sync(event_data, existing)
+        assert decision.action == "skip"
+        assert "identical" in decision.reason
+
+    def test_update_when_description_changed(self):
+        event_data = self._make_event_data(desc="new workout content")
+        existing = {
+            "id": "evt-123",
+            "name": event_data["name"],
+            "description": "old workout content",
+            "start_date_local": event_data["start_date_local"],
+        }
+        decision = evaluate_sync(event_data, existing)
+        assert decision.action == "update"
+        assert "content changed" in decision.reason
+        assert decision.existing_event_id == "evt-123"
+
+    def test_update_when_name_changed(self):
+        event_data = self._make_event_data()
+        existing = {
+            "id": "evt-123",
+            "name": "S083-03-INT-OldName-V001",
+            "description": event_data["description"],
+            "start_date_local": event_data["start_date_local"],
+        }
+        decision = evaluate_sync(event_data, existing)
+        assert decision.action == "update"
+        assert "content changed" in decision.reason
+
+    def test_update_when_start_time_changed(self):
+        event_data = self._make_event_data()
+        existing = {
+            "id": "evt-123",
+            "name": event_data["name"],
+            "description": event_data["description"],
+            "start_date_local": "2026-03-04T09:00:00",
+        }
+        decision = evaluate_sync(event_data, existing)
+        assert decision.action == "update"
+
+    def test_force_update_overrides_identical(self):
+        event_data = self._make_event_data()
+        existing = {
+            "id": "evt-123",
+            "name": event_data["name"],
+            "description": event_data["description"],
+            "start_date_local": event_data["start_date_local"],
+        }
+        decision = evaluate_sync(event_data, existing, force_update=True)
+        assert decision.action == "update"
+        assert "force_update" in decision.reason
+
+    def test_sync_decision_is_frozen(self):
+        decision = SyncDecision(action="create", reason="test")
+        with pytest.raises(AttributeError):
+            decision.action = "update"


### PR DESCRIPTION
## Summary

- Extract duplicated sync decision logic into shared `utils/event_sync.py` module:
  - `SyncDecision` frozen dataclass for create/update/skip decisions
  - `evaluate_sync()` with paired_activity_id protection + content hash comparison
  - `compute_start_time()` canonical definition (previously in `_mcp/_utils.py`)
  - `calculate_description_hash()` canonical definition (previously in `upload_workouts.py`)
- MCP handler `handle_sync_week_to_intervals()` now gains:
  - **paired_activity_id protection** (was missing — bug fix)
  - **Content hash comparison** (was only comparing name/start_time)
- `UploadMixin.upload_workout()` refactored to use shared `evaluate_sync()`
- `_find_matching_event()` extracted as standalone function
- Re-exports in `_mcp/_utils.py` and `upload_workouts.py` preserve backward compatibility

## Test plan

- [x] `poetry run pytest tests/utils/test_event_sync.py -v` — 19/19 passed
- [x] `poetry run pytest tests/test_mcp_extra_handlers.py -v` — 10/10 passed (mock updated for hash comparison)
- [x] `poetry run pytest tests/ -x` — 1915 passed, 0 failed
- [x] `poetry run pre-commit run --all-files` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)