### PR TITLE
fix(validator): reject free text descriptions missing interval lines

### DIFF
--- a/magma_cycling/_mcp/handlers/intervals.py
+++ b/magma_cycling/_mcp/handlers/intervals.py
@@ -113,7 +113,13 @@ async def handle_sync_week_to_intervals(args: dict) -> list[TextContent]:
                 }
 
                 # Validate workout description before creating remote event
-                if full_description and full_description.strip():
+                # Skip validation for rest days (no structured workout expected)
+                if (
+                    session.duration_min
+                    and session.duration_min > 0
+                    and full_description
+                    and full_description.strip()
+                ):
                     from magma_cycling.intervals_format_validator import (
                         IntervalsFormatValidator,
                     )

--- a/magma_cycling/intervals_format_validator.py
+++ b/magma_cycling/intervals_format_validator.py
@@ -107,6 +107,9 @@ class IntervalsFormatValidator:
         # Check 3: Format intervalles
         self._check_interval_format(lines)
 
+        # Check 4: Structure minimale
+        self._check_minimal_structure(lines)
+
         return (len(self.errors) == 0, self.errors, self.warnings)
 
     def _check_repetition_format(self, lines: list[str]):
@@ -188,6 +191,16 @@ class IntervalsFormatValidator:
             # Vérifier présence durée
             if not re.search(r"\d+[msh]", stripped):
                 self.warnings.append(f"Ligne {i + 1}: Aucune durée détectée dans '{stripped}'")
+
+    def _check_minimal_structure(self, lines: list[str]):
+        """Verify presence of at least one interval line."""
+        has_interval = any(re.match(self.INTERVAL_PATTERN, line) for line in lines)
+        if not has_interval:
+            self.errors.append(
+                "Aucune ligne d'intervalle détectée "
+                "(format attendu: '- Xm Y% Zrpm'). "
+                "Le texte libre n'est pas un format workout valide."
+            )
 
     def fix_repetition_format(self, workout_text: str) -> str:
         """

--- a/tests/_mcp/test_sync_skip_rest_validation.py
+++ b/tests/_mcp/test_sync_skip_rest_validation.py
@@ -1,0 +1,54 @@
+"""Tests for sync handler skipping validation on rest days."""
+
+from magma_cycling.intervals_format_validator import IntervalsFormatValidator
+
+
+def test_sync_skips_validation_for_rest_day():
+    """Rest day (duration_min=0) should not trigger validation.
+
+    The sync handler condition is:
+        if session.duration_min and session.duration_min > 0 and ...
+    So duration_min=0 (falsy) skips the validation block entirely.
+    This test verifies that a free-text description that would fail
+    validation is acceptable for rest days via the guard condition.
+    """
+    # Simulate the sync handler guard condition
+    duration_min = 0
+    full_description = "Repos complet"
+
+    # The guard condition from intervals.py:117
+    should_validate = (
+        duration_min and duration_min > 0 and full_description and full_description.strip()
+    )
+
+    assert should_validate is False or not should_validate
+
+    # Confirm that this description WOULD fail validation if checked
+    validator = IntervalsFormatValidator()
+    is_valid, errors, _ = validator.validate_workout(full_description)
+    assert is_valid is False
+    assert any("Aucune ligne d'intervalle" in e for e in errors)
+
+
+def test_sync_validates_normal_session():
+    """Normal session (duration_min>0) with description triggers validation."""
+    duration_min = 45
+    full_description = "- 10m 70% 85rpm"
+
+    should_validate = (
+        duration_min and duration_min > 0 and full_description and full_description.strip()
+    )
+
+    assert should_validate
+
+
+def test_sync_skips_validation_for_none_duration():
+    """Session with duration_min=None should skip validation."""
+    duration_min = None
+    full_description = "Some description"
+
+    should_validate = (
+        duration_min and duration_min > 0 and full_description and full_description.strip()
+    )
+
+    assert not should_validate

--- a/tests/test_intervals_format.py
+++ b/tests/test_intervals_format.py
@@ -178,12 +178,12 @@ def test_generate_examples(validator):
 
 
 def test_empty_workout(validator):
-    """Test workout vide."""
+    """Test workout vide — rejeté (aucune ligne d'intervalle)."""
     workout = ""
 
     is_valid, errors, warnings = validator.validate_workout(workout)
-    # Workout vide techniquement valide (pas d'erreurs)
-    assert is_valid is True
+    assert is_valid is False
+    assert any("Aucune ligne d'intervalle" in e for e in errors)
 
 
 def test_workout_without_sections(validator):
@@ -351,6 +351,38 @@ def test_script_main_entry_point(monkeypatch, capsys):
     # Verify main() was called by checking output
     captured = capsys.readouterr()
     assert "TEST 1" in captured.out or "EXEMPLES" in captured.out
+
+
+def test_free_text_rejected(validator):
+    """Test texte libre narratif rejeté."""
+    workout = "Récupération active — Z1 strict"
+
+    is_valid, errors, warnings = validator.validate_workout(workout)
+
+    assert is_valid is False
+    assert any("Aucune ligne d'intervalle" in e for e in errors)
+
+
+def test_free_text_multiline_rejected(validator):
+    """Test plusieurs lignes narratives rejetées."""
+    workout = """Récupération active
+Zone 1 strict, pas de pic
+Objectif: récupérer du week-end"""
+
+    is_valid, errors, warnings = validator.validate_workout(workout)
+
+    assert is_valid is False
+    assert any("Aucune ligne d'intervalle" in e for e in errors)
+
+
+def test_minimal_single_interval_valid(validator):
+    """Test intervalle unique valide."""
+    workout = "- 10m 70% 85rpm"
+
+    is_valid, errors, warnings = validator.validate_workout(workout)
+
+    assert is_valid is True
+    assert len(errors) == 0
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_extra_handlers.py
+++ b/tests/test_mcp_extra_handlers.py
@@ -34,7 +34,7 @@ def mock_session():
     s.version = "V001"
     s.tss_planned = 65
     s.duration_min = 60
-    s.description = "Tempo 3x10min"
+    s.description = "Warmup\n- 10m ramp 50-75% 85rpm\n\nMain set 3x\n- 10m 88% 90rpm\n- 3m 60% 85rpm\n\nCooldown\n- 10m ramp 70-50% 85rpm"
     s.status = "pending"
     s.intervals_id = None
     s.skip_reason = None
@@ -233,7 +233,8 @@ class TestHandleSyncWeekToIntervals:
         mock_session.intervals_id = "evt123"
         mock_session.status = "pending"
         mock_session.name = "TempoCourt"
-        mock_session.description = "Tempo 3x10min"
+        valid_desc = "Warmup\n- 10m ramp 50-75% 85rpm\n\nMain set 3x\n- 10m 88% 90rpm\n- 3m 60% 85rpm\n\nCooldown\n- 10m ramp 70-50% 85rpm"
+        mock_session.description = valid_desc
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
         mock_client = Mock()
@@ -243,7 +244,7 @@ class TestHandleSyncWeekToIntervals:
                 "id": "evt123",
                 "category": "WORKOUT",
                 "name": "S081-03-INT-TempoCourt-V001",
-                "description": "Tempo 3x10min",
+                "description": valid_desc,
                 "start_date_local": "2026-02-19T17:00:00",
             },
         ]
@@ -266,7 +267,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.intervals_id = "evt123"
         mock_session.status = "pending"
         mock_session.name = "TempoCourt"
-        mock_session.description = "Tempo 3x10min"
+        mock_session.description = "Warmup\n- 10m ramp 50-75% 85rpm\n\nMain set 3x\n- 10m 88% 90rpm\n- 3m 60% 85rpm\n\nCooldown\n- 10m ramp 70-50% 85rpm"
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
         mock_client = Mock()
@@ -375,7 +376,8 @@ class TestHandleSyncWeekToIntervals:
         mock_session.name = "TempoCourt"
         mock_session.session_type = "INT"
         mock_session.version = "V001"
-        mock_session.description = "Short desc"
+        valid_desc = "Warmup\n- 10m ramp 50-75% 85rpm\n\nMain set 3x\n- 10m 88% 90rpm\n- 3m 60% 85rpm\n\nCooldown\n- 10m ramp 70-50% 85rpm"
+        mock_session.description = valid_desc
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
         mock_client = Mock()
@@ -401,7 +403,7 @@ class TestHandleSyncWeekToIntervals:
         update_call = mock_client.update_event.call_args
         event_data = update_call[0][1]
         assert "description" in event_data
-        assert event_data["description"] == "Short desc"
+        assert event_data["description"] == valid_desc
         assert "name" in event_data
         assert "start_date_local" in event_data
 
@@ -417,9 +419,12 @@ class TestHandleSyncWeekToIntervals:
         session2.name = "EnduranceLongue"
         session2.session_type = "END"
         session2.version = "V001"
-        session2.description = "90min endurance"
+        session2.description = "Warmup\n- 15m ramp 50-70% 85rpm\n\nMain set\n- 60m 68% 85rpm\n\nCooldown\n- 15m ramp 65-50% 85rpm"
+        session2.duration_min = 90
+        session2.tss_planned = 55
         session2.status = "pending"
         session2.intervals_id = None
+        session2.skip_reason = None
         mock_session.intervals_id = None
         mock_plan.planned_sessions = [mock_session, session2]
         tower = make_tower(mock_plan)


### PR DESCRIPTION
## Summary

- Add `_check_minimal_structure()` to `IntervalsFormatValidator` — requires at least one interval line (`- Xm Y%`) for a workout to be valid, preventing free text narratives from being uploaded
- Skip validation for rest days (`duration_min=0`) in the sync handler to avoid false positives on rest session descriptions
- Fix existing mock descriptions in `test_mcp_extra_handlers.py` to use valid structured workouts

## Context

The validator only had 3 negative checks (no markdown, no bad repetition, no invalid duration). A free text narrative like *"Récupération active — Z1 strict"* passed all checks because it didn't trigger any error pattern. This caused the S084 sync to upload WORKOUTs with free text when `workout_descriptions` keys didn't match.

## Test plan

- [x] `test_free_text_rejected` — single-line narrative → rejected
- [x] `test_free_text_multiline_rejected` — multi-line narrative → rejected
- [x] `test_minimal_single_interval_valid` — single interval line → valid
- [x] `test_empty_workout` — updated: empty workout now rejected
- [x] `test_sync_skips_validation_for_rest_day` — `duration_min=0` skips validation
- [x] Full suite: 2057 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)