### PR TITLE
fix(mcp): handle None values in get-activity-streams stats computation

### DIFF
--- a/magma_cycling/_mcp/handlers/intervals.py
+++ b/magma_cycling/_mcp/handlers/intervals.py
@@ -733,12 +733,17 @@ async def handle_get_activity_streams(args: dict) -> list[TextContent]:
             data = stream["data"][start_index:end_index]
             stats = {}
             if data:
-                stats["min"] = min(data)
-                stats["max"] = max(data)
-                stats["avg"] = round(sum(data) / len(data), 2)
-                non_zero = [v for v in data if v != 0]
-                stats["non_zero_count"] = len(non_zero)
-                stats["non_zero_avg"] = round(sum(non_zero) / len(non_zero), 2) if non_zero else 0
+                valid = [v for v in data if v is not None]
+                if valid:
+                    stats["min"] = min(valid)
+                    stats["max"] = max(valid)
+                    stats["avg"] = round(sum(valid) / len(valid), 2)
+                    non_zero = [v for v in valid if v != 0]
+                    stats["non_zero_count"] = len(non_zero)
+                    stats["non_zero_avg"] = (
+                        round(sum(non_zero) / len(non_zero), 2) if non_zero else 0
+                    )
+                stats["null_count"] = len(data) - len(valid) if valid else len(data)
             result_streams.append(
                 {
                     "type": stream["type"],

--- a/tests/test_mcp_handlers.py
+++ b/tests/test_mcp_handlers.py
@@ -1311,6 +1311,52 @@ async def test_get_activity_streams_stats_computation(mock_intervals_client):
 
 
 @pytest.mark.asyncio
+async def test_get_activity_streams_stats_with_none_values(mock_intervals_client):
+    """Stats correctly handle None values in stream data (sensor gaps)."""
+    mock_intervals_client.get_activity_streams = Mock(
+        return_value=[{"type": "watts", "data": [100, None, 200, None, 300]}]
+    )
+
+    with patch(
+        "magma_cycling.config.create_intervals_client",
+        return_value=mock_intervals_client,
+    ):
+        from magma_cycling.mcp_server import handle_get_activity_streams
+
+        result = await handle_get_activity_streams({"activity_id": "i123456"})
+        r = json.loads(result[0].text)
+
+        stats = r["streams"][0]["stats"]
+        assert stats["min"] == 100
+        assert stats["max"] == 300
+        assert stats["avg"] == 200.0  # (100+200+300)/3
+        assert stats["null_count"] == 2
+        assert stats["non_zero_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_get_activity_streams_all_none_values(mock_intervals_client):
+    """All-None stream data returns empty stats with null_count."""
+    mock_intervals_client.get_activity_streams = Mock(
+        return_value=[{"type": "watts", "data": [None, None, None]}]
+    )
+
+    with patch(
+        "magma_cycling.config.create_intervals_client",
+        return_value=mock_intervals_client,
+    ):
+        from magma_cycling.mcp_server import handle_get_activity_streams
+
+        result = await handle_get_activity_streams({"activity_id": "i123456"})
+        r = json.loads(result[0].text)
+
+        stats = r["streams"][0]["stats"]
+        assert "min" not in stats
+        assert "max" not in stats
+        assert stats["null_count"] == 3
+
+
+@pytest.mark.asyncio
 async def test_get_activity_streams_missing_type_reported(mock_intervals_client):
     """Requesting a nonexistent type reports it in missing_types."""
     mock_intervals_client.get_activity_streams = Mock(return_value=MOCK_STREAMS)


### PR DESCRIPTION
## Summary

- `min()`/`max()`/`sum()` on stream data containing `None` values (sensor gaps, ANT+ dropouts) caused `TypeError: '<' not supported between NoneType instances`
- Filter out `None` values before computing stats, report `null_count` for data quality transparency
- Tested on activities with known sensor issues (ANT+ dropout on S083-06)

## Test plan

- [x] New test: `test_get_activity_streams_stats_with_none_values` — mixed None/numeric data
- [x] New test: `test_get_activity_streams_all_none_values` — all-None stream
- [x] Existing stats test still passes (no regression)
- [x] Full test suite: 2103 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)