### PR TITLE
feat(withings): detect sleep fragmentation from multi-segment nights

### DIFF
--- a/magma_cycling/_mcp/handlers/withings.py
+++ b/magma_cycling/_mcp/handlers/withings.py
@@ -216,6 +216,22 @@ async def handle_withings_get_readiness(args: dict) -> list[TextContent]:
                 "readiness": readiness.model_dump(),
             }
 
+            # Sleep fragmentation warning
+            sleep = provider.get_sleep_summary(eval_date)
+            seg_count = getattr(sleep, "segments_count", None)
+            if sleep and isinstance(seg_count, int) and seg_count > 1 and sleep.segments_detail:
+                detail = " + ".join(f"{s['start']}\u2192{s['end']}" for s in sleep.segments_detail)
+                first_seg = sleep.segments_detail[0]
+                dur_h = int(first_seg["duration_hours"])
+                dur_m = int((first_seg["duration_hours"] % 1) * 60)
+                result["sleep_fragmentation"] = (
+                    f"Nuit multi-segments d\u00e9tect\u00e9e "
+                    f"({sleep.segments_count} segments fusionn\u00e9s). "
+                    f"L\u2019app mobile Withings peut afficher uniquement le "
+                    f"premier segment ({dur_h}h{dur_m:02d}) "
+                    f"\u2014 les donn\u00e9es Magma sont correctes ({detail})."
+                )
+
     return mcp_response(result, default=str)
 
 

--- a/magma_cycling/api/withings_client.py
+++ b/magma_cycling/api/withings_client.py
@@ -545,8 +545,139 @@ class WithingsClient:
                 }
             )
 
+        # Aggregate segments by sleep_date
+        sleep_sessions = self._aggregate_sleep_segments(sleep_sessions)
+
         logger.info(f"Retrieved {len(sleep_sessions)} sleep sessions")
         return sleep_sessions
+
+    @staticmethod
+    def _aggregate_sleep_segments(
+        sessions: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Aggregate multiple Withings segments that belong to the same night.
+
+        Withings may split a single night into multiple segments (e.g. 22h→01h30
+        + 01h30→07h). This method merges them into one session per date.
+        """
+        from collections import defaultdict
+
+        by_date: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for s in sessions:
+            by_date[s["date"]].append(s)
+
+        result: list[dict[str, Any]] = []
+        for sleep_date, segments in sorted(by_date.items()):
+            if len(segments) == 1:
+                segments[0]["segments_count"] = 1
+                result.append(segments[0])
+                continue
+
+            # Sort segments by start time
+            segments.sort(key=lambda s: s["start_datetime"])
+
+            merged: dict[str, Any] = {
+                "date": sleep_date,
+                "start_datetime": min(s["start_datetime"] for s in segments),
+                "end_datetime": max(s["end_datetime"] for s in segments),
+            }
+
+            # Sum durations
+            merged["total_sleep_hours"] = round(sum(s["total_sleep_hours"] for s in segments), 2)
+
+            # Sum sleep stages (skip None)
+            for key in ("deep_sleep_minutes", "light_sleep_minutes", "rem_sleep_minutes"):
+                values = [s[key] for s in segments if s.get(key) is not None]
+                merged[key] = round(sum(values), 1) if values else None
+
+            # Sum counts
+            merged["wakeup_count"] = sum(s.get("wakeup_count", 0) for s in segments)
+            merged["wakeup_minutes"] = None
+            wakeup_vals = [s["wakeup_minutes"] for s in segments if s.get("wakeup_minutes")]
+            if wakeup_vals:
+                merged["wakeup_minutes"] = round(sum(wakeup_vals), 1)
+
+            merged["out_of_bed_count"] = None
+            oob_vals = [s["out_of_bed_count"] for s in segments if s.get("out_of_bed_count")]
+            if oob_vals:
+                merged["out_of_bed_count"] = sum(oob_vals)
+
+            # First non-None for scores
+            merged["sleep_score"] = next(
+                (s["sleep_score"] for s in segments if s.get("sleep_score") is not None), None
+            )
+            merged["sleep_efficiency"] = next(
+                (s["sleep_efficiency"] for s in segments if s.get("sleep_efficiency") is not None),
+                None,
+            )
+
+            # HR: min/max/weighted average
+            hr_mins = [s["hr_min"] for s in segments if s.get("hr_min") is not None]
+            hr_maxs = [s["hr_max"] for s in segments if s.get("hr_max") is not None]
+            merged["hr_min"] = min(hr_mins) if hr_mins else None
+            merged["hr_max"] = max(hr_maxs) if hr_maxs else None
+
+            hr_avgs = [
+                (s["hr_average"], s["total_sleep_hours"])
+                for s in segments
+                if s.get("hr_average") is not None and s["total_sleep_hours"] > 0
+            ]
+            if hr_avgs:
+                total_dur = sum(d for _, d in hr_avgs)
+                merged["hr_average"] = round(sum(v * d for v, d in hr_avgs) / total_dur)
+            else:
+                merged["hr_average"] = None
+
+            # RR: min/max/weighted average
+            rr_mins = [s["rr_min"] for s in segments if s.get("rr_min") is not None]
+            rr_maxs = [s["rr_max"] for s in segments if s.get("rr_max") is not None]
+            merged["rr_min"] = min(rr_mins) if rr_mins else None
+            merged["rr_max"] = max(rr_maxs) if rr_maxs else None
+
+            rr_avgs = [
+                (s["rr_average"], s["total_sleep_hours"])
+                for s in segments
+                if s.get("rr_average") is not None and s["total_sleep_hours"] > 0
+            ]
+            if rr_avgs:
+                total_dur = sum(d for _, d in rr_avgs)
+                merged["rr_average"] = round(sum(v * d for v, d in rr_avgs) / total_dur, 1)
+            else:
+                merged["rr_average"] = None
+
+            # Sleep latency from first segment only
+            merged["sleep_latency_min"] = segments[0].get("sleep_latency_min")
+
+            # Breathing disturbances: first non-None
+            merged["breathing_disturbances"] = next(
+                (
+                    s["breathing_disturbances"]
+                    for s in segments
+                    if s.get("breathing_disturbances") is not None
+                ),
+                None,
+            )
+
+            # Fragmentation metadata
+            merged["segments_count"] = len(segments)
+            merged["segments_detail"] = []
+            for seg in segments:
+                start_str = seg["start_datetime"]
+                end_str = seg["end_datetime"]
+                # Parse ISO strings to extract HH:MM
+                start_hm = start_str[11:16] if len(start_str) >= 16 else start_str
+                end_hm = end_str[11:16] if len(end_str) >= 16 else end_str
+                merged["segments_detail"].append(
+                    {
+                        "start": start_hm,
+                        "end": end_hm,
+                        "duration_hours": seg["total_sleep_hours"],
+                    }
+                )
+
+            result.append(merged)
+
+        return result
 
     def get_last_night_sleep(self) -> dict[str, Any] | None:
         """Get last night's sleep data.

--- a/magma_cycling/models/withings_models.py
+++ b/magma_cycling/models/withings_models.py
@@ -79,6 +79,15 @@ class SleepData(BaseModel):
         default=None, ge=0, description="Number of times out of bed"
     )
 
+    # Fragmentation tracking
+    segments_count: int = Field(
+        default=1, ge=1, description="Number of raw Withings segments merged"
+    )
+    segments_detail: list[dict] | None = Field(
+        default=None,
+        description="Segment breakdown when segments_count > 1",
+    )
+
     @field_validator("total_sleep_hours")
     @classmethod
     def validate_sleep_hours(cls, v: float) -> float:

--- a/tests/_mcp/test_withings_readiness_fragmentation.py
+++ b/tests/_mcp/test_withings_readiness_fragmentation.py
@@ -1,0 +1,77 @@
+"""Tests for sleep fragmentation warning in readiness handler."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.withings import handle_withings_get_readiness
+from magma_cycling.models.withings_models import SleepData, TrainingReadiness
+
+
+def _make_sleep_data(segments_count=1, segments_detail=None):
+    """Build a SleepData with fragmentation fields."""
+    return SleepData(
+        date=date(2026, 3, 7),
+        start_datetime="2026-03-06T22:08:00",
+        end_datetime="2026-03-07T07:09:00",
+        total_sleep_hours=8.7,
+        wakeup_count=3,
+        sleep_score=78,
+        segments_count=segments_count,
+        segments_detail=segments_detail,
+    )
+
+
+def _make_readiness():
+    """Build a TrainingReadiness for testing."""
+    return TrainingReadiness(
+        date=date(2026, 3, 7),
+        sleep_hours=8.7,
+        sleep_score=78,
+        ready_for_intense=True,
+        recommended_intensity="all_systems_go",
+        veto_reasons=[],
+        recommendations=["Conditions optimales"],
+        sufficient_duration=True,
+        deep_sleep_ok=False,
+    )
+
+
+@pytest.mark.asyncio
+class TestReadinessFragmentationWarning:
+    @patch("magma_cycling.health.create_health_provider")
+    async def test_readiness_includes_fragmentation_warning(self, mock_create):
+        provider = MagicMock()
+        mock_create.return_value = provider
+        provider.get_readiness.return_value = _make_readiness()
+        provider.get_sleep_summary.return_value = _make_sleep_data(
+            segments_count=2,
+            segments_detail=[
+                {"start": "22:08", "end": "01:30", "duration_hours": 3.2},
+                {"start": "01:30", "end": "07:09", "duration_hours": 5.5},
+            ],
+        )
+
+        result = await handle_withings_get_readiness({"date": "2026-03-07"})
+
+        import json
+
+        data = json.loads(result[0].text)
+        assert "sleep_fragmentation" in data
+        assert "2 segments fusionnés" in data["sleep_fragmentation"]
+        assert "22:08" in data["sleep_fragmentation"]
+
+    @patch("magma_cycling.health.create_health_provider")
+    async def test_readiness_no_warning_single_segment(self, mock_create):
+        provider = MagicMock()
+        mock_create.return_value = provider
+        provider.get_readiness.return_value = _make_readiness()
+        provider.get_sleep_summary.return_value = _make_sleep_data(segments_count=1)
+
+        result = await handle_withings_get_readiness({"date": "2026-03-07"})
+
+        import json
+
+        data = json.loads(result[0].text)
+        assert "sleep_fragmentation" not in data

--- a/tests/api/test_withings_sleep_segments.py
+++ b/tests/api/test_withings_sleep_segments.py
@@ -1,0 +1,177 @@
+"""Tests for Withings sleep segment aggregation."""
+
+from magma_cycling.api.withings_client import WithingsClient
+
+
+def _make_segment(
+    date_str,
+    start_dt,
+    end_dt,
+    hours,
+    *,
+    deep=None,
+    light=None,
+    rem=None,
+    wakeup_count=0,
+    wakeup_minutes=None,
+    sleep_score=None,
+    sleep_efficiency=None,
+    hr_average=None,
+    hr_min=None,
+    hr_max=None,
+    rr_average=None,
+    rr_min=None,
+    rr_max=None,
+    sleep_latency_min=None,
+    out_of_bed_count=None,
+    breathing_disturbances=None,
+):
+    """Build a raw sleep segment dict as returned by get_sleep() before aggregation."""
+    return {
+        "date": date_str,
+        "start_datetime": start_dt,
+        "end_datetime": end_dt,
+        "total_sleep_hours": hours,
+        "deep_sleep_minutes": deep,
+        "light_sleep_minutes": light,
+        "rem_sleep_minutes": rem,
+        "wakeup_count": wakeup_count,
+        "wakeup_minutes": wakeup_minutes,
+        "sleep_score": sleep_score,
+        "sleep_efficiency": sleep_efficiency,
+        "hr_average": hr_average,
+        "hr_min": hr_min,
+        "hr_max": hr_max,
+        "rr_average": rr_average,
+        "rr_min": rr_min,
+        "rr_max": rr_max,
+        "sleep_latency_min": sleep_latency_min,
+        "out_of_bed_count": out_of_bed_count,
+        "breathing_disturbances": breathing_disturbances,
+    }
+
+
+class TestSingleSegment:
+    def test_single_segment_has_count_1(self):
+        seg = _make_segment("2026-03-07", "2026-03-06T22:30:00", "2026-03-07T06:30:00", 7.5)
+        result = WithingsClient._aggregate_sleep_segments([seg])
+        assert len(result) == 1
+        assert result[0]["segments_count"] == 1
+        assert result[0].get("segments_detail") is None
+
+
+class TestMultiSegmentAggregation:
+    def _two_segments(self):
+        seg1 = _make_segment(
+            "2026-03-07",
+            "2026-03-06T22:08:00",
+            "2026-03-07T01:30:00",
+            3.2,
+            deep=30.0,
+            light=60.0,
+            rem=20.0,
+            wakeup_count=1,
+            wakeup_minutes=5.0,
+            sleep_score=78,
+            sleep_efficiency=92,
+            hr_average=55,
+            hr_min=48,
+            hr_max=68,
+            rr_average=14.5,
+            rr_min=12.0,
+            rr_max=17.0,
+            sleep_latency_min=8.5,
+            out_of_bed_count=1,
+        )
+        seg2 = _make_segment(
+            "2026-03-07",
+            "2026-03-07T01:30:00",
+            "2026-03-07T07:09:00",
+            5.5,
+            deep=45.0,
+            light=90.0,
+            rem=35.0,
+            wakeup_count=2,
+            wakeup_minutes=10.0,
+            hr_average=52,
+            hr_min=45,
+            hr_max=62,
+            rr_average=13.8,
+            rr_min=11.5,
+            rr_max=16.0,
+            out_of_bed_count=0,
+        )
+        return [seg1, seg2]
+
+    def test_multi_segment_same_date_aggregated(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        assert len(result) == 1
+        assert result[0]["segments_count"] == 2
+
+    def test_multi_segment_duration_sum(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        assert result[0]["total_sleep_hours"] == 8.7  # 3.2 + 5.5
+
+    def test_multi_segment_stages_sum(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        assert result[0]["deep_sleep_minutes"] == 75.0  # 30 + 45
+        assert result[0]["light_sleep_minutes"] == 150.0  # 60 + 90
+        assert result[0]["rem_sleep_minutes"] == 55.0  # 20 + 35
+
+    def test_multi_segment_wakeup_sum(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        assert result[0]["wakeup_count"] == 3  # 1 + 2
+        assert result[0]["wakeup_minutes"] == 15.0  # 5 + 10
+
+    def test_multi_segment_detail_format(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        detail = result[0]["segments_detail"]
+        assert len(detail) == 2
+        assert detail[0] == {"start": "22:08", "end": "01:30", "duration_hours": 3.2}
+        assert detail[1] == {"start": "01:30", "end": "07:09", "duration_hours": 5.5}
+
+    def test_multi_segment_hr_aggregation(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        merged = result[0]
+        assert merged["hr_min"] == 45  # min(48, 45)
+        assert merged["hr_max"] == 68  # max(68, 62)
+        # Weighted avg: (55*3.2 + 52*5.5) / 8.7 ≈ 53.1 → 53
+        assert merged["hr_average"] == 53
+
+    def test_multi_segment_rr_aggregation(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        merged = result[0]
+        assert merged["rr_min"] == 11.5
+        assert merged["rr_max"] == 17.0
+        # Weighted: (14.5*3.2 + 13.8*5.5) / 8.7 ≈ 14.06
+        assert merged["rr_average"] == 14.1
+
+    def test_multi_segment_scores_first_non_none(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        merged = result[0]
+        assert merged["sleep_score"] == 78
+        assert merged["sleep_efficiency"] == 92
+
+    def test_multi_segment_sleep_latency_from_first(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        assert result[0]["sleep_latency_min"] == 8.5
+
+    def test_multi_segment_start_end_range(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        merged = result[0]
+        assert merged["start_datetime"] == "2026-03-06T22:08:00"
+        assert merged["end_datetime"] == "2026-03-07T07:09:00"
+
+    def test_multi_segment_out_of_bed_sum(self):
+        result = WithingsClient._aggregate_sleep_segments(self._two_segments())
+        assert result[0]["out_of_bed_count"] == 1  # 1 + 0 (0 is falsy, skipped)
+
+
+class TestDifferentDates:
+    def test_different_dates_not_merged(self):
+        seg1 = _make_segment("2026-03-06", "2026-03-05T23:00:00", "2026-03-06T06:00:00", 7.0)
+        seg2 = _make_segment("2026-03-07", "2026-03-06T23:00:00", "2026-03-07T06:30:00", 7.5)
+        result = WithingsClient._aggregate_sleep_segments([seg1, seg2])
+        assert len(result) == 2
+        assert result[0]["segments_count"] == 1
+        assert result[1]["segments_count"] == 1

--- a/tests/health/test_withings_provider.py
+++ b/tests/health/test_withings_provider.py
@@ -104,6 +104,38 @@ class TestGetSleepSummary:
         assert provider.get_sleep_summary(date(2026, 2, 28)) is None
 
 
+class TestSleepDataWithSegments:
+    def test_sleep_data_accepts_segments_fields(self):
+        data = SleepData(
+            date="2026-03-07",
+            start_datetime="2026-03-06T22:08:00",
+            end_datetime="2026-03-07T07:09:00",
+            total_sleep_hours=8.7,
+            wakeup_count=3,
+            segments_count=2,
+            segments_detail=[
+                {"start": "22:08", "end": "01:30", "duration_hours": 3.2},
+                {"start": "01:30", "end": "07:09", "duration_hours": 5.5},
+            ],
+        )
+        assert data.segments_count == 2
+        assert len(data.segments_detail) == 2
+        dumped = data.model_dump()
+        assert dumped["segments_count"] == 2
+        assert dumped["segments_detail"][0]["start"] == "22:08"
+
+    def test_sleep_data_defaults_single_segment(self):
+        data = SleepData(
+            date="2026-03-07",
+            start_datetime="2026-03-06T23:00:00",
+            end_datetime="2026-03-07T06:30:00",
+            total_sleep_hours=7.5,
+            wakeup_count=1,
+        )
+        assert data.segments_count == 1
+        assert data.segments_detail is None
+
+
 class TestGetSleepRange:
     def test_returns_list_of_sleep_data(self, mock_client, provider):
         mock_client.get_sleep.return_value = [


### PR DESCRIPTION
## Summary

- **Aggregate Withings sleep segments by date** in `WithingsClient.get_sleep()` — previously only the last segment was kept, silently losing data from fragmented nights
- **Add `segments_count` / `segments_detail` fields** to `SleepData` model for downstream visibility
- **Add `sleep_fragmentation` warning** in readiness handler when night has multiple segments
- **15 new tests** covering aggregation logic, model fields, and handler warning

## Test plan

- [x] `poetry run pytest tests/api/test_withings_sleep_segments.py -v` — 13 tests
- [x] `poetry run pytest tests/_mcp/test_withings_readiness_fragmentation.py -v` — 2 tests
- [x] `poetry run pytest tests/health/test_withings_provider.py -v` — includes 2 new segment tests
- [x] `poetry run pytest tests/ -x` — 2051 passed
- [x] `poetry run pre-commit run --all-files` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)