### PR TITLE
feat(prompts): add prescriptive recovery directives for weekly planning

### DIFF
--- a/magma_cycling/prompts/prompt_builder.py
+++ b/magma_cycling/prompts/prompt_builder.py
@@ -163,6 +163,43 @@ def build_prompt(
     return system_prompt, workflow_data
 
 
+def _build_recovery_directives(
+    risk: str | None,
+    consecutive_days: int | None,
+    veto: bool | None,
+    recovery_priority: str | None,
+) -> list[str]:
+    """Build prescriptive recovery directives for weekly planning."""
+    directives: list[str] = []
+
+    if veto:
+        directives.append("JOUR 1 = repos complet ou Z1 uniquement (<55% FTP, <45min)")
+
+    if risk in ("critical", "high"):
+        directives.append("Commencer la semaine par 1 jour repos avant toute intensite")
+
+    if risk == "critical":
+        directives.append("Maximum 3 seances cette semaine, 2 jours repos minimum espaces")
+
+    if risk == "high":
+        directives.append("Maximum 4 seances, pas d'INT avant 1 jour complet de recup")
+
+    consec = consecutive_days or 0
+    if consec >= 4:
+        directives.append(
+            f"REPOS OBLIGATOIRE jour 1 : surcharge neuromusculaire ({consec} jours consecutifs)"
+        )
+
+    if consec >= 3:
+        directives.append("Alterner : maximum 2 jours ON consecutifs, puis 1 jour OFF")
+        directives.append("Pas d'intensite (>85% FTP) avant 1 jour de repos complet")
+
+    if recovery_priority in ("high", "critical"):
+        directives.append("Semaine allegee : reduire TSS cible de 20-30%")
+
+    return directives
+
+
 def format_athlete_profile(context: dict, metrics: dict) -> str:
     """Format athlete profile for prompt injection.
 
@@ -264,5 +301,18 @@ def format_athlete_profile(context: dict, metrics: dict) -> str:
     if sys_ctx:
         lines.append("")
         lines.append(sys_ctx.strip())
+
+    # Recovery directives (prescriptive section for weekly planning)
+    directives = _build_recovery_directives(
+        risk=metrics.get("overtraining_risk"),
+        consecutive_days=metrics.get("consecutive_training_days"),
+        veto=metrics.get("overtraining_veto"),
+        recovery_priority=metrics.get("recovery_priority"),
+    )
+    if directives:
+        lines.append("")
+        lines.append("Directives de recuperation (OBLIGATOIRES pour le planning):")
+        for d in directives:
+            lines.append(f"  - {d}")
 
     return "\n".join(lines)

--- a/magma_cycling/workflows/planner/prompt.py
+++ b/magma_cycling/workflows/planner/prompt.py
@@ -201,7 +201,7 @@ Si une adaptation recommande un test FTP avec affûtage, suivre ce timing préci
 
 3. **Semaine APRÈS ({self._week_after_next()})**:
    - Test FTP samedi (jour 6)
-   - Repos dimanche
+   - Repos la veille du test
    - TSB optimal pour test: +5 à +15
 
 **Autres adaptations:**
@@ -403,7 +403,7 @@ Cooldown
 
 ### Contraintes Obligatoires
 
-1. **Dimanche = REPOS OBLIGATOIRE** (aucune séance)
+1. **Minimum 1 jour REPOS par semaine** (placement selon etat de fatigue et directives recuperation)
 2. **TSB Management** :
    - Si TSB actuel < +5 : Pas de VO2 max
    - Si TSB < 0 : Prioriser récupération/endurance
@@ -421,7 +421,7 @@ Cooldown
 - **Jeudi** : Endurance progressive ou Force
 - **Vendredi** : Activation ou Sweet-Spot léger
 - **Samedi** : Volume (endurance longue) ou Intensité haute si TSB favorable
-- **Dimanche** : **REPOS COMPLET**
+- **Dimanche** : Repos OU seance legere selon fatigue residuelle
 
 ### Règles Intensité
 
@@ -512,7 +512,7 @@ Cooldown
 
 ## Livrables Attendus
 
-Génère **7 blocs WORKOUT** (un par jour, dimanche = mention repos) au format texte pur Intervals.icu.
+Génère **7 blocs WORKOUT** (un par jour, jour(s) repos selon directives recuperation) au format texte pur Intervals.icu.
 
 **Exemple de format attendu** :
 

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -4,6 +4,7 @@ import pytest
 
 from magma_cycling.prompts.prompt_builder import (
     VALID_MISSIONS,
+    _build_recovery_directives,
     build_prompt,
     format_athlete_profile,
     load_current_metrics,
@@ -957,3 +958,168 @@ class TestWorkflowCoachIntegration:
             dataset=None,
             system_prompt="system prompt",
         )
+
+
+class TestBuildRecoveryDirectives:
+    """Tests for _build_recovery_directives() helper."""
+
+    def test_empty_when_low_risk(self):
+        """Low risk and < 3 consecutive days produces empty list."""
+        result = _build_recovery_directives(
+            risk="low", consecutive_days=2, veto=False, recovery_priority="low"
+        )
+        assert result == []
+
+    def test_empty_when_none(self):
+        """All None parameters produce empty list."""
+        result = _build_recovery_directives(
+            risk=None, consecutive_days=None, veto=None, recovery_priority=None
+        )
+        assert result == []
+
+    def test_veto_directive(self):
+        """Veto=True adds JOUR 1 directive."""
+        result = _build_recovery_directives(
+            risk="critical", consecutive_days=0, veto=True, recovery_priority=None
+        )
+        assert any("JOUR 1" in d for d in result)
+
+    def test_critical_risk(self):
+        """Critical risk adds max 3 sessions directive."""
+        result = _build_recovery_directives(
+            risk="critical", consecutive_days=0, veto=False, recovery_priority=None
+        )
+        assert any("Maximum 3 seances" in d for d in result)
+        assert any("1 jour repos" in d for d in result)
+
+    def test_high_risk(self):
+        """High risk adds max 4 sessions directive."""
+        result = _build_recovery_directives(
+            risk="high", consecutive_days=0, veto=False, recovery_priority=None
+        )
+        assert any("Maximum 4 seances" in d for d in result)
+        assert any("1 jour repos" in d for d in result)
+
+    def test_consecutive_4_days(self):
+        """4+ consecutive days adds REPOS OBLIGATOIRE."""
+        result = _build_recovery_directives(
+            risk="low", consecutive_days=4, veto=False, recovery_priority=None
+        )
+        assert any("REPOS OBLIGATOIRE" in d for d in result)
+        assert any("4 jours consecutifs" in d for d in result)
+
+    def test_consecutive_3_accumulates(self):
+        """3+ consecutive days adds Alterner AND Pas d'intensite."""
+        result = _build_recovery_directives(
+            risk="low", consecutive_days=3, veto=False, recovery_priority=None
+        )
+        assert any("Alterner" in d for d in result)
+        assert any("Pas d'intensite" in d for d in result)
+
+    def test_recovery_priority_high(self):
+        """High recovery priority adds TSS reduction directive."""
+        result = _build_recovery_directives(
+            risk="low", consecutive_days=0, veto=False, recovery_priority="high"
+        )
+        assert any("reduire TSS" in d for d in result)
+
+    def test_recovery_priority_critical(self):
+        """Critical recovery priority adds TSS reduction directive."""
+        result = _build_recovery_directives(
+            risk="low", consecutive_days=0, veto=False, recovery_priority="critical"
+        )
+        assert any("reduire TSS" in d for d in result)
+
+
+class TestRecoveryDirectivesInProfile:
+    """Tests for recovery directives injection in format_athlete_profile()."""
+
+    def test_veto_in_profile(self):
+        """Veto=True injects JOUR 1 directive in profile."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "critical",
+            "overtraining_veto": True,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 1.85,
+            "tsb": -28.0,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Directives de recuperation (OBLIGATOIRES pour le planning):" in result
+        assert "JOUR 1 = repos" in result
+
+    def test_high_risk_in_profile(self):
+        """High risk injects recovery directives in profile."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "high",
+            "overtraining_veto": False,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 1.4,
+            "tsb": -18.0,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Maximum 4 seances" in result
+        assert "1 jour repos" in result
+
+    def test_consecutive_4_in_profile(self):
+        """4 consecutive days injects REPOS OBLIGATOIRE in profile."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "medium",
+            "overtraining_veto": False,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 1.1,
+            "tsb": -5.0,
+            "consecutive_training_days": 4,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "REPOS OBLIGATOIRE" in result
+        assert "4 jours consecutifs" in result
+
+    def test_consecutive_3_in_profile(self):
+        """3 consecutive days injects Alterner + Pas d'intensite."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "medium",
+            "overtraining_veto": False,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 1.05,
+            "tsb": -2.0,
+            "consecutive_training_days": 3,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Alterner" in result
+        assert "Pas d'intensite" in result
+
+    def test_no_directives_low_risk(self):
+        """Low risk, consec < 3 → no directives section."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "low",
+            "overtraining_veto": False,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 0.95,
+            "tsb": 3.0,
+            "consecutive_training_days": 1,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Directives de recuperation" not in result
+
+    def test_combined_high_risk_consecutive_4(self):
+        """High risk + 4 consec days → multiple directives."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "high",
+            "overtraining_veto": False,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 1.4,
+            "tsb": -18.0,
+            "consecutive_training_days": 4,
+            "recovery_priority": "high",
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Maximum 4 seances" in result
+        assert "REPOS OBLIGATOIRE" in result
+        assert "Alterner" in result
+        assert "reduire TSS" in result


### PR DESCRIPTION
## Summary

- Replace hardcoded "Dimanche = REPOS OBLIGATOIRE" (4 occurrences) in `planner/prompt.py` with flexible "minimum 1 jour repos/semaine" driven by fatigue state
- Add `_build_recovery_directives()` helper in `prompt_builder.py` that generates prescriptive directives based on overtraining risk, consecutive training days, veto status, and recovery priority
- Inject directives section into athlete profile (system_prompt) so the AI planner adapts rest day placement dynamically

## Test plan

- [x] 9 new unit tests for `_build_recovery_directives()` (empty, veto, critical, high, consecutive days, recovery priority)
- [x] 6 new integration tests for `format_athlete_profile()` (veto, high risk, consec 3/4, low risk no directives, combined)
- [x] All 1973 existing tests pass (`pytest tests/ -x`)
- [x] Pre-commit all green
- [x] Verified "Dimanche = REPOS OBLIGATOIRE" no longer in `planner/prompt.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)