### PR TITLE
fix(eow): fix calculate_weekly_transition() Monday boundary bug

### DIFF
--- a/magma_cycling/workflows/end_of_week.py
+++ b/magma_cycling/workflows/end_of_week.py
@@ -98,8 +98,10 @@ def calculate_weekly_transition(reference_date: date | None = None) -> tuple[str
     Calculate week IDs for weekly transition (completed → next).
 
     Logic:
-    - If Sunday (day 6) or Monday (day 0): transition from current week to next
-    - Otherwise: transition from current week to next (for manual runs)
+    - Determines the most recently completed week and the next week to plan
+    - On Monday (first day of new week), the previous week is completed
+    - On Sunday (last day of current week), the current week is completed
+    - Both Sunday evening and Monday morning yield the same transition
 
     Args:
         reference_date: Reference date for calculation (default: today)
@@ -111,6 +113,8 @@ def calculate_weekly_transition(reference_date: date | None = None) -> tuple[str
         >>> # Running on Sunday 2026-01-25 or Monday 2026-01-26
         >>> calculate_weekly_transition(date(2026, 1, 25))
         ('S077', 'S078', date(2026, 1, 19), date(2026, 1, 26))
+        >>> calculate_weekly_transition(date(2026, 1, 26))
+        ('S077', 'S078', date(2026, 1, 19), date(2026, 1, 26))
     """
     if reference_date is None:
         reference_date = date.today()
@@ -119,11 +123,15 @@ def calculate_weekly_transition(reference_date: date | None = None) -> tuple[str
     week_config = get_week_config()
     s001_date = week_config.get_s001_date_obj("S001")
 
-    # Calculate weeks offset from S001
-    delta = reference_date - s001_date
+    # Use yesterday to determine completed week: on Monday (first day of
+    # new week), yesterday=Sunday falls in the previous week, giving the
+    # correct "just completed" week. On Sunday, yesterday=Saturday stays
+    # in the same week. Both yield the same transition.
+    adjusted_date = reference_date - timedelta(days=1)
+    delta = adjusted_date - s001_date
     weeks_offset = delta.days // 7
 
-    # Current week is the week containing reference_date
+    # Completed week is the one containing yesterday
     current_week_num = weeks_offset + 1
     week_completed = f"S{current_week_num:03d}"
     week_next = f"S{current_week_num + 1:03d}"

--- a/tests/workflows/test_end_of_week.py
+++ b/tests/workflows/test_end_of_week.py
@@ -102,20 +102,60 @@ class TestCalculateWeeklyTransition:
 
     @patch("magma_cycling.workflows.end_of_week.get_week_config")
     def test_calculate_weekly_transition_monday(self, mock_config):
-        """Test transition calculation on Monday."""
+        """Test transition on Monday gives same result as Sunday."""
         mock_week_config = Mock()
         mock_week_config.get_s001_date_obj.return_value = date(2024, 8, 5)
         mock_config.return_value = mock_week_config
 
-        # Monday 2026-01-26 (S078 start)
+        # Monday 2026-01-26 (first day of S078)
+        # The completed week is S077 (just ended), not S078 (just started)
         reference_date = date(2026, 1, 26)
 
         week_completed, week_next, completed_start, next_start = calculate_weekly_transition(
             reference_date
         )
 
+        assert week_completed == "S077"
+        assert week_next == "S078"
+        assert completed_start == date(2026, 1, 19)
+        assert next_start == date(2026, 1, 26)
+
+    @patch("magma_cycling.workflows.end_of_week.get_week_config")
+    def test_calculate_weekly_transition_midweek(self, mock_config):
+        """Test transition mid-week (Wednesday)."""
+        mock_week_config = Mock()
+        mock_week_config.get_s001_date_obj.return_value = date(2024, 8, 5)
+        mock_config.return_value = mock_week_config
+
+        # Wednesday 2026-01-28 (mid-S078)
+        reference_date = date(2026, 1, 28)
+
+        week_completed, week_next, _, _ = calculate_weekly_transition(reference_date)
+
         assert week_completed == "S078"
         assert week_next == "S079"
+
+    @patch("magma_cycling.workflows.end_of_week.get_week_config")
+    def test_calculate_weekly_transition_s084_monday_bug(self, mock_config):
+        """Regression test: Monday March 9 must return S083 completed, not S084.
+
+        This is the exact scenario that caused the S084 incident.
+        """
+        mock_week_config = Mock()
+        mock_week_config.get_s001_date_obj.return_value = date(2024, 8, 5)
+        mock_config.return_value = mock_week_config
+
+        # Monday 2026-03-09 = first day of S084
+        reference_date = date(2026, 3, 9)
+
+        week_completed, week_next, completed_start, next_start = calculate_weekly_transition(
+            reference_date
+        )
+
+        assert week_completed == "S083"
+        assert week_next == "S084"
+        assert completed_start == date(2026, 3, 2)
+        assert next_start == date(2026, 3, 9)
 
     @patch("magma_cycling.workflows.end_of_week.get_week_config")
     @patch("magma_cycling.workflows.end_of_week.date")


### PR DESCRIPTION
## Summary

- Fix `calculate_weekly_transition()` treating Monday (first day of new week) as "completed week" instead of previous week
- Use `reference_date - 1 day` for calculation so Sunday evening and Monday morning yield the same transition
- Add regression test for the exact S084 incident scenario (Monday March 9 → S083 completed, not S084)

## Root cause

The function used `delta.days // 7` directly, which on Monday (week boundary) already counted the new week. On March 9 (Monday, first day of S084), it returned `week_completed=S084` instead of `S083`, causing the end-of-week workflow to run prematurely and generate S085 a full week early.

## Fix

Use yesterday's date (`reference_date - timedelta(days=1)`) to determine which week completed:
- Sunday: yesterday = Saturday (same week) → correct
- Monday: yesterday = Sunday (previous week) → now correct
- Mid-week: yesterday stays in same week → unchanged behavior

## Test plan

- [x] `test_calculate_weekly_transition_sunday` — Sunday gives S077→S078
- [x] `test_calculate_weekly_transition_monday` — Monday now gives S077→S078 (same as Sunday)
- [x] `test_calculate_weekly_transition_midweek` — Wednesday gives S078→S079
- [x] `test_calculate_weekly_transition_s084_monday_bug` — Regression: March 9 gives S083→S084
- [x] Full suite: 2059 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)