### PR TITLE
docs: add tools.rst for all 38 CLI entry points

### DIFF
--- a/docs/modules/tools.rst
+++ b/docs/modules/tools.rst
@@ -1,0 +1,216 @@
+CLI Tools Reference
+===================
+
+This page provides auto-generated API documentation for all CLI entry points
+defined in ``pyproject.toml`` under ``[tool.poetry.scripts]``.
+
+MCP & Dashboard
+---------------
+
+.. automodule:: magma_cycling.mcp_server
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.dashboard
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Main Workflows
+--------------
+
+.. automodule:: magma_cycling.workflows.workflow_weekly
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.monthly_analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.upload_workouts
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.prepare_analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Automation & Coaching
+---------------------
+
+.. automodule:: magma_cycling.collect_athlete_feedback
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.workflow_coach
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.workflows.end_of_week
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.daily_sync
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.insert_analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+State & Session Management
+--------------------------
+
+.. automodule:: magma_cycling.manage_workflow_state
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.sync_intervals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.planned_sessions_checker
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.update_session_status
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.shift_sessions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Reports & Planning
+------------------
+
+.. automodule:: magma_cycling.organize_weekly_report
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.weekly_planner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.reports.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.session_monitor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.scripts.pid_daily_evaluation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+External Data & Health
+----------------------
+
+.. automodule:: magma_cycling.scripts.withings_presync
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.analysis.baseline_preliminary
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Debug & Maintenance Tools
+-------------------------
+
+.. automodule:: magma_cycling.scripts.backfill_history
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.scripts.validate_templates
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.scripts.backfill_intelligence
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.scripts.search_zwift_workouts
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.scripts.populate_zwift_cache
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.scripts.seed_zwift_workouts
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.check_activity_sources
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.validate_naming_convention
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: magma_cycling.normalize_weekly_reports_casing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scripts.monitoring.check_workout_adherence
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scripts.maintenance.cleanup_old_archives
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scripts.maintenance.project_cleaner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scripts.maintenance.clear_week_planning
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scripts.maintenance.check_tools_documentation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: scripts.maintenance.format_planning
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
## Summary

- Create `docs/modules/tools.rst` with Sphinx `automodule` directives for all 38 CLI tools
- Satisfies the `check-tools-docs` pre-commit hook (0/38 → 38/38 documented)
- Organized by category: MCP & Dashboard, Main Workflows, Automation & Coaching, State Management, Reports & Planning, External Data, Debug & Maintenance

## Test plan

- [x] `poetry run check-tools-docs --verbose` → all 23 production + 15 debug tools documented
- [x] Pre-commit hooks all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)