### PR TITLE
fix(mcp): add workouts.txt fallback to get-workout handler

### DIFF
--- a/magma_cycling/_mcp/handlers/workouts.py
+++ b/magma_cycling/_mcp/handlers/workouts.py
@@ -33,8 +33,9 @@ async def handle_get_workout(args: dict) -> list[TextContent]:
             workout_files = list(workouts_dir.glob(f"{session_id}-*"))
 
             if not workout_files:
-                # No .zwo file — fall back to session description from planning
+                # No .zwo file — fall back to planning + workouts.txt
                 from magma_cycling.planning.control_tower import planning_tower
+                from magma_cycling.workout_parser import load_workout_descriptions
 
                 week_id = session_id[:4]  # "S082-02" → "S082"
                 session_def = None
@@ -47,12 +48,24 @@ async def handle_get_workout(args: dict) -> list[TextContent]:
                 except Exception:
                     pass
 
+                # Load full workout description from {week_id}_workouts.txt
+                full_description = None
+                try:
+                    descriptions = load_workout_descriptions(week_id)
+                    full_description = descriptions.get(session_id)
+                except Exception:
+                    pass
+
                 result = {
-                    "found": False,
+                    "found": bool(full_description or session_def),
                     "session_id": session_id,
                     "structured_file": None,
-                    "message": "No structured workout file (.zwo) found. "
-                    "Session is defined via text description in the planning.",
+                    "message": (
+                        "Workout description loaded from planning."
+                        if full_description or session_def
+                        else "No workout file or description found."
+                    ),
+                    "full_description": full_description,
                     "session_definition": (
                         {
                             "name": session_def.name if session_def else None,

--- a/tests/test_mcp_new_handlers.py
+++ b/tests/test_mcp_new_handlers.py
@@ -716,14 +716,50 @@ class TestHandleGetWorkout:
         tower_mock = Mock()
         tower_mock.read_week.return_value = mock_plan
 
-        with patch(DATA_CONFIG_PATCH, return_value=mc), patch(TOWER_PATCH, tower_mock):
+        with (
+            patch(DATA_CONFIG_PATCH, return_value=mc),
+            patch(TOWER_PATCH, tower_mock),
+            patch(
+                "magma_cycling.workout_parser.load_workout_descriptions",
+                return_value={},
+            ),
+        ):
             result = await handle_get_workout({"session_id": "S081-03"})
         data = json.loads(result[0].text)
-        assert data["found"] is False
+        assert data["found"] is True
         assert data["structured_file"] is None
         assert data["session_definition"]["name"] == "EnduranceBase"
         assert data["session_definition"]["description"] == "2h endurance Z2"
         assert data["session_definition"]["tss_planned"] == 80
+        assert data["full_description"] is None
+
+    @pytest.mark.asyncio
+    async def test_workout_fallback_loads_workouts_txt(self, tmp_path):
+        """get-workout loads full description from {week_id}_workouts.txt."""
+        from magma_cycling.mcp_server import handle_get_workout
+
+        mc = Mock()
+        mc.data_repo_path = tmp_path
+        (tmp_path / "workouts").mkdir()
+
+        tower_mock = Mock()
+        tower_mock.read_week.side_effect = Exception("no plan")
+
+        full_desc = "2x20min @ 85% FTP\nRecup 5min entre series"
+
+        with (
+            patch(DATA_CONFIG_PATCH, return_value=mc),
+            patch(TOWER_PATCH, tower_mock),
+            patch(
+                "magma_cycling.workout_parser.load_workout_descriptions",
+                return_value={"S081-03": full_desc},
+            ),
+        ):
+            result = await handle_get_workout({"session_id": "S081-03"})
+        data = json.loads(result[0].text)
+        assert data["found"] is True
+        assert data["full_description"] == full_desc
+        assert data["session_definition"] is None
 
     @pytest.mark.asyncio
     async def test_workout_found_returns_content(self, tmp_path):


### PR DESCRIPTION
## Summary
- The `get-workout` MCP tool now loads full workout descriptions from `{week_id}_workouts.txt` via `load_workout_descriptions()` when no `.zwo` file exists
- Returns both structured planning data AND full text description as fallback
- Fixes gap where Claude D couldn't retrieve workout content for sessions without `.zwo` files

## Test plan
- [x] Existing test updated to verify `full_description` field
- [x] New test `test_workout_fallback_loads_workouts_txt` added
- [x] All 1923 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)