### PR TITLE
docs(roadmap): add auto-rest planning item to Phase 3.3 backlog

### DIFF
--- a/project-docs/ROADMAP.md
+++ b/project-docs/ROADMAP.md
@@ -181,6 +181,7 @@ prompts/
 | Workflow Diversity Integration (S4) | P1 | 2-3h | 📋 Planifié |
 | Test History Tracking | P2 | 2-4h | 📋 Backlog |
 | Indoor/Outdoor Adaptive Analysis | P1 | 3-4h | 📋 Backlog |
+| Auto-rest: directives récup → statut planning | P2 | 4-6h | 📋 Backlog |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add backlog item: when recovery directives prescribe rest, auto-update planned session status to `rest_day` to avoid adherence penalties

## Test plan

- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)