### PR TITLE
feat(planner): expose full prompt in MCP response for AI providers

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -61,16 +61,24 @@ async def handle_weekly_planner(args: dict) -> list[TextContent]:
         "provider": provider,
         "prompt_length": len(prompt),
         "message": f"Planning prompt generated for {week_id}",
-        "next_steps": [
-            f"Copy prompt and paste to {provider}",
-            "Generate 7 workouts",
-            "Save workouts to file",
-            "Run upload-workouts to sync to Intervals.icu",
-        ],
     }
 
     if provider == "clipboard":
         result["prompt"] = prompt[:500] + "..." if len(prompt) > 500 else prompt
+        result["next_steps"] = [
+            f"Copy prompt and paste to {provider}",
+            "Generate 7 workouts",
+            "Save workouts to file",
+            "Run upload-workouts to sync to Intervals.icu",
+        ]
+    else:
+        # Full prompt for AI providers — any MCP client can consume it
+        result["prompt"] = prompt
+        result["next_steps"] = [
+            "Use the prompt field to generate 7 structured workouts",
+            "Call modify-session-details for each session with the workout description",
+            "Call sync-week-to-intervals to upload to Intervals.icu",
+        ]
 
     return mcp_response(result)
 

--- a/tests/_mcp/test_weekly_planner_prompt_exposure.py
+++ b/tests/_mcp/test_weekly_planner_prompt_exposure.py
@@ -1,0 +1,98 @@
+"""Tests for weekly planner MCP prompt exposure."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import nullcontext
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.planning import handle_weekly_planner
+
+
+def _run(coro):
+    """Run async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+FAKE_PROMPT = "A" * 16000  # Simulates a 16k-char planning prompt
+
+
+@pytest.fixture()
+def _patch_planner():
+    """Patch WeeklyPlanner to avoid real API/filesystem calls."""
+    mock_cls = MagicMock()
+    instance = mock_cls.return_value
+    instance.collect_current_metrics.return_value = {}
+    instance.load_previous_week_bilan.return_value = ""
+    instance.load_context_files.return_value = {}
+    instance.generate_planning_prompt.return_value = FAKE_PROMPT
+
+    with (
+        patch(
+            "magma_cycling.weekly_planner.WeeklyPlanner",
+            mock_cls,
+        ),
+        patch(
+            "magma_cycling._mcp.handlers.planning.suppress_stdout_stderr",
+            return_value=nullcontext(),
+        ),
+    ):
+        yield
+
+
+BASE_ARGS = {
+    "week_id": "S099",
+    "start_date": "2026-03-09",
+}
+
+
+@pytest.mark.usefixtures("_patch_planner")
+class TestWeeklyPlannerPromptExposure:
+    """Test prompt exposure in weekly planner MCP handler."""
+
+    def test_clipboard_provider_truncates_prompt(self):
+        """Clipboard provider returns prompt truncated to 500 chars."""
+        args = {**BASE_ARGS, "provider": "clipboard"}
+        result = _run(handle_weekly_planner(args))
+
+        import json
+
+        data = json.loads(result[0].text)
+        assert data["prompt"].endswith("...")
+        assert len(data["prompt"]) == 503  # 500 chars + "..."
+
+    def test_claude_api_returns_full_prompt(self):
+        """claude_api provider returns the complete prompt."""
+        args = {**BASE_ARGS, "provider": "claude_api"}
+        result = _run(handle_weekly_planner(args))
+
+        import json
+
+        data = json.loads(result[0].text)
+        assert data["prompt"] == FAKE_PROMPT
+        assert len(data["prompt"]) == 16000
+
+    def test_mistral_api_returns_full_prompt(self):
+        """mistral_api provider returns the complete prompt."""
+        args = {**BASE_ARGS, "provider": "mistral_api"}
+        result = _run(handle_weekly_planner(args))
+
+        import json
+
+        data = json.loads(result[0].text)
+        assert data["prompt"] == FAKE_PROMPT
+        assert len(data["prompt"]) == 16000
+
+    def test_ai_provider_next_steps(self):
+        """AI providers get next_steps mentioning modify-session-details."""
+        args = {**BASE_ARGS, "provider": "claude_api"}
+        result = _run(handle_weekly_planner(args))
+
+        import json
+
+        data = json.loads(result[0].text)
+        steps_text = " ".join(data["next_steps"])
+        assert "modify-session-details" in steps_text
+        assert "sync-week-to-intervals" in steps_text


### PR DESCRIPTION
## Summary

- Expose the full planning prompt in the MCP `weekly-planner` response for non-clipboard providers (`claude_api`, `mistral_api`)
- Clipboard provider still returns truncated prompt (500 chars)
- Adapt `next_steps` per provider type: clipboard gets copy-paste instructions, AI providers get MCP tool chain (`modify-session-details` → `sync-week-to-intervals`)

## Test plan

- [x] `test_clipboard_provider_truncates_prompt` — clipboard retourne prompt tronqué
- [x] `test_claude_api_returns_full_prompt` — claude_api retourne le prompt complet
- [x] `test_mistral_api_returns_full_prompt` — mistral_api retourne le prompt complet
- [x] `test_ai_provider_next_steps` — next_steps contient modify-session-details
- [x] Full test suite: 2063 passed
- [x] Pre-commit: all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)