### PR TITLE
feat(prompts): add indoor/outdoor adaptive analysis

### DIFF
--- a/magma_cycling/prompts/daily_feedback.txt
+++ b/magma_cycling/prompts/daily_feedback.txt
@@ -7,6 +7,9 @@ Tu evalues UNE SEANCE qui vient d'etre realisee. Ton role :
 3. **Contextualiser** : la performance est-elle coherente avec le sommeil de la nuit,
    la fatigue accumulee (ATL), la position dans la semaine ?
 4. **Suggerer pour J+1** : faut-il maintenir le plan, alleger, ou prendre un repos ?
+5. **Evaluer la discipline environnement** : en outdoor, la deviation IF >10%
+   signale un echec discipline (methodologie Peaks Coaching). En indoor,
+   l'execution doit etre plus proche du plan (conditions controlees).
 
 Sois FACTUEL : appuie-toi sur les donnees (watts, bpm, cadence, decouplage).
 Une seance a -15% de TSS cible n'est pas un echec si le sommeil etait de 4h.

--- a/magma_cycling/workflows/prompt/data_formatting.py
+++ b/magma_cycling/workflows/prompt/data_formatting.py
@@ -13,6 +13,10 @@ class DataFormattingMixin:
         # Vérifier si l'activité vient de Strava
         is_strava = activity.get("source") == "STRAVA"
 
+        # Détecter l'environnement indoor/outdoor
+        activity_type = activity.get("type", "")
+        is_indoor = activity_type == "VirtualRide"
+
         data = {
             "id": activity.get("id", "Non spécifié"),
             "name": activity.get("name", "Séance"),
@@ -37,6 +41,8 @@ class DataFormattingMixin:
             "feel": activity.get("feel"),  # 1-5 scale Intervals.icu (1=Excellent, 5=Poor)
             "is_strava": is_strava,
             "source": activity.get("source", "Unknown"),
+            "environment": "indoor" if is_indoor else "outdoor",
+            "is_indoor": is_indoor,
         }
 
         return data

--- a/magma_cycling/workflows/prompt/prompt_assembly.py
+++ b/magma_cycling/workflows/prompt/prompt_assembly.py
@@ -1,6 +1,13 @@
 """Prompt assembly and output methods for PromptGenerator."""
 
 import subprocess
+from datetime import date
+
+from magma_cycling.planning.outdoor_discipline import (
+    check_discipline,
+    format_discipline_report,
+    generate_discipline_report,
+)
 
 
 class PromptAssemblyMixin:
@@ -94,6 +101,7 @@ Certaines métriques (puissance, découplage) peuvent être manquantes ou incomp
 - **Type** : {act['type']}
 - **Date** : {act['date']}
 - **Source** : {act['source']}
+- **Environnement** : {"Indoor (Home Trainer)" if act.get('is_indoor') else "Outdoor"}
 
 ### Métriques Pré-séance
 - CTL : {w_pre['ctl']:.0f}
@@ -180,6 +188,9 @@ ci-dessus. Identifier les écarts entre intention et réalisation.
 
 ---.
 """
+        # Ajouter section discipline environnement
+        prompt += self._build_environment_section(act, planned)
+
         # Ajouter contexte de périodisation si disponible
         if periodization_context:
             pc = periodization_context
@@ -315,6 +326,66 @@ Date : {act['date']}
 Génère maintenant l'entrée d'analyse.
 """
         return prompt
+
+    def _build_environment_section(self, act, planned):
+        """Construit la section environnement indoor/outdoor pour le prompt."""
+        is_indoor = act.get("is_indoor", False)
+
+        if is_indoor:
+            return """
+## 🏠 Environnement : Indoor (Home Trainer)
+
+→ Conditions contrôlées. Évaluer la précision d'exécution par rapport au plan.
+Pas de variables externes (vent, terrain, trafic). L'adhérence au plan doit être optimale.
+
+---
+"""
+        # Outdoor : ajouter analyse discipline si planned workout avec IF
+        if planned and planned.get("intensity_planned", 0) > 0 and act.get("intensity", 0) > 0:
+            discipline_check = check_discipline(
+                workout_name=act.get("name", "Séance"),
+                workout_date=date.fromisoformat(act["date_iso"]),
+                intensity_zone=self._guess_intensity_zone(act.get("intensity", 0)),
+                environment="outdoor",
+                if_planned=planned["intensity_planned"],
+                if_actual=act["intensity"],
+            )
+            report = generate_discipline_report(discipline_check)
+            discipline_md = format_discipline_report(report)
+
+            return f"""
+## 🌳 {discipline_md}
+
+**Consigne** : En outdoor, évaluer la capacité à respecter l'intensité cible.
+Déviation >10% = échec discipline (surcharge). Recommander indoor si récidive.
+
+---
+"""
+        # Outdoor sans planned workout
+        return """
+## 🌳 Environnement : Outdoor
+
+→ Variables externes possibles (vent, dénivelé, trafic).
+Tenir compte de ces facteurs dans l'évaluation de l'exécution.
+
+---
+"""
+
+    @staticmethod
+    def _guess_intensity_zone(intensity_factor):
+        """Détermine la zone d'intensité à partir de l'IF."""
+        if intensity_factor >= 1.05:
+            return "VO2"
+        elif intensity_factor >= 0.91:
+            return "FTP"
+        elif intensity_factor >= 0.84:
+            return "Sweet-Spot"
+        elif intensity_factor >= 0.76:
+            return "Tempo"
+        elif intensity_factor >= 0.56:
+            return "Endurance"
+        else:
+            return "Recovery"
 
     def copy_to_clipboard(self, text):
         """Copy le texte dans le presse-papier macOS."""

--- a/project-docs/ROADMAP.md
+++ b/project-docs/ROADMAP.md
@@ -180,7 +180,7 @@ prompts/
 | DRY violation Intervals.icu scales | P2 | 2-3h | ✅ Résolu |
 | Workflow Diversity Integration (S4) | P1 | 2-3h | 📋 Planifié |
 | Test History Tracking | P2 | 2-4h | 📋 Backlog |
-| Indoor/Outdoor Adaptive Analysis | P1 | 3-4h | 📋 Backlog |
+| Indoor/Outdoor Adaptive Analysis | P1 | 3-4h | ✅ Résolu |
 | Auto-rest: directives récup → statut planning | P2 | 4-6h | 📋 Backlog |
 
 ---

--- a/tests/planning/test_outdoor_discipline.py
+++ b/tests/planning/test_outdoor_discipline.py
@@ -1,0 +1,170 @@
+"""Tests for outdoor discipline monitoring module."""
+
+from datetime import date
+
+import pytest
+
+from magma_cycling.planning.outdoor_discipline import (
+    DisciplineStatus,
+    EnvironmentRecommendation,
+    analyze_zone_history,
+    calculate_if_deviation,
+    check_discipline,
+    generate_discipline_report,
+)
+
+
+class TestCalculateIfDeviation:
+    """Tests for IF deviation calculation."""
+
+    def test_overload(self):
+        """Positive deviation = overload."""
+        result = calculate_if_deviation(0.85, 0.75)
+        assert result == pytest.approx(13.33, abs=0.01)
+
+    def test_underload(self):
+        """Negative deviation = underload."""
+        result = calculate_if_deviation(0.70, 0.75)
+        assert result == pytest.approx(-6.67, abs=0.01)
+
+    def test_exact_match(self):
+        """No deviation."""
+        result = calculate_if_deviation(0.80, 0.80)
+        assert result == 0.0
+
+    def test_if_planned_zero(self):
+        """Division by zero protection."""
+        result = calculate_if_deviation(0.85, 0.0)
+        assert result == 0.0
+
+    def test_small_deviation(self):
+        """Small deviation within tolerance."""
+        result = calculate_if_deviation(0.82, 0.80)
+        assert result == pytest.approx(2.5, abs=0.01)
+
+
+class TestCheckDiscipline:
+    """Tests for single discipline check."""
+
+    def test_success_within_5_percent(self):
+        """IF deviation <5% → SUCCESS."""
+        check = check_discipline("Tempo ride", date(2026, 3, 1), "Tempo", "outdoor", 0.80, 0.82)
+        assert check.status == DisciplineStatus.SUCCESS
+        assert "Discipline respectée" in check.message
+
+    def test_warning_between_5_and_10(self):
+        """IF deviation 5-10% → WARNING."""
+        check = check_discipline(
+            "Sweet Spot", date(2026, 3, 1), "Sweet-Spot", "outdoor", 0.80, 0.87
+        )
+        assert check.status == DisciplineStatus.WARNING
+        assert "Discipline limite" in check.message
+
+    def test_failure_over_10_percent(self):
+        """IF deviation >10% → FAILURE."""
+        check = check_discipline("VO2 intervals", date(2026, 3, 1), "VO2", "outdoor", 0.90, 1.02)
+        assert check.status == DisciplineStatus.FAILURE
+        assert "Échec discipline" in check.message
+
+    def test_underload_warning(self):
+        """IF deviation <-10% → WARNING (sous-intensité)."""
+        check = check_discipline("FTP test", date(2026, 3, 1), "FTP", "outdoor", 0.95, 0.80)
+        assert check.status == DisciplineStatus.WARNING
+        assert "Sous-intensité" in check.message
+
+    def test_deviation_stored_in_result(self):
+        """Deviation percentage stored in result."""
+        check = check_discipline("Test", date(2026, 3, 1), "Tempo", "outdoor", 0.80, 0.90)
+        assert check.if_deviation_percent == pytest.approx(12.5, abs=0.01)
+
+
+class TestAnalyzeZoneHistory:
+    """Tests for zone history analysis."""
+
+    def _make_check(self, status, environment="outdoor"):
+        """Create a DisciplineCheck for testing."""
+        return check_discipline(
+            "Test",
+            date(2026, 3, 1),
+            "VO2",
+            environment,
+            0.90,
+            1.05 if status == DisciplineStatus.FAILURE else 0.91,
+        )
+
+    def test_no_failures_outdoor_ok(self):
+        """0 failures → OUTDOOR_OK."""
+        checks = [self._make_check(DisciplineStatus.SUCCESS)]
+        history = analyze_zone_history("VO2", checks)
+        assert history.environment_recommendation == EnvironmentRecommendation.OUTDOOR_OK
+
+    def test_one_failure_indoor_preferred(self):
+        """1 failure → INDOOR_PREFERRED."""
+        checks = [self._make_check(DisciplineStatus.FAILURE)]
+        history = analyze_zone_history("VO2", checks)
+        assert history.environment_recommendation == EnvironmentRecommendation.INDOOR_PREFERRED
+
+    def test_two_failures_indoor_required(self):
+        """2+ failures → INDOOR_REQUIRED."""
+        checks = [
+            self._make_check(DisciplineStatus.FAILURE),
+            self._make_check(DisciplineStatus.FAILURE),
+        ]
+        history = analyze_zone_history("VO2", checks)
+        assert history.environment_recommendation == EnvironmentRecommendation.INDOOR_REQUIRED
+
+    def test_no_outdoor_checks(self):
+        """No outdoor checks → OUTDOOR_OK."""
+        history = analyze_zone_history("VO2", [])
+        assert history.environment_recommendation == EnvironmentRecommendation.OUTDOOR_OK
+        assert history.total_outdoor_workouts == 0
+
+    def test_indoor_checks_ignored(self):
+        """Indoor checks not counted as outdoor failures."""
+        checks = [
+            self._make_check(DisciplineStatus.FAILURE, environment="indoor"),
+            self._make_check(DisciplineStatus.FAILURE, environment="indoor"),
+        ]
+        history = analyze_zone_history("VO2", checks)
+        assert history.environment_recommendation == EnvironmentRecommendation.OUTDOOR_OK
+        assert history.failure_count == 0
+
+    def test_custom_failure_threshold(self):
+        """Custom threshold applies."""
+        checks = [self._make_check(DisciplineStatus.FAILURE)]
+        history = analyze_zone_history("VO2", checks, failure_threshold=1)
+        assert history.environment_recommendation == EnvironmentRecommendation.INDOOR_REQUIRED
+
+
+class TestGenerateDisciplineReport:
+    """Tests for discipline report generation."""
+
+    def test_success_no_alert(self):
+        """Success → no alert message."""
+        check = check_discipline("Tempo", date(2026, 3, 1), "Tempo", "outdoor", 0.80, 0.82)
+        report = generate_discipline_report(check)
+        assert report.alert_message is None
+        assert report.overall_recommendation == EnvironmentRecommendation.OUTDOOR_OK
+
+    def test_failure_has_alert(self):
+        """Failure → alert message present."""
+        check = check_discipline("VO2", date(2026, 3, 1), "VO2", "outdoor", 0.90, 1.05)
+        report = generate_discipline_report(check)
+        assert report.alert_message is not None
+        assert "ÉCHEC DISCIPLINE" in report.alert_message
+
+    def test_failure_with_history_indoor_required(self):
+        """Failure + repeated history → INDOOR_REQUIRED with alert."""
+        check = check_discipline("VO2", date(2026, 3, 1), "VO2", "outdoor", 0.90, 1.05)
+        history = analyze_zone_history("VO2", [check, check])
+        report = generate_discipline_report(check, history)
+        assert report.overall_recommendation == EnvironmentRecommendation.INDOOR_REQUIRED
+        assert "ALERTE DISCIPLINE OUTDOOR" in report.alert_message
+        assert report.recovery_period_months == 3
+
+    def test_warning_has_alert(self):
+        """Warning → alert message with surveillance."""
+        check = check_discipline("SS", date(2026, 3, 1), "Sweet-Spot", "outdoor", 0.80, 0.87)
+        report = generate_discipline_report(check)
+        assert report.alert_message is not None
+        assert "LIMITE" in report.alert_message

--- a/tests/workflows/prompt/__init__.py
+++ b/tests/workflows/prompt/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for prompt workflow modules."""

--- a/tests/workflows/prompt/test_data_formatting_environment.py
+++ b/tests/workflows/prompt/test_data_formatting_environment.py
@@ -1,0 +1,197 @@
+"""Tests for environment detection in format_activity_data()."""
+
+from magma_cycling.workflows.prompt.data_formatting import DataFormattingMixin
+
+
+class TestEnvironmentDetection:
+    """Test indoor/outdoor detection based on activity type."""
+
+    def setup_method(self):
+        """Create a mixin instance for testing."""
+        self.formatter = DataFormattingMixin()
+
+    def _make_activity(self, activity_type=None):
+        """Create minimal activity dict."""
+        activity = {
+            "start_date_local": "2026-03-07T08:00:00",
+            "name": "Test Ride",
+        }
+        if activity_type is not None:
+            activity["type"] = activity_type
+        return activity
+
+    def test_virtual_ride_is_indoor(self):
+        """VirtualRide → indoor."""
+        result = self.formatter.format_activity_data(self._make_activity("VirtualRide"))
+        assert result["environment"] == "indoor"
+        assert result["is_indoor"] is True
+
+    def test_ride_is_outdoor(self):
+        """Ride → outdoor."""
+        result = self.formatter.format_activity_data(self._make_activity("Ride"))
+        assert result["environment"] == "outdoor"
+        assert result["is_indoor"] is False
+
+    def test_missing_type_defaults_outdoor(self):
+        """Type absent → outdoor."""
+        result = self.formatter.format_activity_data(self._make_activity())
+        assert result["environment"] == "outdoor"
+        assert result["is_indoor"] is False
+
+    def test_empty_type_is_outdoor(self):
+        """Type vide → outdoor."""
+        result = self.formatter.format_activity_data(self._make_activity(""))
+        assert result["environment"] == "outdoor"
+        assert result["is_indoor"] is False
+
+    def test_other_type_is_outdoor(self):
+        """Autre type (Run, etc.) → outdoor."""
+        result = self.formatter.format_activity_data(self._make_activity("Run"))
+        assert result["environment"] == "outdoor"
+        assert result["is_indoor"] is False
+
+
+class TestDisciplineInPrompt:
+    """Test discipline section appears in prompt for outdoor with planned workout."""
+
+    def setup_method(self):
+        """Create a mixed class for testing prompt assembly."""
+        from magma_cycling.workflows.prompt.prompt_assembly import PromptAssemblyMixin
+
+        class TestGenerator(DataFormattingMixin, PromptAssemblyMixin):
+            """Test class combining both mixins."""
+
+            def get_power_value(self, act, key):
+                return act.get(f"{key}_power", act.get("avg_power"))
+
+            def get_cadence_value(self, act, key):
+                return act.get(f"{key}_cadence", act.get("avg_cadence"))
+
+            def get_hr_value(self, act, key):
+                return act.get(f"{key}_hr", act.get("avg_hr"))
+
+            def safe_format_metric(self, value, fmt, unit):
+                if value is None:
+                    return "N/A"
+                return f"{value:{fmt}}{unit}"
+
+            def _format_feel_value(self, feel):
+                return str(feel) if feel else "N/A"
+
+            def _format_athlete_notes(self, desc, comments):
+                return desc or comments or "_Aucune note_"
+
+            def _format_temperature_data(self, avg, min_t, max_t, has_weather):
+                return "N/A"
+
+        self.generator = TestGenerator()
+
+    def _make_activity_data(self, is_indoor=False):
+        """Create formatted activity data dict."""
+        return {
+            "id": "i123",
+            "name": "Test Ride",
+            "type": "VirtualRide" if is_indoor else "Ride",
+            "date": "07/03/2026",
+            "date_iso": "2026-03-07",
+            "duration_min": 60,
+            "tss": 50,
+            "intensity": 0.85,
+            "avg_power": 200,
+            "np": 210,
+            "avg_cadence": 90,
+            "avg_hr": 140,
+            "max_hr": 165,
+            "decoupling": 3.5,
+            "avg_temp": None,
+            "min_temp": None,
+            "max_temp": None,
+            "has_weather": False,
+            "description": "",
+            "tags": [],
+            "feel": 3,
+            "is_strava": False,
+            "source": "INTERVALS",
+            "environment": "indoor" if is_indoor else "outdoor",
+            "is_indoor": is_indoor,
+        }
+
+    def _make_planned_workout(self):
+        """Create a planned workout event with workout_doc."""
+        return {
+            "name": "Sweet Spot 2x20",
+            "description": "Sweet Spot intervals",
+            "icu_training_load": 55,
+            "icu_intensity": 82,
+            "workout_doc": {
+                "duration": 3600,
+                "average_watts": 195,
+                "normalized_power": 205,
+                "joules": 0,
+                "steps": [],
+                "zoneTimes": [],
+            },
+        }
+
+    def test_outdoor_with_planned_has_discipline_section(self):
+        """Outdoor + planned workout → discipline section present."""
+        act = self._make_activity_data(is_indoor=False)
+        planned_event = self._make_planned_workout()
+
+        prompt = self.generator.generate_prompt(
+            activity_data=act,
+            wellness_pre=None,
+            wellness_post=None,
+            athlete_context="Test context",
+            recent_workouts="",
+            planned_workout=planned_event,
+        )
+
+        assert "Analyse Discipline Outdoor" in prompt
+        assert "IF prévu" in prompt
+        assert "IF réel" in prompt
+
+    def test_indoor_has_indoor_section(self):
+        """Indoor → indoor environment section present."""
+        act = self._make_activity_data(is_indoor=True)
+
+        prompt = self.generator.generate_prompt(
+            activity_data=act,
+            wellness_pre=None,
+            wellness_post=None,
+            athlete_context="Test context",
+            recent_workouts="",
+        )
+
+        assert "Indoor (Home Trainer)" in prompt
+        assert "Conditions contrôlées" in prompt
+        assert "Analyse Discipline Outdoor" not in prompt
+
+    def test_outdoor_without_planned_has_outdoor_section(self):
+        """Outdoor sans planned → section outdoor générique."""
+        act = self._make_activity_data(is_indoor=False)
+
+        prompt = self.generator.generate_prompt(
+            activity_data=act,
+            wellness_pre=None,
+            wellness_post=None,
+            athlete_context="Test context",
+            recent_workouts="",
+        )
+
+        assert "Environnement : Outdoor" in prompt
+        assert "Variables externes" in prompt
+
+    def test_environment_in_general_info(self):
+        """Environnement affiché dans Informations Générales."""
+        act = self._make_activity_data(is_indoor=True)
+
+        prompt = self.generator.generate_prompt(
+            activity_data=act,
+            wellness_pre=None,
+            wellness_post=None,
+            athlete_context="Test context",
+            recent_workouts="",
+        )
+
+        assert "**Environnement** : Indoor (Home Trainer)" in prompt


### PR DESCRIPTION
## Summary

- Detect `VirtualRide` vs `Ride` to set `environment`/`is_indoor` in `format_activity_data()`
- Add environment-aware section to AI prompt: indoor gets controlled-environment guidance, outdoor gets Peaks Coaching discipline check (IF deviation analysis)
- Activate the existing but unused `outdoor_discipline.py` module in the prompt pipeline
- Add discipline environment point to `daily_feedback.txt` mission template
- Mark ROADMAP item 3.3 Indoor/Outdoor Adaptive Analysis as resolved

## Test plan

- [x] `tests/workflows/prompt/test_data_formatting_environment.py` — 9 tests (environment detection + prompt sections)
- [x] `tests/planning/test_outdoor_discipline.py` — 20 tests (discipline check, zone history, report generation)
- [x] Full test suite: 2019 passed
- [x] Pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)