### PR TITLE
refactor(utils): consolidate sleep quality scale into intervals_scales

### DIFF
--- a/magma_cycling/_mcp/handlers/withings.py
+++ b/magma_cycling/_mcp/handlers/withings.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 import requests
 
 from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
+from magma_cycling.utils.intervals_scales import sleep_score_to_quality
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
@@ -218,26 +219,6 @@ async def handle_withings_get_readiness(args: dict) -> list[TextContent]:
     return mcp_response(result, default=str)
 
 
-def _sleep_score_to_quality(score: int | None) -> int | None:
-    """Convert Withings sleep_score (0-100) to Intervals.icu sleepQuality (1-4).
-
-    Intervals.icu uses an inverted 1-4 scale:
-      1 = Excellent (score >= 90)
-      2 = Good      (score >= 75)
-      3 = Average   (score >= 60)
-      4 = Poor      (score < 60)
-    """
-    if score is None:
-        return None
-    if score >= 90:
-        return 1
-    if score >= 75:
-        return 2
-    if score >= 60:
-        return 3
-    return 4
-
-
 def _extract_422_detail(http_err: requests.exceptions.HTTPError) -> str:
     """Extract error detail from a 422 response body."""
     try:
@@ -364,7 +345,7 @@ def sync_withings_to_intervals(
             if sync_sleep and date_str in sleep_by_date:
                 sleep_info = sleep_by_date[date_str]
                 wellness["sleepSecs"] = int(sleep_info["total_sleep_hours"] * 3600)
-                quality = _sleep_score_to_quality(sleep_info.get("sleep_score"))
+                quality = sleep_score_to_quality(sleep_info.get("sleep_score"))
                 if quality is not None:
                     wellness["sleepQuality"] = quality
                 if sleep_info.get("hr_min"):

--- a/magma_cycling/utils/intervals_scales.py
+++ b/magma_cycling/utils/intervals_scales.py
@@ -39,3 +39,50 @@ def format_feel(value: int | None, with_emoji: bool = False) -> str:
         return f"{emoji} {label} ({value}/5)"
 
     return label
+
+
+SLEEP_QUALITY_LABELS: dict[int, str] = {
+    1: "Excellent",
+    2: "Good",
+    3: "Average",
+    4: "Poor",
+}
+
+
+def sleep_score_to_quality(score: int | None) -> int | None:
+    """Convert Withings sleep_score (0-100) to Intervals.icu sleepQuality (1-4).
+
+    Intervals.icu uses an inverted 1-4 scale:
+      1 = Excellent (score >= 90)
+      2 = Good      (score >= 75)
+      3 = Average   (score >= 60)
+      4 = Poor      (score < 60)
+    """
+    if score is None:
+        return None
+    if score >= 90:
+        return 1
+    if score >= 75:
+        return 2
+    if score >= 60:
+        return 3
+    return 4
+
+
+def format_sleep_quality(value: int | None) -> str:
+    """Format sleepQuality value (1-4 Intervals.icu scale).
+
+    Args:
+        value: Sleep quality value 1-4 or None (1=Excellent, 4=Poor).
+
+    Returns:
+        Formatted label string.
+    """
+    if value is None:
+        return "_Non renseigné_"
+
+    label = SLEEP_QUALITY_LABELS.get(value)
+    if label is None:
+        return f"_Valeur inconnue: {value}_"
+
+    return label

--- a/project-docs/ROADMAP.md
+++ b/project-docs/ROADMAP.md
@@ -177,7 +177,7 @@ prompts/
 | Item | Priorité | Effort | Status |
 |------|----------|--------|--------|
 | PID Calibration post-S080 (R10) | P1 | 5-7j | 📋 Planifié |
-| DRY violation Intervals.icu scales | P2 | 2-3h | 📋 Backlog |
+| DRY violation Intervals.icu scales | P2 | 2-3h | ✅ Résolu |
 | Workflow Diversity Integration (S4) | P1 | 2-3h | 📋 Planifié |
 | Test History Tracking | P2 | 2-4h | 📋 Backlog |
 | Indoor/Outdoor Adaptive Analysis | P1 | 3-4h | 📋 Backlog |
@@ -388,12 +388,12 @@ Items long-terme, priorisés après déploiement Phase 4.
 
 ## 🔧 Dette Technique
 
-### DRY Violation: Intervals.icu Scales
+### ~~DRY Violation: Intervals.icu Scales~~
 
-**Priorité :** P2 | **Effort :** 2-3h | **Status :** Backlog
+**Priorité :** P2 | **Effort :** 2-3h | **Status :** ✅ Résolu
 
-Échelle Feel d'Intervals.icu (1-5) dupliquée dans `prepare_analysis.py` et `daily_sync.py`.
-Solution : module centralisé `intervals_scales.py` (même pattern applicable aux autres échelles).
+Module centralisé `utils/intervals_scales.py` : Feel 1-5 (PR #83-84) + Sleep Quality 1-4 consolidés.
+`FEEL_LABELS`, `FEEL_EMOJIS`, `format_feel()`, `SLEEP_QUALITY_LABELS`, `sleep_score_to_quality()`, `format_sleep_quality()`.
 
 ### ~~sync-week-to-intervals force_update incomplete~~
 

--- a/tests/utils/test_intervals_scales.py
+++ b/tests/utils/test_intervals_scales.py
@@ -2,7 +2,14 @@
 
 import pytest
 
-from magma_cycling.utils.intervals_scales import FEEL_EMOJIS, FEEL_LABELS, format_feel
+from magma_cycling.utils.intervals_scales import (
+    FEEL_EMOJIS,
+    FEEL_LABELS,
+    SLEEP_QUALITY_LABELS,
+    format_feel,
+    format_sleep_quality,
+    sleep_score_to_quality,
+)
 
 
 class TestFeelLabels:
@@ -62,3 +69,61 @@ class TestFormatFeel:
 
     def test_zero_returns_valeur_inconnue(self):
         assert format_feel(0) == "_Valeur inconnue: 0_"
+
+
+class TestSleepQualityLabels:
+    """Tests for SLEEP_QUALITY_LABELS constant."""
+
+    def test_labels_cover_1_to_4(self):
+        assert set(SLEEP_QUALITY_LABELS.keys()) == {1, 2, 3, 4}
+
+    def test_label_values(self):
+        assert SLEEP_QUALITY_LABELS[1] == "Excellent"
+        assert SLEEP_QUALITY_LABELS[2] == "Good"
+        assert SLEEP_QUALITY_LABELS[3] == "Average"
+        assert SLEEP_QUALITY_LABELS[4] == "Poor"
+
+
+class TestSleepScoreToQuality:
+    """Tests for sleep_score_to_quality conversion."""
+
+    def test_none_returns_none(self):
+        assert sleep_score_to_quality(None) is None
+
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (0, 4),
+            (59, 4),
+            (60, 3),
+            (74, 3),
+            (75, 2),
+            (89, 2),
+            (90, 1),
+            (100, 1),
+        ],
+    )
+    def test_score_thresholds(self, score, expected):
+        assert sleep_score_to_quality(score) == expected
+
+
+class TestFormatSleepQuality:
+    """Tests for format_sleep_quality function."""
+
+    def test_none_returns_non_renseigne(self):
+        assert format_sleep_quality(None) == "_Non renseigné_"
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (1, "Excellent"),
+            (2, "Good"),
+            (3, "Average"),
+            (4, "Poor"),
+        ],
+    )
+    def test_valid_values(self, value, expected):
+        assert format_sleep_quality(value) == expected
+
+    def test_invalid_value_returns_valeur_inconnue(self):
+        assert format_sleep_quality(99) == "_Valeur inconnue: 99_"


### PR DESCRIPTION
## Summary

- Move `_sleep_score_to_quality()` from `withings.py` to shared `utils/intervals_scales.py` as public `sleep_score_to_quality()`
- Add `SLEEP_QUALITY_LABELS` dict and `format_sleep_quality()` formatter
- Add 17 tests covering labels, score thresholds, and formatting
- Update ROADMAP to mark DRY Intervals.icu Scales as resolved

## Test plan

- [x] `poetry run pytest tests/utils/test_intervals_scales.py -v` — 34 passed
- [x] `poetry run pytest tests/ -x` — 1990 passed
- [x] `poetry run pre-commit run --all-files` — 15/15 passed
- [x] Verify `_sleep_score_to_quality` no longer exists in `withings.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)