### PR TITLE
fix(planner): fix stale bilan and missing f-string in weekly planner prompt

### DIFF
--- a/magma_cycling/workflows/planner/context_loading.py
+++ b/magma_cycling/workflows/planner/context_loading.py
@@ -8,6 +8,112 @@ from pathlib import Path
 class ContextLoadingMixin:
     """File I/O for reference files, previous week bilan, and workout analyses."""
 
+    def _fetch_actual_tss(self, plan) -> dict[str, int] | None:
+        """Fetch actual TSS from Intervals.icu for completed sessions.
+
+        Returns a dict mapping session_id to actual TSS, or None if unavailable.
+        Uses 2 API calls: get_activities + get_events for the whole week.
+        """
+        try:
+            from magma_cycling.config import create_intervals_client
+
+            client = create_intervals_client()
+
+            start = str(plan.start_date)
+            end = str(plan.end_date)
+
+            activities = client.get_activities(oldest=start, newest=end)
+            events = client.get_events(oldest=start, newest=end)
+
+            # activity_id → icu_training_load
+            activity_tss = {}
+            for a in activities:
+                aid = a.get("id")
+                tss = a.get("icu_training_load")
+                if aid and tss is not None:
+                    activity_tss[aid] = round(tss)
+
+            # event_id → paired_activity_id
+            event_to_activity = {}
+            for e in events:
+                eid = e.get("id")
+                paid = e.get("paired_activity_id")
+                if eid and paid:
+                    event_to_activity[eid] = paid
+
+            # session_id → actual TSS
+            result = {}
+            for s in plan.planned_sessions:
+                if s.status == "completed" and s.intervals_id:
+                    activity_id = event_to_activity.get(s.intervals_id)
+                    if activity_id and activity_id in activity_tss:
+                        result[s.session_id] = activity_tss[activity_id]
+
+            return result if result else None
+        except Exception:
+            return None
+
+    def _compute_live_bilan(self, week_id: str) -> str | None:
+        """Compute bilan from Control Tower when bilan file is stale or missing."""
+        try:
+            from magma_cycling.planning.control_tower import planning_tower
+
+            plan = planning_tower.read_week(week_id)
+
+            completed = [s for s in plan.planned_sessions if s.status == "completed"]
+            active = [
+                s
+                for s in plan.planned_sessions
+                if s.status not in ("cancelled", "rest_day", "skipped")
+            ]
+
+            if not completed:
+                return None
+
+            # Try to enrich with actual TSS from Intervals.icu
+            actual_tss_map = self._fetch_actual_tss(plan)
+            has_actual = actual_tss_map is not None
+
+            if has_actual:
+                total_tss = sum(
+                    actual_tss_map.get(s.session_id, s.tss_planned or 0) for s in completed
+                )
+                tss_label = "TSS total réel"
+                tss_source = "live + Intervals.icu"
+            else:
+                total_tss = sum(s.tss_planned or 0 for s in completed)
+                tss_label = "TSS total planifié"
+                tss_source = "live"
+
+            compliance = (len(completed) / len(active) * 100) if active else 0
+
+            lines = [
+                f"# Bilan Final {week_id} (données planning {tss_source})\n",
+                "## Objectifs vs Réalisé\n",
+                f"- **Compliance :** {compliance:.1f}%",
+                f"- **Séances planifiées :** {len(active)}",
+                f"- **Séances exécutées :** {len(completed)}\n",
+                "## Métriques Clés\n",
+                f"- **{tss_label} :** {total_tss}",
+                f"- **TSS moyen :** {total_tss / len(completed):.1f}\n",
+                "## Séances Complétées\n",
+            ]
+
+            for s in completed:
+                if has_actual and s.session_id in actual_tss_map:
+                    tss_val = actual_tss_map[s.session_id]
+                    tss_display = f"TSS réel: {tss_val}"
+                else:
+                    tss_display = f"TSS planifié: {s.tss_planned or 0}"
+                lines.append(
+                    f"- {s.session_id} ({s.session_type}) — {s.name} — "
+                    f"{tss_display}, {s.duration_min or 0}min"
+                )
+
+            return "\n".join(lines)
+        except Exception:
+            return None
+
     def load_previous_week_bilan(self) -> str:
         """Load le bilan de la semaine précédente."""
         print("\n📄 Chargement bilan semaine précédente...", file=sys.stderr)
@@ -24,11 +130,31 @@ class ContextLoadingMixin:
         # Load bilan_final
         if bilan_file.exists():
             bilan_content = bilan_file.read_text(encoding="utf-8")
+
+            # Detect stale bilan: compliance 0% but completed sessions exist
+            if "Compliance : 0.0%" in bilan_content or "Séances exécutées : 0" in bilan_content:
+                live_bilan = self._compute_live_bilan(prev_week)
+                if live_bilan:
+                    print(
+                        f"  ⚠️  Bilan {prev_week} stale (0%), " "enrichi avec données planning live",
+                        file=sys.stderr,
+                    )
+                    bilan_content = live_bilan
+
             content_parts.append(f"## Bilan Final {prev_week}\n\n{bilan_content}")
             print(f"  ✅ Bilan {prev_week} chargé ({len(bilan_content)} chars)", file=sys.stderr)
         else:
-            print(f"  ⚠️ Bilan {prev_week} non trouvé : {bilan_file}", file=sys.stderr)
-            content_parts.append(f"[Bilan {prev_week} non disponible]")
+            # Fichier absent — tenter un bilan live
+            live_bilan = self._compute_live_bilan(prev_week)
+            if live_bilan:
+                print(
+                    f"  ℹ️  Bilan {prev_week} absent, généré depuis planning",
+                    file=sys.stderr,
+                )
+                content_parts.append(f"## Bilan Final {prev_week}\n\n{live_bilan}")
+            else:
+                print(f"  ⚠️ Bilan {prev_week} non trouvé : {bilan_file}", file=sys.stderr)
+                content_parts.append(f"[Bilan {prev_week} non disponible]")
 
         # Load transition (contains TSS, TSB, recommendations for next week)
         if transition_file.exists():

--- a/magma_cycling/workflows/planner/prompt.py
+++ b/magma_cycling/workflows/planner/prompt.py
@@ -96,7 +96,7 @@ class PromptMixin:
             prompt += mesocycle_context
             prompt += "\n---\n"
 
-        prompt += """
+        prompt += f"""
 ## MÉTHODOLOGIE PEAKS COACHING (HUNTER ALLEN) - PRINCIPES OBLIGATOIRES
 
 ### Distribution Intensité Hebdomadaire (Méthode Traditionnelle)

--- a/tests/test_weekly_planner_bilan.py
+++ b/tests/test_weekly_planner_bilan.py
@@ -1,0 +1,396 @@
+"""Tests for stale bilan detection and live bilan enrichment in weekly planner."""
+
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.planning.models import Session, WeeklyPlan
+from magma_cycling.workflows.planner.context_loading import ContextLoadingMixin
+
+PATCH_TOWER = "magma_cycling.planning.control_tower.planning_tower"
+PATCH_CLIENT = "magma_cycling.config.create_intervals_client"
+
+
+def _make_session(session_id, session_type, name, tss, duration, status, **kwargs):
+    """Helper to create a Session with required fields."""
+    sess_num = int(session_id.split("-")[1])
+    base_date = date(2026, 3, 9)  # Monday of S084
+    session_date = base_date + timedelta(days=sess_num - 1)
+
+    params = {
+        "session_id": session_id,
+        "date": session_date,
+        "name": name,
+        "type": session_type,
+        "tss_planned": tss,
+        "duration_min": duration,
+        "status": status,
+    }
+    if status in ("skipped", "cancelled", "replaced"):
+        params["reason"] = kwargs.get("reason", "test reason")
+    params.update(kwargs)
+    return Session(**params)
+
+
+def _make_plan(week_id, sessions):
+    """Helper to create a WeeklyPlan."""
+    start = date(2026, 3, 9)
+    return WeeklyPlan(
+        week_id=week_id,
+        start_date=start,
+        end_date=date(2026, 3, 15),
+        created_at=datetime(2026, 3, 9, tzinfo=UTC),
+        last_updated=datetime(2026, 3, 9, tzinfo=UTC),
+        version=1,
+        athlete_id="i12345",
+        tss_target=400,
+        planned_sessions=sessions,
+    )
+
+
+class FakePlanner(ContextLoadingMixin):
+    """Minimal planner stub for testing ContextLoadingMixin."""
+
+    def __init__(self, week_number, weekly_reports_dir):
+        self.week_number = week_number
+        self.weekly_reports_dir = Path(weekly_reports_dir)
+
+    def _previous_week_number(self):
+        num = int(self.week_number[1:])
+        return f"S{num - 1:03d}"
+
+
+@pytest.fixture
+def tmp_planner(tmp_path):
+    """Create a FakePlanner with temp directories."""
+    reports_dir = tmp_path / "reports"
+    reports_dir.mkdir()
+    return FakePlanner("S085", reports_dir)
+
+
+@pytest.fixture
+def s084_dir(tmp_planner):
+    """Create the S084 report directory."""
+    d = tmp_planner.weekly_reports_dir / "S084"
+    d.mkdir()
+    return d
+
+
+def _plan_with_completed_sessions(**overrides):
+    """Return a plan with 3 completed + 1 cancelled + 1 rest_day session."""
+    return _make_plan(
+        "S084",
+        [
+            _make_session(
+                "S084-01",
+                "END",
+                "EnduranceDouce",
+                50,
+                60,
+                "completed",
+                **overrides.get("s01", {}),
+            ),
+            _make_session(
+                "S084-02",
+                "INT",
+                "SweetSpot",
+                90,
+                75,
+                "completed",
+                **overrides.get("s02", {}),
+            ),
+            _make_session(
+                "S084-03",
+                "REC",
+                "Recuperation",
+                30,
+                45,
+                "completed",
+                **overrides.get("s03", {}),
+            ),
+            _make_session("S084-04", "VO2", "VO2max", 110, 60, "cancelled", reason="fatigue"),
+            _make_session("S084-05", "END", "Repos", 0, 0, "rest_day"),
+        ],
+    )
+
+
+def _plan_with_intervals_ids():
+    """Return a plan where completed sessions have intervals_id set."""
+    return _plan_with_completed_sessions(
+        s01={"intervals_id": 1001},
+        s02={"intervals_id": 1002},
+        s03={"intervals_id": 1003},
+    )
+
+
+def _mock_intervals_client(activities, events):
+    """Create a mock IntervalsClient returning given activities and events."""
+    client = MagicMock()
+    client.get_activities.return_value = activities
+    client.get_events.return_value = events
+    return client
+
+
+# =============================================================================
+# Phase 1 tests: stale detection + live bilan from Control Tower
+# =============================================================================
+
+
+class TestStaleBilanEnriched:
+    """Bilan with 0% compliance is replaced by live data."""
+
+    def test_stale_bilan_enriched(self, tmp_planner, s084_dir):
+        """Stale bilan (0% compliance) is replaced by live Control Tower data."""
+        stale_bilan = (
+            "# Bilan Final S084\n"
+            "- Compliance : 0.0%\n"
+            "- Séances exécutées : 0\n"
+            "- TSS total : 0\n"
+        )
+        (s084_dir / "bilan_final_s084.md").write_text(stale_bilan, encoding="utf-8")
+
+        plan = _plan_with_completed_sessions()
+
+        with patch(PATCH_TOWER) as mock_tower:
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        assert "données planning live" in result
+        assert "**Compliance :** 100.0%" in result
+        assert "**Séances planifiées :** 3" in result
+        assert "**Séances exécutées :** 3" in result
+        assert "**TSS total planifié :** 170" in result
+
+
+class TestNormalBilanKept:
+    """Bilan with non-zero compliance is kept as-is."""
+
+    def test_normal_bilan_kept(self, tmp_planner, s084_dir):
+        """Non-stale bilan is kept unchanged."""
+        good_bilan = (
+            "# Bilan Final S084\n"
+            "- Compliance : 85.7%\n"
+            "- Séances exécutées : 6\n"
+            "- TSS total : 420\n"
+        )
+        (s084_dir / "bilan_final_s084.md").write_text(good_bilan, encoding="utf-8")
+
+        result = tmp_planner.load_previous_week_bilan()
+
+        assert "Compliance : 85.7%" in result
+        assert "données planning live" not in result
+
+
+class TestMissingBilanLiveFallback:
+    """Missing bilan file triggers live generation from Control Tower."""
+
+    def test_missing_bilan_live_fallback(self, tmp_planner, s084_dir):
+        """Missing bilan file generates live bilan from planning data."""
+        plan = _plan_with_completed_sessions()
+
+        with patch(PATCH_TOWER) as mock_tower:
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        assert "données planning live" in result
+        assert "**Séances exécutées :** 3" in result
+
+
+class TestMissingBilanNoPlanning:
+    """Missing bilan + no planning data gives fallback message."""
+
+    def test_missing_bilan_no_planning(self, tmp_planner, s084_dir):
+        """Missing bilan with no planning data returns non-disponible message."""
+        plan = _make_plan(
+            "S084",
+            [_make_session("S084-01", "END", "Repos", 0, 0, "rest_day")],
+        )
+
+        with patch(PATCH_TOWER) as mock_tower:
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        assert "[Bilan S084 non disponible]" in result
+
+
+class TestLiveBilanListsSessions:
+    """Live bilan includes completed session details."""
+
+    def test_live_bilan_lists_sessions(self, tmp_planner, s084_dir):
+        """Live bilan lists each completed session with details."""
+        plan = _plan_with_completed_sessions()
+
+        with patch(PATCH_TOWER) as mock_tower:
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        assert "S084-01 (END)" in result
+        assert "EnduranceDouce" in result
+        assert "S084-02 (INT)" in result
+        assert "SweetSpot" in result
+        assert "S084-03 (REC)" in result
+        assert "S084-04" not in result
+
+
+class TestStaleBilanZeroSessions:
+    """Stale bilan with 'Séances exécutées : 0' pattern detected."""
+
+    def test_stale_bilan_zero_sessions_pattern(self, tmp_planner, s084_dir):
+        """Detect stale bilan via 'Séances exécutées : 0' pattern."""
+        stale_bilan = "# Bilan Final S084\n- Compliance : N/A\n- Séances exécutées : 0\n"
+        (s084_dir / "bilan_final_s084.md").write_text(stale_bilan, encoding="utf-8")
+
+        plan = _plan_with_completed_sessions()
+
+        with patch(PATCH_TOWER) as mock_tower:
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        assert "données planning live" in result
+        assert "**Séances exécutées :** 3" in result
+
+
+class TestComputeLiveBilanException:
+    """Control Tower exception returns None gracefully."""
+
+    def test_control_tower_exception(self, tmp_planner):
+        """_compute_live_bilan returns None if Control Tower fails."""
+        with patch(PATCH_TOWER) as mock_tower:
+            mock_tower.read_week.side_effect = Exception("boom")
+            result = tmp_planner._compute_live_bilan("S084")
+
+        assert result is None
+
+
+# =============================================================================
+# Phase 2 tests: actual TSS enrichment from Intervals.icu
+# =============================================================================
+
+
+class TestActualTssEnrichment:
+    """Live bilan uses actual TSS from Intervals.icu when available."""
+
+    def test_actual_tss_replaces_planned(self, tmp_planner, s084_dir):
+        """Actual TSS from activities replaces planned TSS in bilan."""
+        plan = _plan_with_intervals_ids()
+
+        activities = [
+            {"id": "i100", "icu_training_load": 21},
+            {"id": "i200", "icu_training_load": 62},
+            {"id": "i300", "icu_training_load": 175},
+        ]
+        events = [
+            {"id": 1001, "paired_activity_id": "i100"},
+            {"id": 1002, "paired_activity_id": "i200"},
+            {"id": 1003, "paired_activity_id": "i300"},
+        ]
+        mock_client = _mock_intervals_client(activities, events)
+
+        with (
+            patch(PATCH_TOWER) as mock_tower,
+            patch(PATCH_CLIENT, return_value=mock_client),
+        ):
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        # Total actual TSS: 21 + 62 + 175 = 258
+        assert "**TSS total réel :** 258" in result
+        assert "Intervals.icu" in result
+        assert "TSS réel: 21" in result
+        assert "TSS réel: 62" in result
+        assert "TSS réel: 175" in result
+
+    def test_partial_actual_tss(self, tmp_planner, s084_dir):
+        """When only some sessions have paired activities, mix actual and planned."""
+        plan = _plan_with_intervals_ids()
+
+        # Only 2 of 3 activities matched
+        activities = [
+            {"id": "i100", "icu_training_load": 21},
+            {"id": "i200", "icu_training_load": 62},
+        ]
+        events = [
+            {"id": 1001, "paired_activity_id": "i100"},
+            {"id": 1002, "paired_activity_id": "i200"},
+            # event 1003 has no paired activity yet
+            {"id": 1003},
+        ]
+        mock_client = _mock_intervals_client(activities, events)
+
+        with (
+            patch(PATCH_TOWER) as mock_tower,
+            patch(PATCH_CLIENT, return_value=mock_client),
+        ):
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        # Total: 21 + 62 + 30 (planned fallback for S084-03)
+        assert "**TSS total réel :** 113" in result
+        assert "TSS réel: 21" in result
+        assert "TSS réel: 62" in result
+        assert "TSS planifié: 30" in result  # S084-03 falls back to planned
+
+    def test_api_failure_falls_back_to_planned(self, tmp_planner, s084_dir):
+        """When Intervals.icu API fails, gracefully fall back to planned TSS."""
+        plan = _plan_with_intervals_ids()
+
+        with (
+            patch(PATCH_TOWER) as mock_tower,
+            patch(PATCH_CLIENT, side_effect=Exception("API down")),
+        ):
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        assert "**TSS total planifié :** 170" in result
+        assert "TSS planifié: 50" in result
+        assert "TSS réel" not in result
+
+    def test_no_intervals_id_uses_planned(self, tmp_planner, s084_dir):
+        """Sessions without intervals_id always use planned TSS."""
+        plan = _plan_with_completed_sessions()  # No intervals_id
+
+        with patch(PATCH_TOWER) as mock_tower:
+            mock_tower.read_week.return_value = plan
+            result = tmp_planner.load_previous_week_bilan()
+
+        assert "**TSS total planifié :** 170" in result
+        assert "TSS planifié: 50" in result
+
+
+class TestFetchActualTss:
+    """Unit tests for _fetch_actual_tss method."""
+
+    def test_returns_tss_map(self, tmp_planner):
+        """Returns dict mapping session_id to actual TSS."""
+        plan = _plan_with_intervals_ids()
+
+        activities = [{"id": "i100", "icu_training_load": 42.7}]
+        events = [{"id": 1001, "paired_activity_id": "i100"}]
+        mock_client = _mock_intervals_client(activities, events)
+
+        with patch(PATCH_CLIENT, return_value=mock_client):
+            result = tmp_planner._fetch_actual_tss(plan)
+
+        assert result == {"S084-01": 43}  # Rounded
+
+    def test_returns_none_on_empty_match(self, tmp_planner):
+        """Returns None when no sessions match activities."""
+        plan = _plan_with_intervals_ids()
+
+        mock_client = _mock_intervals_client([], [])
+
+        with patch(PATCH_CLIENT, return_value=mock_client):
+            result = tmp_planner._fetch_actual_tss(plan)
+
+        assert result is None
+
+    def test_returns_none_on_exception(self, tmp_planner):
+        """Returns None when API call raises an exception."""
+        plan = _plan_with_intervals_ids()
+
+        with patch(PATCH_CLIENT, side_effect=Exception("timeout")):
+            result = tmp_planner._fetch_actual_tss(plan)
+
+        assert result is None


### PR DESCRIPTION
## Summary

- **Bug #1**: `prompt.py:99` was a regular string instead of f-string — ~15 expressions (`{self.context_files}`, `{self.week_number}`, etc.) appeared as literal text in the prompt (prompt jumped from 16K to 145K chars after fix)
- **Bug #2**: `load_previous_week_bilan()` now detects stale bilan files (0% compliance) and replaces them with live data from the Control Tower
- **Phase 2**: `_fetch_actual_tss()` enriches live bilan with real TSS from Intervals.icu (2 API calls per week), graceful fallback to `tss_planned`

## Test plan

- [x] 14 tests in `tests/test_weekly_planner_bilan.py` (stale detection, live fallback, actual TSS enrichment, API failure)
- [x] Full test suite: 2098 passed, 0 failed
- [x] Pre-commit hooks: all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)