### PR TITLE
feat(planning): add source field to WeeklyPlan model

### DIFF
--- a/magma_cycling/planning/models.py
+++ b/magma_cycling/planning/models.py
@@ -195,6 +195,10 @@ class WeeklyPlan(BaseModel):
     version: int = Field(ge=1, description="Plan version number")
     athlete_id: str = Field(description="Athlete identifier (e.g., iXXXXXX)")
     tss_target: int = Field(ge=0, le=2000, description="Target weekly TSS")
+    source: str | None = Field(
+        default=None,
+        description="Origin of planning creation (eow, mcp, planner, manual)",
+    )
     planned_sessions: list[Session] = Field(
         default_factory=list, alias="planned_sessions", description="List of planned sessions"
     )

--- a/magma_cycling/workflows/end_of_week.py
+++ b/magma_cycling/workflows/end_of_week.py
@@ -214,6 +214,11 @@ class EndOfWeekWorkflow(
         except Exception:
             return False
 
+        # Explicit source check — non-EOW plannings are always respected
+        if plan.source and plan.source != "eow":
+            return True
+
+        # Heuristic fallback for legacy files without source field
         for session in plan.planned_sessions:
             if session.intervals_id is not None:
                 return True

--- a/magma_cycling/workflows/eow/upload.py
+++ b/magma_cycling/workflows/eow/upload.py
@@ -194,6 +194,7 @@ class UploadMixin:
                 "version": 1,
                 "athlete_id": config.athlete_id,
                 "tss_target": 0,
+                "source": "eow",
                 "planned_sessions": [],
             }
 

--- a/magma_cycling/workflows/planner/output.py
+++ b/magma_cycling/workflows/planner/output.py
@@ -127,6 +127,7 @@ class OutputMixin:
             "version": 1,
             "athlete_id": intervals_config.athlete_id,
             "tss_target": sum(w.get("tss_planned", 0) for w in workouts_data),
+            "source": "planner",
             "planned_sessions": workouts_data,
         }
 

--- a/tests/planning/test_weekly_plan_source.py
+++ b/tests/planning/test_weekly_plan_source.py
@@ -1,0 +1,64 @@
+"""Tests for WeeklyPlan source field."""
+
+import json
+
+from magma_cycling.planning.models import WeeklyPlan
+
+
+def _make_plan_data(**overrides):
+    """Build minimal valid WeeklyPlan data dict."""
+    data = {
+        "week_id": "S084",
+        "start_date": "2026-03-09",
+        "end_date": "2026-03-15",
+        "created_at": "2026-03-08T20:00:00",
+        "last_updated": "2026-03-08T20:00:00",
+        "version": 1,
+        "athlete_id": "i999999",
+        "tss_target": 300,
+        "planned_sessions": [
+            {
+                "session_id": "S084-01",
+                "date": "2026-03-09",
+                "name": "Endurance",
+                "type": "END",
+                "tss_planned": 50,
+                "duration_min": 60,
+                "status": "planned",
+            },
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+class TestWeeklyPlanSourceField:
+    """Test source field on WeeklyPlan model."""
+
+    def test_source_field_default_none(self):
+        """WeeklyPlan without source field defaults to None."""
+        plan = WeeklyPlan(**_make_plan_data())
+        assert plan.source is None
+
+    def test_source_field_roundtrip(self, tmp_path):
+        """Serialization/deserialization preserves source field."""
+        plan = WeeklyPlan(**_make_plan_data(source="mcp"))
+        assert plan.source == "mcp"
+
+        json_file = tmp_path / "week_planning_S084.json"
+        plan.to_json(json_file)
+
+        loaded = WeeklyPlan.from_json(json_file)
+        assert loaded.source == "mcp"
+
+    def test_legacy_json_without_source_loads(self, tmp_path):
+        """Legacy JSON without source field loads without error."""
+        data = _make_plan_data()
+        assert "source" not in data
+
+        json_file = tmp_path / "week_planning_S084.json"
+        json_file.write_text(json.dumps(data), encoding="utf-8")
+
+        plan = WeeklyPlan.from_json(json_file)
+        assert plan.source is None
+        assert len(plan.planned_sessions) == 1

--- a/tests/workflows/test_end_of_week.py
+++ b/tests/workflows/test_end_of_week.py
@@ -721,6 +721,40 @@ class TestNextWeekPrecondition:
 
         assert workflow._check_next_week_already_planned() is True
 
+    def test_next_week_source_mcp_skips(self, workflow):
+        """Planning with source=mcp should skip even if sessions are planned."""
+        sessions = [
+            {
+                "session_id": "S084-01",
+                "date": "2026-03-09",
+                "name": "Endurance",
+                "type": "END",
+                "tss_planned": 50,
+                "duration_min": 60,
+                "status": "planned",
+            },
+        ]
+        self._write_planning(workflow.planning_dir, "S084", sessions, source="mcp")
+
+        assert workflow._check_next_week_already_planned() is True
+
+    def test_next_week_source_eow_with_empty_sessions_continues(self, workflow):
+        """Planning with source=eow and template sessions — should continue."""
+        sessions = [
+            {
+                "session_id": "S084-01",
+                "date": "2026-03-09",
+                "name": "Endurance",
+                "type": "END",
+                "tss_planned": 50,
+                "duration_min": 60,
+                "status": "planned",
+            },
+        ]
+        self._write_planning(workflow.planning_dir, "S084", sessions, source="eow")
+
+        assert workflow._check_next_week_already_planned() is False
+
 
 # =============================================================================
 # Tests: EndOfWeekWorkflow Integration


### PR DESCRIPTION
## Summary
- Add optional `source` field to `WeeklyPlan` model (eow, mcp, planner, manual)
- EOW workflow sets `source=eow`, weekly-planner sets `source=planner`
- Precondition check now respects non-EOW sources (always skip) with heuristic fallback for legacy files without source
- Stacked on PR #104

## Test plan
- [x] 3 new tests in `TestWeeklyPlanSourceField` (default None, roundtrip, legacy compat)
- [x] 2 new tests in `TestNextWeekPrecondition` (source=mcp skips, source=eow continues)
- [x] All 57 tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)