### PR TITLE
feat(prompts): add consecutive training days counter

### DIFF
--- a/magma_cycling/prompts/prompt_builder.py
+++ b/magma_cycling/prompts/prompt_builder.py
@@ -52,6 +52,35 @@ def load_current_metrics() -> dict:
     except Exception:
         logger.debug("Could not load Intervals.icu metrics, skipping CTL/ATL")
 
+    # --- ACWR / Monotony / Strain + consecutive days (1 extra API call: 28d activities) ---
+    activities = []
+    try:
+        from datetime import timedelta
+
+        from magma_cycling.utils.training_load import (
+            compute_training_load,
+            count_consecutive_training_days,
+        )
+
+        if "client" not in locals():
+            from magma_cycling.config import create_intervals_client
+
+            client = create_intervals_client()
+            today = datetime.now().strftime("%Y-%m-%d")
+
+        oldest_28d = (datetime.now() - timedelta(days=28)).strftime("%Y-%m-%d")
+        activities = client.get_activities(oldest=oldest_28d, newest=today)
+        load = compute_training_load(activities)
+        if load:
+            metrics["acwr"] = load["acwr"]
+            metrics["monotony"] = load["monotony"]
+            metrics["strain"] = load["strain"]
+        consec = count_consecutive_training_days(activities)
+        if consec:
+            metrics["consecutive_training_days"] = consec["consecutive_days"]
+    except Exception:
+        logger.debug("Could not compute training load indicators")
+
     # --- Derived metrics from existing data (no extra API call) ---
     ctl = metrics.get("ctl")
     atl = metrics.get("atl")
@@ -75,6 +104,7 @@ def load_current_metrics() -> dict:
                 atl=atl,
                 tsb=tsb,
                 sleep_hours=sleep_hours,
+                consecutive_days=metrics.get("consecutive_training_days"),
                 profile={"age": 54, "category": "master", "sleep_dependent": True},
             )
             metrics["overtraining_risk"] = risk["risk_level"]
@@ -91,28 +121,6 @@ def load_current_metrics() -> dict:
             metrics["intensity_limit_pct"] = recovery["intensity_limit"]
         except Exception:
             logger.debug("Could not compute overtraining/recovery metrics")
-
-    # --- ACWR / Monotony / Strain (1 extra API call: 28d activities) ---
-    try:
-        from datetime import timedelta
-
-        from magma_cycling.utils.training_load import compute_training_load
-
-        if "client" not in locals():
-            from magma_cycling.config import create_intervals_client
-
-            client = create_intervals_client()
-            today = datetime.now().strftime("%Y-%m-%d")
-
-        oldest_28d = (datetime.now() - timedelta(days=28)).strftime("%Y-%m-%d")
-        activities = client.get_activities(oldest=oldest_28d, newest=today)
-        load = compute_training_load(activities)
-        if load:
-            metrics["acwr"] = load["acwr"]
-            metrics["monotony"] = load["monotony"]
-            metrics["strain"] = load["strain"]
-    except Exception:
-        logger.debug("Could not compute training load indicators")
 
     return metrics
 
@@ -239,6 +247,9 @@ def format_athlete_profile(context: dict, metrics: dict) -> str:
         if strain is not None:
             strain_label = "ALERTE" if strain > 3500 else "OK"
             lines.append(f"  - Strain: {strain:.0f} ({strain_label})")
+        consec = metrics.get("consecutive_training_days")
+        if consec and consec >= 2:
+            lines.append(f"  - Jours consecutifs: {consec}")
 
     # Constraints
     constraints = context.get("constraints", [])

--- a/magma_cycling/utils/metrics_advanced.py
+++ b/magma_cycling/utils/metrics_advanced.py
@@ -359,6 +359,7 @@ def detect_overtraining_risk(
     atl: float,
     tsb: float,
     sleep_hours: float | None = None,
+    consecutive_days: int | None = None,
     profile: dict[str, Any] | None = None,
     thresholds: dict[str, float] | None = None,
 ) -> dict[str, Any]:
@@ -375,6 +376,7 @@ def detect_overtraining_risk(
         atl: Current Acute Training Load (Fatigue)
         tsb: Current Training Stress Balance (Form)
         sleep_hours: Sleep duration from previous night (optional but recommended)
+        consecutive_days: Number of consecutive training days ending today (optional)
         profile: Athlete profile dict with keys:
                  - age: int
                  - category: 'junior' | 'senior' | 'master'
@@ -439,6 +441,8 @@ def detect_overtraining_risk(
             "ratio_optimal": 1.3,
             "sleep_critical": 6.0,
             "sleep_veto": 5.5,
+            "consecutive_days_warning": 3,
+            "consecutive_days_critical": 4,
         }
 
     # Default profile
@@ -507,6 +511,37 @@ def detect_overtraining_risk(
             if sleep_hours < 7.0:
                 factors.append(f"Sleep below optimal ({sleep_hours:.1f}h < 7h)")
                 risk_level = "medium" if risk_level == "low" else risk_level
+
+        # Consecutive training days check
+        if consecutive_days is not None:
+            if is_master and consecutive_days >= thresholds["consecutive_days_critical"]:
+                factors.append(
+                    f"Consecutive training: {consecutive_days} days "
+                    f"(>={thresholds['consecutive_days_critical']:.0f}"
+                    f" = neuromuscular overload)"
+                )
+                risk_level = "high"
+            elif consecutive_days >= thresholds["consecutive_days_warning"]:
+                factors.append(
+                    f"Consecutive training: {consecutive_days} days "
+                    f"(>={thresholds['consecutive_days_warning']:.0f}"
+                    f" = fatigue accumulation)"
+                )
+                risk_level = "medium" if risk_level == "low" else risk_level
+
+        # Combined: consecutive days + poor sleep → escalate for master
+        if (
+            consecutive_days is not None
+            and sleep_hours is not None
+            and is_master
+            and consecutive_days >= thresholds["consecutive_days_warning"]
+            and sleep_hours < 7.0
+        ):
+            factors.append(
+                f"Combined: {consecutive_days} consecutive days "
+                f"+ low sleep ({sleep_hours:.1f}h)"
+            )
+            risk_level = "high"
 
     # MEDIUM RISK CHECKS
 

--- a/magma_cycling/utils/training_load.py
+++ b/magma_cycling/utils/training_load.py
@@ -11,7 +11,7 @@ References:
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from statistics import mean, stdev
 
 
@@ -76,4 +76,62 @@ def compute_training_load(activities_28d: list[dict]) -> dict:
         "strain": strain,
         "acute_load": round(acute_load, 1),
         "chronic_load": round(chronic_load, 1),
+    }
+
+
+def count_consecutive_training_days(
+    activities_28d: list[dict],
+    min_tss: float = 20.0,
+) -> dict:
+    """Count current streak of consecutive training days ending today.
+
+    Args:
+        activities_28d: Activity list from Intervals.icu API.
+        min_tss: Minimum daily TSS to count as a training day (default 20).
+
+    Returns:
+        Dict with consecutive_days, streak_dates, streak_tss.
+        Empty dict on failure.
+    """
+    if not activities_28d:
+        return {}
+
+    # Aggregate TSS per day
+    today = date.today()
+    daily_tss: dict[date, float] = {}
+    for act in activities_28d:
+        tss = act.get("icu_training_load")
+        if tss is None:
+            continue
+        date_str = act.get("start_date_local", "")[:10]
+        if not date_str:
+            continue
+        try:
+            d = date.fromisoformat(date_str)
+        except ValueError:
+            continue
+        daily_tss[d] = daily_tss.get(d, 0.0) + float(tss)
+
+    if not daily_tss:
+        return {}
+
+    # Walk backwards from today counting consecutive days with TSS >= min_tss
+    streak_dates: list[str] = []
+    streak_tss = 0.0
+    current = today
+    while True:
+        day_tss = daily_tss.get(current, 0.0)
+        if day_tss < min_tss:
+            break
+        streak_dates.append(current.isoformat())
+        streak_tss += day_tss
+        current -= timedelta(days=1)
+
+    if not streak_dates:
+        return {}
+
+    return {
+        "consecutive_days": len(streak_dates),
+        "streak_dates": list(reversed(streak_dates)),
+        "streak_tss": round(streak_tss, 1),
     }

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -439,6 +439,34 @@ class TestFormatAthleteProfile:
         result = format_athlete_profile(context, metrics)
         assert "Intensite max" not in result
 
+    def test_consecutive_days_displayed(self):
+        """Consecutive days >= 2 appear in load indicators."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "medium",
+            "overtraining_veto": False,
+            "overtraining_factors": ["Consecutive training: 3 days"],
+            "atl_ctl_ratio": 1.07,
+            "tsb": -3.0,
+            "consecutive_training_days": 3,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Jours consecutifs: 3" in result
+
+    def test_consecutive_days_one_not_displayed(self):
+        """Consecutive days < 2 not displayed."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "low",
+            "overtraining_veto": False,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 0.95,
+            "tsb": 3.0,
+            "consecutive_training_days": 1,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Jours consecutifs" not in result
+
 
 class TestLoadCurrentMetricsDerived:
     """Tests for derived metrics in load_current_metrics()."""

--- a/tests/test_training_load.py
+++ b/tests/test_training_load.py
@@ -4,7 +4,10 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from magma_cycling.utils.training_load import compute_training_load
+from magma_cycling.utils.training_load import (
+    compute_training_load,
+    count_consecutive_training_days,
+)
 
 
 def _make_activities(daily_tss: list[float], days_back: int = 28) -> list[dict]:
@@ -136,3 +139,105 @@ class TestComputeTrainingLoad:
         ]
         result = compute_training_load(activities)
         assert result["acute_load"] == 0.0
+
+
+class TestCountConsecutiveTrainingDays:
+    """Tests for count_consecutive_training_days()."""
+
+    def test_empty_returns_empty(self):
+        """Empty activity list returns empty dict."""
+        assert count_consecutive_training_days([]) == {}
+
+    def test_no_recent_training(self):
+        """Activities only far in the past return empty dict."""
+        today = datetime.now().date()
+        activities = [
+            {
+                "start_date_local": (today - timedelta(days=10)).isoformat() + "T08:00:00",
+                "icu_training_load": 80,
+            },
+        ]
+        assert count_consecutive_training_days(activities) == {}
+
+    def test_single_day(self):
+        """One activity today gives consecutive_days=1."""
+        today = datetime.now().date()
+        activities = [
+            {
+                "start_date_local": today.isoformat() + "T08:00:00",
+                "icu_training_load": 50,
+            },
+        ]
+        result = count_consecutive_training_days(activities)
+        assert result["consecutive_days"] == 1
+        assert result["streak_tss"] == 50.0
+
+    def test_three_consecutive(self):
+        """Three consecutive days returns consecutive_days=3."""
+        today = datetime.now().date()
+        activities = [
+            {
+                "start_date_local": (today - timedelta(days=2)).isoformat() + "T08:00:00",
+                "icu_training_load": 85,
+            },
+            {
+                "start_date_local": (today - timedelta(days=1)).isoformat() + "T08:00:00",
+                "icu_training_load": 45,
+            },
+            {
+                "start_date_local": today.isoformat() + "T08:00:00",
+                "icu_training_load": 72,
+            },
+        ]
+        result = count_consecutive_training_days(activities)
+        assert result["consecutive_days"] == 3
+        assert result["streak_tss"] == pytest.approx(85 + 45 + 72, rel=0.01)
+
+    def test_gap_breaks_streak(self):
+        """A rest day breaks the streak."""
+        today = datetime.now().date()
+        activities = [
+            {
+                "start_date_local": (today - timedelta(days=3)).isoformat() + "T08:00:00",
+                "icu_training_load": 80,
+            },
+            # day -2: rest day (gap)
+            {
+                "start_date_local": (today - timedelta(days=1)).isoformat() + "T08:00:00",
+                "icu_training_load": 60,
+            },
+            {
+                "start_date_local": today.isoformat() + "T08:00:00",
+                "icu_training_load": 50,
+            },
+        ]
+        result = count_consecutive_training_days(activities)
+        assert result["consecutive_days"] == 2
+
+    def test_below_min_tss_not_counted(self):
+        """TSS below min_tss does not count as training."""
+        today = datetime.now().date()
+        activities = [
+            {
+                "start_date_local": (today - timedelta(days=1)).isoformat() + "T08:00:00",
+                "icu_training_load": 15,  # Below default 20 threshold
+            },
+            {
+                "start_date_local": today.isoformat() + "T08:00:00",
+                "icu_training_load": 50,
+            },
+        ]
+        result = count_consecutive_training_days(activities)
+        assert result["consecutive_days"] == 1
+
+    def test_multiple_activities_same_day(self):
+        """Two activities on same day count as 1 day."""
+        today = datetime.now().date()
+        date_str = today.isoformat() + "T08:00:00"
+        activities = [
+            {"start_date_local": date_str, "icu_training_load": 15},
+            {"start_date_local": date_str, "icu_training_load": 10},
+        ]
+        result = count_consecutive_training_days(activities)
+        assert result["consecutive_days"] == 1
+        assert result["streak_tss"] == 25.0

--- a/tests/utils/test_metrics_advanced.py
+++ b/tests/utils/test_metrics_advanced.py
@@ -422,3 +422,83 @@ def test_overtraining_risk_custom_thresholds():
     # Should be critical with custom threshold of -20
     assert result["risk_level"] == "critical"
     assert result["veto"] is True
+
+
+# ============================================================================
+# Test detect_overtraining_risk: consecutive_days
+# ============================================================================
+
+
+class TestDetectOvertrainingRiskConsecutiveDays:
+    """Tests for consecutive_days parameter in detect_overtraining_risk()."""
+
+    def test_consecutive_days_warning_factor(self):
+        """3 consecutive days adds a fatigue accumulation factor."""
+        result = detect_overtraining_risk(
+            ctl=43,
+            atl=46,
+            tsb=-3,
+            consecutive_days=3,
+            profile={"age": 30, "category": "senior"},
+        )
+        assert any("Consecutive training: 3 days" in f for f in result["factors"])
+        assert result["risk_level"] in ("medium", "high")
+
+    def test_consecutive_days_critical_master(self):
+        """4 consecutive days = high risk for master athlete."""
+        result = detect_overtraining_risk(
+            ctl=43,
+            atl=46,
+            tsb=-3,
+            consecutive_days=4,
+            profile={"age": 54, "category": "master"},
+        )
+        assert any("neuromuscular overload" in f for f in result["factors"])
+        assert result["risk_level"] == "high"
+
+    def test_consecutive_days_combined_with_sleep(self):
+        """3 consecutive days + sleep < 7h escalates to high for master."""
+        result = detect_overtraining_risk(
+            ctl=43,
+            atl=46,
+            tsb=-3,
+            sleep_hours=6.5,
+            consecutive_days=3,
+            profile={"age": 54, "category": "master", "sleep_dependent": True},
+        )
+        assert result["risk_level"] == "high"
+        assert any("Combined" in f for f in result["factors"])
+
+    def test_no_consecutive_days_no_factor(self):
+        """Without consecutive_days, no consecutive factor added."""
+        result = detect_overtraining_risk(
+            ctl=43,
+            atl=46,
+            tsb=-3,
+            profile={"age": 54, "category": "master"},
+        )
+        assert not any("Consecutive" in f for f in result["factors"])
+
+    def test_two_consecutive_days_no_warning(self):
+        """2 consecutive days below threshold, no factor added."""
+        result = detect_overtraining_risk(
+            ctl=43,
+            atl=46,
+            tsb=-3,
+            consecutive_days=2,
+            profile={"age": 54, "category": "master"},
+        )
+        assert not any("Consecutive" in f for f in result["factors"])
+
+    def test_simulation_s083_04(self):
+        """Simulate S083-04: 3 days + sleep 6.5h should detect risk."""
+        result = detect_overtraining_risk(
+            ctl=43,
+            atl=46,
+            tsb=-3,
+            sleep_hours=6.5,
+            consecutive_days=3,
+            profile={"age": 54, "category": "master", "sleep_dependent": True},
+        )
+        assert result["risk_level"] in ("medium", "high")
+        assert any("Consecutive" in f for f in result["factors"])


### PR DESCRIPTION
## Summary

- Add `count_consecutive_training_days()` in `training_load.py` to detect sequences of 3+ training days without rest
- Enrich `detect_overtraining_risk()` with `consecutive_days` parameter — 3+ days = warning, 4+ = high risk for master athletes
- Combined signal: consecutive days + poor sleep (<7h) escalates to HIGH risk
- Display "Jours consecutifs: N" in AI prompt load indicators section
- Reorder `load_current_metrics()` blocks so activities are fetched before overtraining risk assessment

## Context

Smoothed metrics (TSB, ACWR) failed to detect neuromuscular fatigue on S083-04 (3 consecutive training days + 6.5h sleep). This counter captures the missing signal.

## Test plan

- [x] 7 tests for `count_consecutive_training_days()` (empty, single day, 3 consecutive, gap breaks streak, min TSS threshold, multi-activity same day)
- [x] 6 tests for `consecutive_days` in `detect_overtraining_risk()` (warning, critical master, combined sleep, no factor, below threshold, S083-04 simulation)
- [x] 2 tests for display in `format_athlete_profile()` (displayed >= 2, not displayed < 2)
- [x] All 1958 existing tests pass
- [x] Pre-commit all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)