### PR TITLE
feat(servo): add rest_day action to planning servo control

### DIFF
--- a/magma_cycling/update_session_status.py
+++ b/magma_cycling/update_session_status.py
@@ -43,7 +43,7 @@ from magma_cycling.config import create_intervals_client
 from magma_cycling.planning.control_tower import planning_tower
 
 # Statuses that should remove the event from Intervals.icu
-STATUSES_TO_DELETE = ["cancelled", "skipped", "replaced"]
+STATUSES_TO_DELETE = ["cancelled", "skipped", "replaced", "rest_day"]
 
 
 def find_event_by_session(
@@ -113,7 +113,10 @@ def sync_with_intervals(
             print(f"   Found event: {event_name} (ID: {event_id}, Type: {event_category})")
 
             # Check if already marked as cancelled/skipped/replaced
-            if any(event_name.startswith(tag) for tag in ["[ANNULÉE]", "[SAUTÉE]", "[REMPLACÉE]"]):
+            if any(
+                event_name.startswith(tag)
+                for tag in ["[ANNULÉE]", "[SAUTÉE]", "[REMPLACÉE]", "[REPOS]"]
+            ):
                 print(f"   ℹ️  Event already marked (current: {event_name.split(']')[0]}])")
                 return True
 
@@ -124,6 +127,9 @@ def sync_with_intervals(
             elif new_status == "skipped":
                 status_emoji = "⏭️"
                 status_text = "SAUTÉE"
+            elif new_status == "rest_day":
+                status_emoji = "😴"
+                status_text = "REPOS"
             else:  # replaced
                 status_emoji = "🔄"
                 status_text = "REMPLACÉE"
@@ -168,6 +174,9 @@ def sync_with_intervals(
             elif new_status == "skipped":
                 status_emoji = "⏭️"
                 status_text = "SAUTÉE"
+            elif new_status == "rest_day":
+                status_emoji = "😴"
+                status_text = "REPOS"
             else:  # replaced
                 status_emoji = "🔄"
                 status_text = "REMPLACÉE"

--- a/magma_cycling/workflows/coach/servo_control.py
+++ b/magma_cycling/workflows/coach/servo_control.py
@@ -156,6 +156,114 @@ class ServoControlMixin:
         else:
             print("   ⚠️  Échec mise à jour planning JSON")
 
+    def _apply_rest_day(self, mod: dict, week_id: str):
+        """Applique conversion en jour de repos.
+
+        Args:
+            mod: Modification dict avec target_date, current_workout, reason
+            week_id: ID semaine.
+        """
+        import sys
+
+        print("\n😴 Conversion en jour de repos")
+        print(f"   Date : {mod['target_date']}")
+        print(f"   Séance remplacée : {mod.get('current_workout', 'N/A')}")
+        print(f"   Raison : {mod['reason']}")
+
+        # Check if non-interactive mode (LaunchAgent or auto_mode)
+        is_non_interactive = self.auto_mode or not sys.stdin.isatty()
+
+        if is_non_interactive:
+            print("   ℹ️  Mode automatique : recommandation enregistrée (pas d'application)")
+            print("   💡 Lancer manuellement : poetry run workflow-coach --servo-mode")
+            if not hasattr(self, "_servo_recommendations"):
+                self._servo_recommendations = []
+            self._servo_recommendations.append(
+                {
+                    "action": "rest_day",
+                    "date": mod["target_date"],
+                    "current_workout": mod.get("current_workout", "N/A"),
+                    "reason": mod["reason"],
+                    "status": "pending_manual_application",
+                }
+            )
+            return
+
+        # Interactive mode: Ask for confirmation
+        confirm = input("   Appliquer repos ? (o/n) : ").strip().lower()
+        if confirm != "o":
+            print("   ❌ Ignoré")
+            return
+
+        self._execute_rest_day(mod, week_id)
+
+    def _execute_rest_day(self, mod: dict, week_id: str):
+        """Exécute la conversion en jour de repos (planning + Intervals.icu).
+
+        Args:
+            mod: Modification dict
+            week_id: ID semaine.
+        """
+        from magma_cycling.config import create_intervals_client
+        from magma_cycling.update_session_status import sync_with_intervals
+
+        target_date = mod["target_date"]
+        reason = mod["reason"]
+
+        # 1. Update planning JSON via Control Tower
+        try:
+            with planning_tower.modify_week(
+                week_id,
+                requesting_script="workflow-coach",
+                reason=f"AI Coach rest_day: {mod.get('current_workout', 'N/A')} → repos ({reason})",
+            ) as plan:
+                session_found = False
+                session_info = None
+                session_id = None
+                for session in plan.planned_sessions:
+                    if str(session.session_date) == target_date:
+                        session_id = session.session_id
+                        session_info = {
+                            "name": session.name,
+                            "type": session.session_type,
+                            "version": session.version,
+                            "description": session.description,
+                            "tss_planned": session.tss_planned,
+                            "duration_min": session.duration_min,
+                        }
+                        session.status = "rest_day"
+                        session.skip_reason = reason
+                        session_found = True
+                        break
+
+                if not session_found:
+                    print(f"   ⚠️  Session non trouvée pour date {target_date}")
+                    return
+
+            print("   📝 Planning JSON mis à jour (status=rest_day)")
+        except Exception as e:
+            print(f"   ⚠️  Erreur mise à jour planning : {e}")
+            return
+
+        # 2. Sync with Intervals.icu (convert WORKOUT → NOTE [REPOS])
+        try:
+            client = create_intervals_client()
+            sync_success = sync_with_intervals(
+                client=client,
+                session_id=session_id,
+                session_date=target_date,
+                new_status="rest_day",
+                reason=reason,
+                session_info=session_info,
+            )
+            if sync_success:
+                print("   ✅ Jour de repos appliqué")
+            else:
+                print("   ⚠️  Sync Intervals.icu échouée (planning local mis à jour)")
+        except Exception as e:
+            print(f"   ⚠️  Erreur sync Intervals.icu : {e}")
+            print("   📝 Planning local mis à jour (sync manuelle nécessaire)")
+
     def apply_planning_modifications(self, modifications: list, week_id: str):
         """Applique modifications planning.
 
@@ -174,9 +282,8 @@ class ServoControlMixin:
 
             if action == "lighten":
                 self._apply_lighten(mod, week_id)
-            elif action == "cancel":
-                # TODO: Implémenter cancel si nécessaire
-                print(f"⚠️  Action 'cancel' non implémentée: {mod}")
+            elif action in ("rest_day", "cancel"):
+                self._apply_rest_day(mod, week_id)
             elif action == "reschedule":
                 # TODO: Implémenter reschedule si nécessaire
                 print(f"⚠️  Action 'reschedule' non implémentée: {mod}")
@@ -326,6 +433,16 @@ Critères de décision:
   "current_workout": "CODE",
   "template_id": "recovery_active_30tss",
   "reason": "Découplage 11.2%, prioriser récupération"
+}}]}}
+```
+
+**Action `rest_day`** (convertir séance en jour de repos) :
+```json
+{{"modifications": [{{
+  "action": "rest_day",
+  "target_date": "YYYY-MM-DD",
+  "current_workout": "CODE",
+  "reason": "TSB -22, sommeil 4.8h, récupération prioritaire"
 }}]}}
 ```
 

--- a/magma_cycling/workflows/sync/servo_evaluation.py
+++ b/magma_cycling/workflows/sync/servo_evaluation.py
@@ -180,6 +180,76 @@ class ServoEvaluationMixin:
 
         return should_trigger, reasons
 
+    def _apply_auto_rest_day(self, mod: dict, week_id: str):
+        """Applique automatiquement un jour de repos (daily-sync non-interactif).
+
+        Args:
+            mod: Modification dict avec target_date, current_workout, reason
+            week_id: ID semaine.
+        """
+        from magma_cycling.config import create_intervals_client
+        from magma_cycling.planning.control_tower import planning_tower
+        from magma_cycling.update_session_status import sync_with_intervals
+
+        target_date = mod.get("target_date", "N/A")
+        reason = mod.get("reason", "N/A")
+
+        print(f"\n  😴 Application automatique repos : {target_date}")
+        print(f"     Raison : {reason}")
+
+        # 1. Update planning JSON
+        try:
+            with planning_tower.modify_week(
+                week_id,
+                requesting_script="daily-sync",
+                reason=f"Auto rest_day: {mod.get('current_workout', 'N/A')} → repos ({reason})",
+            ) as plan:
+                session_found = False
+                session_info = None
+                session_id = None
+                for session in plan.planned_sessions:
+                    if str(session.session_date) == target_date:
+                        session_id = session.session_id
+                        session_info = {
+                            "name": session.name,
+                            "type": session.session_type,
+                            "version": session.version,
+                            "description": session.description,
+                            "tss_planned": session.tss_planned,
+                            "duration_min": session.duration_min,
+                        }
+                        session.status = "rest_day"
+                        session.skip_reason = reason
+                        session_found = True
+                        break
+
+                if not session_found:
+                    print(f"     ⚠️  Session non trouvée pour date {target_date}")
+                    return
+
+            print("     📝 Planning JSON mis à jour (status=rest_day)")
+        except Exception as e:
+            print(f"     ⚠️  Erreur mise à jour planning : {e}")
+            return
+
+        # 2. Sync with Intervals.icu
+        try:
+            client = create_intervals_client()
+            sync_success = sync_with_intervals(
+                client=client,
+                session_id=session_id,
+                session_date=target_date,
+                new_status="rest_day",
+                reason=reason,
+                session_info=session_info,
+            )
+            if sync_success:
+                print("     ✅ Jour de repos appliqué automatiquement")
+            else:
+                print("     ⚠️  Sync Intervals.icu échouée (planning local mis à jour)")
+        except Exception as e:
+            print(f"     ⚠️  Erreur sync Intervals.icu : {e}")
+
     def run_servo_adjustment(
         self, week_id: str, activity: dict, metrics: dict, analysis: str | None
     ) -> dict | None:
@@ -289,6 +359,16 @@ Critères de décision:
 }}]}}
 ```
 
+**Action `rest_day`** (convertir séance en jour de repos) :
+```json
+{{"modifications": [{{
+  "action": "rest_day",
+  "target_date": "YYYY-MM-DD",
+  "current_workout": "CODE",
+  "reason": "TSB -22, sommeil 4.8h, récupération prioritaire"
+}}]}}
+```
+
 **Si aucune modification nécessaire** : Ne rien ajouter (pas de JSON).
 
 Réponds maintenant."""
@@ -320,6 +400,11 @@ Réponds maintenant."""
                     target_date = mod.get("target_date", "N/A")
                     reason = mod.get("reason", "N/A")
                     print(f"  • {target_date}: {action} - {reason}")
+
+                # Auto-apply rest_day/cancel actions (daily-sync is non-interactive)
+                for mod in modifications:
+                    if mod.get("action") in ("rest_day", "cancel"):
+                        self._apply_auto_rest_day(mod, week_id)
             else:
                 print("✅ Aucune modification recommandée - planning maintenu")
 

--- a/project-docs/ROADMAP.md
+++ b/project-docs/ROADMAP.md
@@ -181,7 +181,7 @@ prompts/
 | Workflow Diversity Integration (S4) | P1 | 2-3h | 📋 Planifié |
 | Test History Tracking | P2 | 2-4h | 📋 Backlog |
 | Indoor/Outdoor Adaptive Analysis | P1 | 3-4h | ✅ Résolu |
-| Auto-rest: directives récup → statut planning | P2 | 4-6h | 📋 Backlog |
+| Auto-rest: directives récup → statut planning | P2 | 4-6h | ✅ Résolu |
 
 ---
 

--- a/tests/workflows/test_servo_auto_rest.py
+++ b/tests/workflows/test_servo_auto_rest.py
@@ -1,0 +1,251 @@
+"""Tests for auto rest_day application in daily-sync servo evaluation."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.planning.models import WeeklyPlan
+from magma_cycling.update_session_status import STATUSES_TO_DELETE, sync_with_intervals
+
+
+@pytest.fixture
+def planning_data():
+    """Sample planning data with sessions."""
+    return {
+        "week_id": "S999",
+        "start_date": "2026-03-02",
+        "end_date": "2026-03-08",
+        "created_at": "2026-02-01T20:00:00Z",
+        "last_updated": "2026-02-01T20:00:00Z",
+        "version": 1,
+        "athlete_id": "iXXXXXX",
+        "tss_target": 350,
+        "planned_sessions": [
+            {
+                "session_id": "S999-01",
+                "date": "2026-03-02",
+                "name": "Endurance",
+                "type": "END",
+                "version": "V001",
+                "tss_planned": 50,
+                "duration_min": 60,
+                "description": "Endurance Z2",
+                "status": "planned",
+                "intervals_id": None,
+                "description_hash": None,
+            },
+            {
+                "session_id": "S999-02",
+                "date": "2026-03-03",
+                "name": "Interval",
+                "type": "INT",
+                "version": "V001",
+                "tss_planned": 70,
+                "duration_min": 65,
+                "description": "Sweet Spot 3x10",
+                "status": "planned",
+                "intervals_id": 12345,
+                "description_hash": None,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_control_tower(tmp_path, planning_data):
+    """Mock Control Tower to use tmp_path for planning."""
+    from magma_cycling.planning.control_tower import planning_tower
+
+    original_planning_dir = planning_tower.planning_dir
+    planning_tower.planning_dir = tmp_path
+    planning_tower.backup_system.planning_dir = tmp_path
+
+    planning_file = tmp_path / "week_planning_S999.json"
+    with open(planning_file, "w", encoding="utf-8") as f:
+        json.dump(planning_data, f, indent=2)
+
+    yield tmp_path
+
+    planning_tower.planning_dir = original_planning_dir
+    planning_tower.backup_system.planning_dir = original_planning_dir
+
+
+class TestAutoRestDayApplication:
+    """Test daily-sync auto-applies rest_day."""
+
+    @patch("magma_cycling.config.create_intervals_client")
+    @patch("magma_cycling.update_session_status.sync_with_intervals")
+    def test_auto_rest_day_updates_planning(self, mock_sync, mock_client, mock_control_tower):
+        """Test _apply_auto_rest_day updates planning JSON."""
+        from magma_cycling.workflows.sync.servo_evaluation import (
+            ServoEvaluationMixin,
+        )
+
+        mock_sync.return_value = True
+        mock_client.return_value = MagicMock()
+
+        mixin = ServoEvaluationMixin()
+        mod = {
+            "action": "rest_day",
+            "target_date": "2026-03-03",
+            "current_workout": "S999-02-INT-Interval-V001",
+            "reason": "TSB -22, sommeil 4.8h",
+        }
+
+        mixin._apply_auto_rest_day(mod, "S999")
+
+        # Verify planning JSON updated
+        planning_file = mock_control_tower / "week_planning_S999.json"
+        plan = WeeklyPlan.from_json(planning_file)
+        session = plan.planned_sessions[1]
+        assert session.status == "rest_day"
+        assert session.skip_reason == "TSB -22, sommeil 4.8h"
+
+        # Verify sync called with correct params
+        mock_sync.assert_called_once()
+        call_kwargs = mock_sync.call_args[1]
+        assert call_kwargs["new_status"] == "rest_day"
+        assert call_kwargs["session_id"] == "S999-02"
+        assert call_kwargs["session_date"] == "2026-03-03"
+
+    @patch("magma_cycling.config.create_intervals_client")
+    @patch("magma_cycling.update_session_status.sync_with_intervals")
+    def test_auto_rest_day_session_not_found(self, mock_sync, mock_client, mock_control_tower):
+        """Test _apply_auto_rest_day handles missing session gracefully."""
+        from magma_cycling.workflows.sync.servo_evaluation import (
+            ServoEvaluationMixin,
+        )
+
+        mixin = ServoEvaluationMixin()
+        mod = {
+            "action": "rest_day",
+            "target_date": "2026-03-09",
+            "current_workout": "S999-99",
+            "reason": "Fatigue",
+        }
+
+        # Should not raise
+        mixin._apply_auto_rest_day(mod, "S999")
+
+        # Sync should not be called (session not found)
+        mock_sync.assert_not_called()
+
+    @patch("magma_cycling.config.create_intervals_client")
+    @patch("magma_cycling.update_session_status.sync_with_intervals")
+    def test_cancel_treated_as_rest_day(self, mock_sync, mock_client, mock_control_tower):
+        """Test that cancel action is treated same as rest_day."""
+        from magma_cycling.workflows.sync.servo_evaluation import (
+            ServoEvaluationMixin,
+        )
+
+        mock_sync.return_value = True
+        mock_client.return_value = MagicMock()
+
+        mixin = ServoEvaluationMixin()
+        mod = {
+            "action": "cancel",
+            "target_date": "2026-03-03",
+            "current_workout": "S999-02",
+            "reason": "Blessure",
+        }
+
+        mixin._apply_auto_rest_day(mod, "S999")
+
+        # Planning should be updated with rest_day status
+        planning_file = mock_control_tower / "week_planning_S999.json"
+        plan = WeeklyPlan.from_json(planning_file)
+        session = plan.planned_sessions[1]
+        assert session.status == "rest_day"
+
+
+class TestSyncIntervalsRestDay:
+    """Test sync_with_intervals handles rest_day status."""
+
+    def test_rest_day_in_statuses_to_delete(self):
+        """Test rest_day is in STATUSES_TO_DELETE."""
+        assert "rest_day" in STATUSES_TO_DELETE
+
+    def test_sync_rest_day_converts_to_note(self):
+        """Test rest_day converts event to NOTE with [REPOS] tag."""
+        mock_client = MagicMock()
+        mock_client.get_events.return_value = [
+            {
+                "id": 42,
+                "name": "S999-02-INT-Interval-V001",
+                "category": "WORKOUT",
+                "description": "Sweet Spot 3x10",
+            }
+        ]
+        mock_client.update_event.return_value = True
+
+        result = sync_with_intervals(
+            client=mock_client,
+            session_id="S999-02",
+            session_date="2026-03-03",
+            new_status="rest_day",
+            reason="TSB -22, sommeil 4.8h",
+        )
+
+        assert result is True
+        mock_client.update_event.assert_called_once()
+        call_args = mock_client.update_event.call_args
+        update_data = call_args[0][1]
+        assert update_data["name"] == "[REPOS] S999-02-INT-Interval-V001"
+        assert update_data["category"] == "NOTE"
+        assert "😴 SÉANCE REPOS" in update_data["description"]
+        assert "TSB -22, sommeil 4.8h" in update_data["description"]
+
+    def test_sync_rest_day_creates_note_when_no_event(self):
+        """Test rest_day creates NOTE when no event exists."""
+        mock_client = MagicMock()
+        mock_client.get_events.return_value = []
+        mock_client.create_event.return_value = {"id": 99}
+
+        session_info = {
+            "name": "Interval",
+            "type": "INT",
+            "version": "V001",
+            "description": "Sweet Spot 3x10",
+            "tss_planned": 70,
+            "duration_min": 65,
+        }
+
+        result = sync_with_intervals(
+            client=mock_client,
+            session_id="S999-02",
+            session_date="2026-03-03",
+            new_status="rest_day",
+            reason="Fatigue accumulée",
+            session_info=session_info,
+        )
+
+        assert result is True
+        mock_client.create_event.assert_called_once()
+        call_args = mock_client.create_event.call_args
+        event_data = call_args[0][0]
+        assert event_data["name"] == "[REPOS] S999-02-INT-Interval-V001"
+        assert event_data["category"] == "NOTE"
+        assert "😴 SÉANCE REPOS" in event_data["description"]
+
+    def test_sync_rest_day_skips_already_tagged(self):
+        """Test rest_day skips event already tagged [REPOS]."""
+        mock_client = MagicMock()
+        mock_client.get_events.return_value = [
+            {
+                "id": 42,
+                "name": "[REPOS] S999-02-INT-Interval-V001",
+                "category": "NOTE",
+                "description": "Already repos",
+            }
+        ]
+
+        result = sync_with_intervals(
+            client=mock_client,
+            session_id="S999-02",
+            session_date="2026-03-03",
+            new_status="rest_day",
+        )
+
+        assert result is True
+        mock_client.update_event.assert_not_called()

--- a/tests/workflows/test_servo_rest_day.py
+++ b/tests/workflows/test_servo_rest_day.py
@@ -1,0 +1,247 @@
+"""Tests for rest_day action in servo control (workflow-coach)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.planning.models import WeeklyPlan
+
+
+@pytest.fixture
+def planning_data():
+    """Sample planning data with sessions."""
+    return {
+        "week_id": "S999",
+        "start_date": "2026-03-02",
+        "end_date": "2026-03-08",
+        "created_at": "2026-02-01T20:00:00Z",
+        "last_updated": "2026-02-01T20:00:00Z",
+        "version": 1,
+        "athlete_id": "iXXXXXX",
+        "tss_target": 350,
+        "planned_sessions": [
+            {
+                "session_id": "S999-01",
+                "date": "2026-03-02",
+                "name": "Endurance",
+                "type": "END",
+                "version": "V001",
+                "tss_planned": 50,
+                "duration_min": 60,
+                "description": "Endurance Z2",
+                "status": "planned",
+                "intervals_id": None,
+                "description_hash": None,
+            },
+            {
+                "session_id": "S999-02",
+                "date": "2026-03-03",
+                "name": "Interval",
+                "type": "INT",
+                "version": "V001",
+                "tss_planned": 70,
+                "duration_min": 65,
+                "description": "Sweet Spot 3x10",
+                "status": "planned",
+                "intervals_id": 12345,
+                "description_hash": None,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_control_tower(tmp_path, planning_data):
+    """Mock Control Tower to use tmp_path for planning."""
+    from magma_cycling.planning.control_tower import planning_tower
+
+    original_planning_dir = planning_tower.planning_dir
+    planning_tower.planning_dir = tmp_path
+    planning_tower.backup_system.planning_dir = tmp_path
+
+    planning_file = tmp_path / "week_planning_S999.json"
+    with open(planning_file, "w", encoding="utf-8") as f:
+        json.dump(planning_data, f, indent=2)
+
+    yield tmp_path
+
+    planning_tower.planning_dir = original_planning_dir
+    planning_tower.backup_system.planning_dir = original_planning_dir
+
+
+class TestApplyRestDay:
+    """Test _apply_rest_day updates planning JSON with status=rest_day."""
+
+    def test_rest_day_updates_planning_json(self, mock_control_tower):
+        """Test that rest_day sets session.status to rest_day in planning."""
+        from magma_cycling.workflows.coach.servo_control import ServoControlMixin
+
+        mixin = ServoControlMixin()
+        mod = {
+            "action": "rest_day",
+            "target_date": "2026-03-03",
+            "current_workout": "S999-02-INT-Interval-V001",
+            "reason": "TSB -22, sommeil 4.8h",
+        }
+
+        with patch.object(mixin, "auto_mode", True, create=True):
+            mixin._apply_rest_day(mod, "S999")
+
+        # In auto_mode, recommendation is stored but not applied
+        assert hasattr(mixin, "_servo_recommendations")
+        assert len(mixin._servo_recommendations) == 1
+        assert mixin._servo_recommendations[0]["action"] == "rest_day"
+
+    @patch("magma_cycling.config.create_intervals_client")
+    @patch("magma_cycling.update_session_status.sync_with_intervals")
+    def test_execute_rest_day_updates_planning(self, mock_sync, mock_client, mock_control_tower):
+        """Test _execute_rest_day updates planning and syncs Intervals.icu."""
+        from magma_cycling.workflows.coach.servo_control import ServoControlMixin
+
+        mock_sync.return_value = True
+        mock_client.return_value = MagicMock()
+
+        mixin = ServoControlMixin()
+        mod = {
+            "action": "rest_day",
+            "target_date": "2026-03-03",
+            "current_workout": "S999-02-INT-Interval-V001",
+            "reason": "TSB -22, sommeil 4.8h",
+        }
+
+        mixin._execute_rest_day(mod, "S999")
+
+        # Verify planning JSON updated
+        planning_file = mock_control_tower / "week_planning_S999.json"
+        plan = WeeklyPlan.from_json(planning_file)
+        session = plan.planned_sessions[1]
+        assert session.status == "rest_day"
+        assert session.skip_reason == "TSB -22, sommeil 4.8h"
+
+        # Verify sync called
+        mock_sync.assert_called_once()
+        call_kwargs = mock_sync.call_args[1]
+        assert call_kwargs["new_status"] == "rest_day"
+        assert call_kwargs["session_id"] == "S999-02"
+
+
+class TestApplyRestDayNonInteractive:
+    """Test rest_day in non-interactive mode (auto_mode)."""
+
+    def test_auto_mode_stores_recommendation(self, mock_control_tower):
+        """Test that auto_mode stores recommendation without applying."""
+        from magma_cycling.workflows.coach.servo_control import ServoControlMixin
+
+        mixin = ServoControlMixin()
+        mixin.auto_mode = True
+        mod = {
+            "action": "rest_day",
+            "target_date": "2026-03-03",
+            "current_workout": "S999-02-INT",
+            "reason": "Fatigue accumulée",
+        }
+
+        mixin._apply_rest_day(mod, "S999")
+
+        assert hasattr(mixin, "_servo_recommendations")
+        assert len(mixin._servo_recommendations) == 1
+        rec = mixin._servo_recommendations[0]
+        assert rec["action"] == "rest_day"
+        assert rec["status"] == "pending_manual_application"
+        assert rec["date"] == "2026-03-03"
+
+    @patch("sys.stdin")
+    def test_non_tty_stores_recommendation(self, mock_stdin, mock_control_tower):
+        """Test that non-tty mode stores recommendation."""
+        from magma_cycling.workflows.coach.servo_control import ServoControlMixin
+
+        mock_stdin.isatty.return_value = False
+
+        mixin = ServoControlMixin()
+        mixin.auto_mode = False
+        mod = {
+            "action": "rest_day",
+            "target_date": "2026-03-03",
+            "current_workout": "S999-02-INT",
+            "reason": "Sommeil < 5h",
+        }
+
+        mixin._apply_rest_day(mod, "S999")
+
+        assert hasattr(mixin, "_servo_recommendations")
+        assert len(mixin._servo_recommendations) == 1
+
+
+class TestServoPromptContainsRestDay:
+    """Test that servo prompt documents the rest_day action."""
+
+    def test_coach_prompt_contains_rest_day(self):
+        """Test workflow-coach servo prompt includes rest_day action."""
+        import inspect
+
+        from magma_cycling.workflows.coach.servo_control import ServoControlMixin
+
+        source = inspect.getsource(ServoControlMixin.step_6b_servo_control)
+        assert '"action": "rest_day"' in source
+        assert "rest_day" in source
+
+    def test_sync_prompt_contains_rest_day(self):
+        """Test daily-sync servo prompt includes rest_day action."""
+        import inspect
+
+        from magma_cycling.workflows.sync.servo_evaluation import ServoEvaluationMixin
+
+        source = inspect.getsource(ServoEvaluationMixin.run_servo_adjustment)
+        assert '"action": "rest_day"' in source
+        assert "rest_day" in source
+
+
+class TestApplyPlanningModificationsRouting:
+    """Test that apply_planning_modifications routes rest_day and cancel correctly."""
+
+    @patch.object(
+        __import__(
+            "magma_cycling.workflows.coach.servo_control", fromlist=["ServoControlMixin"]
+        ).ServoControlMixin,
+        "_apply_rest_day",
+    )
+    def test_rest_day_routed(self, mock_apply_rest_day):
+        """Test rest_day action is routed to _apply_rest_day."""
+        from magma_cycling.workflows.coach.servo_control import ServoControlMixin
+
+        mixin = ServoControlMixin()
+        modifications = [
+            {
+                "action": "rest_day",
+                "target_date": "2026-03-03",
+                "current_workout": "CODE",
+                "reason": "Fatigue",
+            }
+        ]
+
+        mixin.apply_planning_modifications(modifications, "S999")
+        mock_apply_rest_day.assert_called_once_with(modifications[0], "S999")
+
+    @patch.object(
+        __import__(
+            "magma_cycling.workflows.coach.servo_control", fromlist=["ServoControlMixin"]
+        ).ServoControlMixin,
+        "_apply_rest_day",
+    )
+    def test_cancel_routed_to_rest_day(self, mock_apply_rest_day):
+        """Test cancel action is routed to _apply_rest_day (same treatment)."""
+        from magma_cycling.workflows.coach.servo_control import ServoControlMixin
+
+        mixin = ServoControlMixin()
+        modifications = [
+            {
+                "action": "cancel",
+                "target_date": "2026-03-03",
+                "current_workout": "CODE",
+                "reason": "Blessure",
+            }
+        ]
+
+        mixin.apply_planning_modifications(modifications, "S999")
+        mock_apply_rest_day.assert_called_once_with(modifications[0], "S999")


### PR DESCRIPTION
## Summary

- Add `rest_day` and `cancel` actions to servo control (previously TODO)
- AI coach can now recommend converting a session to a rest day
- Interactive mode (workflow-coach): asks confirmation before applying
- Non-interactive mode (daily-sync): applies automatically
- Intervals.icu sync: converts WORKOUT → NOTE with `[REPOS]` tag

## Changes

| File | Change |
|------|--------|
| `workflows/coach/servo_control.py` | +`_apply_rest_day()`, +`_execute_rest_day()`, route `rest_day`+`cancel` |
| `workflows/sync/servo_evaluation.py` | +`rest_day` in prompt, +`_apply_auto_rest_day()` |
| `update_session_status.py` | +`rest_day` in `STATUSES_TO_DELETE` + `[REPOS]` mapping |
| `tests/workflows/test_servo_rest_day.py` | 8 tests (routing, interactive, non-interactive, prompt) |
| `tests/workflows/test_servo_auto_rest.py` | 7 tests (auto-apply, sync, NOTE conversion) |
| `project-docs/ROADMAP.md` | Section 3.3: Auto-rest → ✅ Résolu |

## Test plan

- [x] 15 new tests all passing
- [x] Full test suite: 2034 passed
- [x] Pre-commit: 15/15 hooks passing
- [x] Servo prompt contains `rest_day` action documentation
- [x] `sync_with_intervals()` handles `rest_day` → NOTE `[REPOS]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)