### PR TITLE
feat(mcp): add get-coach-analysis tool

### DIFF
--- a/magma_cycling/_mcp/handlers/analysis.py
+++ b/magma_cycling/_mcp/handlers/analysis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -20,6 +21,7 @@ __all__ = [
     "handle_export_week_to_json",
     "handle_restore_week_from_backup",
     "handle_analyze_training_patterns",
+    "handle_get_coach_analysis",
 ]
 
 
@@ -596,3 +598,220 @@ async def handle_analyze_training_patterns(args: dict) -> list[TextContent]:
             "depth": depth,
         }
         return mcp_response(error)
+
+
+# ---------------------------------------------------------------------------
+# Coach analysis history lookup
+# ---------------------------------------------------------------------------
+
+SECTION_MAP = {
+    "metrics_pre": "Métriques Pré-séance",
+    "execution": "Exécution",
+    "technique": "Exécution Technique",
+    "load": "Charge d'Entraînement",
+    "validation": "Validation Objectifs",
+    "attention": "Points d'Attention",
+    "recommendations": "Recommandations Progression",
+    "metrics_post": "Métriques Post-séance",
+    "full": None,
+}
+
+
+def _parse_analysis_entry(entry_text: str) -> dict:
+    """Parse a single analysis entry into structured fields."""
+    lines = entry_text.strip().splitlines()
+    if not lines:
+        return {}
+
+    # Extract title from first line (### TITLE)
+    title_line = lines[0].lstrip("#").strip()
+    activity_name = title_line
+
+    # Extract ID, Date from header lines
+    activity_id = ""
+    date_str = ""
+    for line in lines[1:5]:
+        id_match = re.match(r"ID\s*:\s*(.+)", line.strip())
+        if id_match:
+            activity_id = id_match.group(1).strip()
+        date_match = re.match(r"Date\s*:\s*(.+)", line.strip())
+        if date_match:
+            date_str = date_match.group(1).strip()
+
+    # Extract week_id from activity_name (e.g. S084-04-END-... → S084)
+    week_id = ""
+    wid_match = re.match(r"(S\d{3})", activity_name)
+    if wid_match:
+        week_id = wid_match.group(1)
+
+    # Parse #### sections
+    sections: dict[str, str] = {}
+    current_section = None
+    current_lines: list[str] = []
+
+    for line in lines:
+        section_match = re.match(r"####\s+(.+)", line)
+        if section_match:
+            # Save previous section
+            if current_section:
+                sections[current_section] = "\n".join(current_lines).strip()
+            current_section = section_match.group(1).strip()
+            current_lines = []
+        elif current_section is not None:
+            current_lines.append(line)
+
+    # Save last section
+    if current_section:
+        sections[current_section] = "\n".join(current_lines).strip()
+
+    # Map French section titles to API keys
+    mapped_sections: dict[str, str] = {}
+    for key, french_title in SECTION_MAP.items():
+        if french_title and french_title in sections:
+            mapped_sections[key] = sections[french_title]
+
+    return {
+        "activity_name": activity_name,
+        "activity_id": activity_id,
+        "date": date_str,
+        "week_id": week_id,
+        "sections": mapped_sections,
+        "content": entry_text.strip(),
+    }
+
+
+def _search_analyses(
+    content: str,
+    activity_id: str | None = None,
+    session_id: str | None = None,
+    date: str | None = None,
+) -> list[str]:
+    """Search analysis entries matching the given criteria."""
+    # Split on ### headers — handle file starting with ### (no leading \n)
+    raw_entries = re.split(r"(?:^|\n)(?=### )", content)
+    entries = [e.strip() for e in raw_entries if e.strip()]
+
+    results = []
+    for entry in entries:
+        if activity_id:
+            pattern = rf"ID\s*:\s*{re.escape(activity_id)}\s*$"
+            if not re.search(pattern, entry, re.MULTILINE):
+                continue
+
+        if session_id:
+            # Word-boundary match to avoid S084-04 matching S084-040
+            pattern = rf"^###\s+{re.escape(session_id)}\b"
+            if not re.search(pattern, entry, re.MULTILINE):
+                continue
+
+        if date:
+            # Convert YYYY-MM-DD to DD/MM/YYYY for matching
+            try:
+                parts = date.split("-")
+                date_fr = f"{parts[2]}/{parts[1]}/{parts[0]}"
+                pattern = rf"Date\s*:\s*{re.escape(date_fr)}\s*$"
+                if not re.search(pattern, entry, re.MULTILINE):
+                    continue
+            except (IndexError, ValueError):
+                continue
+
+        results.append(entry)
+
+    return results
+
+
+async def handle_get_coach_analysis(args: dict) -> list[TextContent]:
+    """Retrieve coach AI analysis from workouts-history.md."""
+    activity_id = args.get("activity_id")
+    session_id = args.get("session_id")
+    date = args.get("date")
+    section = args.get("section", "full")
+
+    # Validate: at least one search parameter required
+    if not any([activity_id, session_id, date]):
+        return mcp_response(
+            {
+                "error": "At least one search parameter required: activity_id, session_id, or date",
+            }
+        )
+
+    # Validate section parameter
+    if section not in SECTION_MAP:
+        return mcp_response(
+            {
+                "error": f"Invalid section: {section}",
+                "valid_sections": list(SECTION_MAP.keys()),
+            }
+        )
+
+    try:
+        from magma_cycling.config import get_data_config
+
+        config = get_data_config()
+        history_path = config.workouts_history_path
+
+        if not history_path.exists():
+            return mcp_response(
+                {
+                    "status": "success",
+                    "analyses": [],
+                    "count": 0,
+                    "message": "workouts-history.md not found",
+                }
+            )
+
+        content = history_path.read_text(encoding="utf-8")
+        if not content.strip():
+            return mcp_response(
+                {
+                    "status": "success",
+                    "analyses": [],
+                    "count": 0,
+                    "message": "workouts-history.md is empty",
+                }
+            )
+
+        # Search matching entries
+        matched_entries = _search_analyses(
+            content,
+            activity_id=activity_id,
+            session_id=session_id,
+            date=date,
+        )
+
+        # Parse and format results
+        analyses = []
+        for entry_text in matched_entries:
+            parsed = _parse_analysis_entry(entry_text)
+            if not parsed:
+                continue
+
+            if section != "full":
+                # Return only the requested section
+                section_content = parsed["sections"].get(section, "")
+                analyses.append(
+                    {
+                        "activity_name": parsed["activity_name"],
+                        "activity_id": parsed["activity_id"],
+                        "date": parsed["date"],
+                        "week_id": parsed["week_id"],
+                        "sections": {section: section_content} if section_content else {},
+                    }
+                )
+            else:
+                analyses.append(parsed)
+
+        count = len(analyses)
+        message = f"{count} analysis found" if count == 1 else f"{count} analyses found"
+
+        return mcp_response(
+            {
+                "status": "success",
+                "analyses": analyses,
+                "count": count,
+                "message": message,
+            }
+        )
+
+    except Exception as e:
+        return mcp_response({"error": f"Failed to retrieve coach analysis: {str(e)}"})

--- a/magma_cycling/_mcp/schemas/analysis.py
+++ b/magma_cycling/_mcp/schemas/analysis.py
@@ -141,4 +141,42 @@ def get_tools() -> list[Tool]:
                 "required": ["week_id"],
             },
         ),
+        Tool(
+            name="get-coach-analysis",
+            description="Retrieve past coach AI analysis from workouts-history.md by activity ID, session ID, or date",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "activity_id": {
+                        "type": "string",
+                        "description": "Intervals.icu activity ID (e.g., i131572602)",
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Planning session ID (e.g., S084-04). Uses word-boundary match to avoid partial hits.",
+                    },
+                    "date": {
+                        "type": "string",
+                        "description": "Date in YYYY-MM-DD format. Returns all analyses for that day.",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    },
+                    "section": {
+                        "type": "string",
+                        "description": "Filter to a specific section (default: full)",
+                        "enum": [
+                            "metrics_pre",
+                            "execution",
+                            "technique",
+                            "load",
+                            "validation",
+                            "attention",
+                            "recommendations",
+                            "metrics_post",
+                            "full",
+                        ],
+                        "default": "full",
+                    },
+                },
+            },
+        ),
     ]

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -37,6 +37,7 @@ from magma_cycling._mcp.handlers.analysis import (  # noqa: F401
     handle_analyze_session_adherence,
     handle_analyze_training_patterns,
     handle_export_week_to_json,
+    handle_get_coach_analysis,
     handle_get_recommendations,
     handle_get_training_statistics,
     handle_restore_week_from_backup,
@@ -175,7 +176,7 @@ TOOL_HANDLERS = {
     # Athlete (2)
     "get-athlete-profile": handle_get_athlete_profile,
     "update-athlete-profile": handle_update_athlete_profile,
-    # Analysis (7)
+    # Analysis (8)
     "validate-week-consistency": handle_validate_week_consistency,
     "get-recommendations": handle_get_recommendations,
     "analyze-session-adherence": handle_analyze_session_adherence,
@@ -183,6 +184,7 @@ TOOL_HANDLERS = {
     "export-week-to-json": handle_export_week_to_json,
     "restore-week-from-backup": handle_restore_week_from_backup,
     "analyze-training-patterns": handle_analyze_training_patterns,
+    "get-coach-analysis": handle_get_coach_analysis,
     # Admin (1)
     "reload-server": handle_reload_server,
     # Withings (8)

--- a/tests/test_mcp_coach_analysis.py
+++ b/tests/test_mcp_coach_analysis.py
@@ -1,0 +1,332 @@
+"""Tests for the get-coach-analysis MCP tool."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest_plugins = ("pytest_asyncio",)
+
+# ---------------------------------------------------------------------------
+# Fixture: sample workouts-history.md content
+# ---------------------------------------------------------------------------
+
+SAMPLE_HISTORY = """\
+### S084-04-END-EnduranceLongue-V001
+ID : i131572602
+Date : 12/03/2026
+
+#### Métriques Pré-séance
+- CTL : 45
+- ATL : 57
+- TSB : -12
+- Sommeil : 7.0h
+
+#### Exécution
+- Durée : 174min
+- IF : 0.78
+- TSS : 175
+
+#### Exécution Technique
+La séance visait une endurance longue en zone 2.
+
+#### Charge d'Entraînement
+Le TSS réalisé (175) dépasse le TSS planifié (150).
+
+#### Validation Objectifs
+- ❌ Respect intensité Z2 : IF 0.78 > 0.70
+- ✅ Découplage aérobie < 5%
+
+#### Points d'Attention
+- Surcharge non intentionnelle due au vent
+
+#### Recommandations Progression
+1. Passer en indoor pour mieux contrôler l'intensité
+2. Réduire la durée de 15min si conditions venteuses
+
+#### Métriques Post-séance
+- CTL : 45
+- ATL : 53
+- TSB : -9
+
+### S084-03-INT-TempoCourt-V001
+ID : i131572601
+Date : 11/03/2026
+
+#### Métriques Pré-séance
+- CTL : 44
+- ATL : 55
+
+#### Exécution
+- Durée : 60min
+- IF : 0.88
+
+#### Exécution Technique
+Bonne exécution des intervalles tempo.
+
+#### Charge d'Entraînement
+TSS conforme au plan.
+
+#### Validation Objectifs
+- ✅ Puissance tempo maintenue
+- ✅ Cadence cible atteinte
+
+#### Points d'Attention
+Aucun point particulier.
+
+#### Recommandations Progression
+1. Augmenter la durée des intervalles la semaine prochaine
+
+#### Métriques Post-séance
+- CTL : 44
+- ATL : 56
+
+### S084-05-REC-Recuperation-V001
+ID : i131572603
+Date : 12/03/2026
+
+#### Métriques Pré-séance
+- CTL : 45
+
+#### Exécution
+- Durée : 30min
+
+#### Exécution Technique
+Récupération active légère.
+
+#### Charge d'Entraînement
+TSS faible comme prévu.
+
+#### Validation Objectifs
+- ✅ Intensité basse respectée
+
+#### Points d'Attention
+RAS
+
+#### Recommandations Progression
+Maintenir ce type de séance après les blocs intensifs.
+
+#### Métriques Post-séance
+- CTL : 45
+"""
+
+
+@pytest.fixture
+def mock_data_config(tmp_path):
+    """Mock get_data_config to use a temp workouts-history.md."""
+    history_file = tmp_path / "workouts-history.md"
+    history_file.write_text(SAMPLE_HISTORY, encoding="utf-8")
+
+    config = MagicMock()
+    config.workouts_history_path = history_file
+
+    with patch(
+        "magma_cycling.config.get_data_config",
+        return_value=config,
+    ):
+        yield config
+
+
+@pytest.fixture
+def mock_data_config_empty(tmp_path):
+    """Mock with empty history file."""
+    history_file = tmp_path / "workouts-history.md"
+    history_file.write_text("", encoding="utf-8")
+
+    config = MagicMock()
+    config.workouts_history_path = history_file
+
+    with patch(
+        "magma_cycling.config.get_data_config",
+        return_value=config,
+    ):
+        yield config
+
+
+@pytest.fixture
+def mock_data_config_missing(tmp_path):
+    """Mock with non-existent history file."""
+    config = MagicMock()
+    config.workouts_history_path = tmp_path / "nonexistent.md"
+
+    with patch(
+        "magma_cycling.config.get_data_config",
+        return_value=config,
+    ):
+        yield config
+
+
+def _parse_result(result):
+    """Parse MCP TextContent result to dict."""
+    return json.loads(result[0].text)
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_by_activity_id(mock_data_config):
+    """Find analysis by Intervals.icu activity ID."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"activity_id": "i131572602"}))
+
+    assert result["status"] == "success"
+    assert result["count"] == 1
+    assert result["analyses"][0]["activity_id"] == "i131572602"
+    assert result["analyses"][0]["activity_name"] == "S084-04-END-EnduranceLongue-V001"
+    assert result["analyses"][0]["week_id"] == "S084"
+
+
+@pytest.mark.asyncio
+async def test_by_session_id(mock_data_config):
+    """Find analysis by session ID (word-boundary match)."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"session_id": "S084-04"}))
+
+    assert result["status"] == "success"
+    assert result["count"] == 1
+    assert result["analyses"][0]["activity_name"] == "S084-04-END-EnduranceLongue-V001"
+
+
+@pytest.mark.asyncio
+async def test_by_session_id_no_partial_match(mock_data_config):
+    """Session ID S084-0 should NOT match S084-03, S084-04, S084-05."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"session_id": "S084-0"}))
+
+    # S084-0 has word boundary after "0", but S084-03 has "3" after — no match
+    assert result["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_by_date(mock_data_config):
+    """Find all analyses for a given date (multiple results)."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"date": "2026-03-12"}))
+
+    assert result["status"] == "success"
+    assert result["count"] == 2
+    names = [a["activity_name"] for a in result["analyses"]]
+    assert "S084-04-END-EnduranceLongue-V001" in names
+    assert "S084-05-REC-Recuperation-V001" in names
+
+
+@pytest.mark.asyncio
+async def test_section_filter(mock_data_config):
+    """Filter to a specific section only."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(
+        await handle_get_coach_analysis({"activity_id": "i131572602", "section": "recommendations"})
+    )
+
+    assert result["status"] == "success"
+    assert result["count"] == 1
+    analysis = result["analyses"][0]
+    assert "recommendations" in analysis["sections"]
+    assert "indoor" in analysis["sections"]["recommendations"]
+    # When section filter is active, content should be absent
+    assert "content" not in analysis
+
+
+@pytest.mark.asyncio
+async def test_not_found(mock_data_config):
+    """Gracefully return empty when no match."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"activity_id": "i999999999"}))
+
+    assert result["status"] == "success"
+    assert result["count"] == 0
+    assert result["analyses"] == []
+
+
+@pytest.mark.asyncio
+async def test_no_params_error():
+    """Return error when no search parameter provided."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({}))
+
+    assert "error" in result
+    assert "At least one search parameter" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_structured_sections(mock_data_config):
+    """Verify all 8 sections are parsed correctly."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"activity_id": "i131572602"}))
+
+    sections = result["analyses"][0]["sections"]
+    expected_keys = [
+        "metrics_pre",
+        "execution",
+        "technique",
+        "load",
+        "validation",
+        "attention",
+        "recommendations",
+        "metrics_post",
+    ]
+    for key in expected_keys:
+        assert key in sections, f"Missing section: {key}"
+        assert sections[key], f"Empty section: {key}"
+
+    # Spot-check content
+    assert "CTL : 45" in sections["metrics_pre"]
+    assert "174min" in sections["execution"]
+    assert "❌" in sections["validation"]
+    assert "indoor" in sections["recommendations"]
+
+
+@pytest.mark.asyncio
+async def test_missing_file(mock_data_config_missing):
+    """Handle missing workouts-history.md gracefully."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"activity_id": "i131572602"}))
+
+    assert result["status"] == "success"
+    assert result["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_file(mock_data_config_empty):
+    """Handle empty workouts-history.md gracefully."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"activity_id": "i131572602"}))
+
+    assert result["status"] == "success"
+    assert result["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_invalid_section():
+    """Return error for invalid section parameter."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(
+        await handle_get_coach_analysis({"activity_id": "i131572602", "section": "nonexistent"})
+    )
+
+    assert "error" in result
+    assert "Invalid section" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_week_id_extracted(mock_data_config):
+    """Verify week_id is extracted from activity name."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    result = _parse_result(await handle_get_coach_analysis({"session_id": "S084-03"}))
+
+    assert result["analyses"][0]["week_id"] == "S084"


### PR DESCRIPTION
## Summary

- New MCP tool `get-coach-analysis` to retrieve past coach AI analyses from `workouts-history.md`
- Search by `activity_id`, `session_id` (word-boundary match), or `date` (returns all analyses for that day)
- Optional `section` filter (metrics_pre, execution, technique, load, validation, attention, recommendations, metrics_post, full)
- Response includes `week_id` extracted from activity name for planning context
- 12 tests covering all cases (search, filtering, edge cases, error handling)

## Test plan

- [x] `pytest tests/test_mcp_coach_analysis.py -x` — 12/12 passed
- [x] `pytest tests/ -x` — 2084 passed, no regression
- [x] Pre-commit hooks all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)