### PR TITLE
fix(prompts): remove duplicate heading in outdoor discipline section

### DIFF
--- a/magma_cycling/workflows/prompt/prompt_assembly.py
+++ b/magma_cycling/workflows/prompt/prompt_assembly.py
@@ -354,7 +354,7 @@ Pas de variables externes (vent, terrain, trafic). L'adhérence au plan doit êt
             discipline_md = format_discipline_report(report)
 
             return f"""
-## 🌳 {discipline_md}
+{discipline_md}
 
 **Consigne** : En outdoor, évaluer la capacité à respecter l'intensité cible.
 Déviation >10% = échec discipline (surcharge). Recommander indoor si récidive.


### PR DESCRIPTION
## Summary

- Fix `## 🌳 ## Analyse Discipline Outdoor` double heading
- `format_discipline_report()` already produces a `##` heading, the wrapper added another one

## Test plan

- [x] 29 tests pass
- [x] Verified with simulated outdoor activity: heading now clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)