### PR TITLE
fix(mcp): analysis header + daily report fallback for get-coach-analysis

### DIFF
--- a/magma_cycling/_mcp/handlers/analysis.py
+++ b/magma_cycling/_mcp/handlers/analysis.py
@@ -720,6 +720,111 @@ def _search_analyses(
     return results
 
 
+def _search_daily_reports(
+    reports_dir: Path,
+    activity_id: str | None = None,
+    session_id: str | None = None,
+    date: str | None = None,
+) -> list[str]:
+    r"""Search daily report files for AI analyses as fallback.
+
+    Daily reports use a different format than workouts-history.md::
+
+        ### ACTIVITY_NAME
+        - **ID**: activity_id
+        ...
+        #### 🤖 Analyse AI
+        [analysis content]
+
+    Returns analysis entries reconstituted in the workouts-history.md
+    header format (``### NAME\nID : xxx\nDate : xxx``) so they can be
+    parsed by ``_parse_analysis_entry``.
+    """
+    if not reports_dir.exists():
+        return []
+
+    # Determine which files to scan
+    if date:
+        # Target specific file
+        target = reports_dir / f"daily_report_{date}.md"
+        report_files = [target] if target.exists() else []
+    else:
+        # Scan recent files (last 30 days)
+        from datetime import date as date_cls
+        from datetime import timedelta as td
+
+        today = date_cls.today()
+        report_files = []
+        for i in range(30):
+            d = today - td(days=i)
+            f = reports_dir / f"daily_report_{d.isoformat()}.md"
+            if f.exists():
+                report_files.append(f)
+
+    results = []
+    for report_file in report_files:
+        content = report_file.read_text(encoding="utf-8")
+
+        # Extract report date from filename (daily_report_YYYY-MM-DD.md)
+        file_date_match = re.search(r"daily_report_(\d{4}-\d{2}-\d{2})\.md", report_file.name)
+        if not file_date_match:
+            continue
+        file_date_iso = file_date_match.group(1)
+        parts = file_date_iso.split("-")
+        file_date_fr = f"{parts[2]}/{parts[1]}/{parts[0]}"
+
+        # Split on ### headers (activity entries in daily report)
+        raw_entries = re.split(r"(?:^|\n)(?=### )", content)
+
+        for entry in raw_entries:
+            entry = entry.strip()
+            if not entry.startswith("### "):
+                continue
+
+            # Skip non-activity headings (e.g. report title)
+            if entry.startswith("### ") and "Rapport" in entry.split("\n")[0]:
+                continue
+
+            # Extract activity name from ### line
+            name_line = entry.split("\n")[0]
+            act_name = name_line.lstrip("#").strip()
+
+            # Extract ID from - **ID**: value
+            id_match = re.search(r"-\s*\*\*ID\*\*\s*:\s*(\S+)", entry)
+            act_id = id_match.group(1) if id_match else ""
+
+            # Filter by activity_id
+            if activity_id and act_id != activity_id:
+                continue
+
+            # Filter by session_id (prefix match on activity name)
+            if session_id and not re.match(rf"{re.escape(session_id)}\b", act_name):
+                continue
+
+            # Extract AI analysis section
+            ai_match = re.search(r"####\s*🤖\s*Analyse AI\s*\n(.*)", entry, re.DOTALL)
+            if not ai_match:
+                continue
+
+            analysis_body = ai_match.group(1).strip()
+            if not analysis_body:
+                continue
+
+            # Upgrade ##### back to #### (reverse the normalization done for reports)
+            analysis_body = re.sub(r"^##### ", "#### ", analysis_body, flags=re.MULTILINE)
+
+            # Reconstitute in workouts-history.md format
+            reconstituted = (
+                f"### {act_name}\n"
+                f"ID : {act_id}\n"
+                f"Date : {file_date_fr}\n\n"
+                f"{analysis_body}"
+            )
+            results.append(reconstituted)
+
+    return results
+
+
 async def handle_get_coach_analysis(args: dict) -> list[TextContent]:
     """Retrieve coach AI analysis from workouts-history.md."""
     activity_id = args.get("activity_id")
@@ -750,34 +855,30 @@ async def handle_get_coach_analysis(args: dict) -> list[TextContent]:
         config = get_data_config()
         history_path = config.workouts_history_path
 
-        if not history_path.exists():
-            return mcp_response(
-                {
-                    "status": "success",
-                    "analyses": [],
-                    "count": 0,
-                    "message": "workouts-history.md not found",
-                }
-            )
+        # Search in workouts-history.md
+        matched_entries = []
+        if history_path.exists():
+            content = history_path.read_text(encoding="utf-8")
+            if content.strip():
+                matched_entries = _search_analyses(
+                    content,
+                    activity_id=activity_id,
+                    session_id=session_id,
+                    date=date,
+                )
 
-        content = history_path.read_text(encoding="utf-8")
-        if not content.strip():
-            return mcp_response(
-                {
-                    "status": "success",
-                    "analyses": [],
-                    "count": 0,
-                    "message": "workouts-history.md is empty",
-                }
+        # Fallback: search in daily reports if nothing found
+        source = "workouts_history"
+        if not matched_entries:
+            reports_dir = config.data_repo_path / "daily-reports"
+            matched_entries = _search_daily_reports(
+                reports_dir,
+                activity_id=activity_id,
+                session_id=session_id,
+                date=date,
             )
-
-        # Search matching entries
-        matched_entries = _search_analyses(
-            content,
-            activity_id=activity_id,
-            session_id=session_id,
-            date=date,
-        )
+            if matched_entries:
+                source = "daily_report"
 
         # Parse and format results
         analyses = []
@@ -809,6 +910,7 @@ async def handle_get_coach_analysis(args: dict) -> list[TextContent]:
                 "status": "success",
                 "analyses": analyses,
                 "count": count,
+                "source": source,
                 "message": message,
             }
         )

--- a/magma_cycling/workflows/sync/ai_analysis.py
+++ b/magma_cycling/workflows/sync/ai_analysis.py
@@ -92,11 +92,11 @@ class AIAnalysisMixin:
 
             # Extract date from activity
             activity_date = date.fromisoformat(activity["start_date_local"].split("T")[0])
-            activity_date_str = activity_date.strftime("%d/%m/%Y")
+            activity_date_fr = activity_date.strftime("%d/%m/%Y")
 
             # Check if analysis already exists
             existing_analysis = self._extract_existing_analysis(
-                activity_name, activity_id, activity_date_str
+                activity_name, activity_id, activity_date_fr
             )
 
             if existing_analysis:
@@ -230,9 +230,19 @@ class AIAnalysisMixin:
                         print(f"     ⚠️  Impossible de capturer adhérence : {e}")
 
                 # Insert analysis into workouts-history.md
+                # Ensure the standard header is present for insert_analysis()
+                if not analysis.strip().startswith("### "):
+                    formatted = (
+                        f"### {activity_name}\n"
+                        f"ID : {activity_id}\n"
+                        f"Date : {activity_date_fr}\n\n" + analysis
+                    )
+                else:
+                    formatted = analysis
+
                 print("     📝 Insertion dans workouts-history.md...")
                 try:
-                    if self.history_manager.insert_analysis(analysis):
+                    if self.history_manager.insert_analysis(formatted):
                         print("     ✅ Analyse insérée dans workouts-history.md")
                     else:
                         print("     ⚠️  Échec insertion (analyse utilisée quand même)")

--- a/tests/test_daily_sync_analysis_header.py
+++ b/tests/test_daily_sync_analysis_header.py
@@ -1,0 +1,159 @@
+"""Tests for analysis header prepend in daily-sync ai_analysis.py."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+@pytest.fixture
+def ai_analysis_mixin():
+    """Create an AIAnalysisMixin instance with mocked dependencies."""
+    from magma_cycling.workflows.sync.ai_analysis import AIAnalysisMixin
+
+    mixin = AIAnalysisMixin.__new__(AIAnalysisMixin)
+    mixin.enable_ai_analysis = True
+    mixin.ai_analyzer = Mock()
+    mixin.history_manager = Mock()
+    mixin.client = Mock()
+    mixin.prompt_generator = Mock()
+    return mixin
+
+
+def _make_activity(name="S084-04-END-EnduranceLongue-V001", activity_id="i131572602"):
+    """Create a mock activity dict."""
+    return {
+        "id": activity_id,
+        "name": name,
+        "start_date_local": "2026-03-12T10:00:00",
+        "type": "VirtualRide",
+        "moving_time": 5400,
+        "icu_training_load": 80,
+        "icu_intensity": 0.72,
+    }
+
+
+class TestAnalysisHeaderPrepend:
+    """Tests for header prepend logic in analyze_activity()."""
+
+    def test_raw_analysis_gets_header_prepended(self, ai_analysis_mixin):
+        """Analysis without ### header gets the standard header prepended."""
+        raw_analysis = (
+            "#### Métriques Pré-séance\n"
+            "- CTL : 45\n"
+            "- ATL : 57\n\n"
+            "#### Exécution\n"
+            "- Durée : 90min\n"
+            "- IF : 0.72\n"
+        )
+        ai_analysis_mixin.ai_analyzer.analyze_session.return_value = raw_analysis
+        ai_analysis_mixin.history_manager.insert_analysis.return_value = True
+        ai_analysis_mixin.history_manager.read_history.return_value = ""
+        ai_analysis_mixin.client.get_wellness.return_value = []
+        ai_analysis_mixin.prompt_generator.load_athlete_context.return_value = {}
+        ai_analysis_mixin.prompt_generator.load_recent_workouts.return_value = []
+        ai_analysis_mixin.prompt_generator.format_activity_data.return_value = {}
+        ai_analysis_mixin.prompt_generator.load_periodization_context.return_value = {}
+        ai_analysis_mixin.prompt_generator.generate_prompt.return_value = "prompt"
+
+        activity = _make_activity()
+
+        with (
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.load_current_metrics",
+                return_value={},
+            ),
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.build_prompt",
+                return_value=("system", ""),
+            ),
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.planning_tower",
+            ),
+        ):
+            result = ai_analysis_mixin.analyze_activity(activity)
+
+        assert result == raw_analysis
+
+        # Verify insert_analysis was called with the header-prepended version
+        call_args = ai_analysis_mixin.history_manager.insert_analysis.call_args[0][0]
+        assert call_args.startswith("### S084-04-END-EnduranceLongue-V001\n")
+        assert "ID : i131572602\n" in call_args
+        assert "Date : 12/03/2026\n" in call_args
+        assert "#### Métriques Pré-séance" in call_args
+
+    def test_analysis_with_header_kept_as_is(self, ai_analysis_mixin):
+        """Analysis already starting with ### is not double-headed."""
+        formatted_analysis = (
+            "### S084-04-END-EnduranceLongue-V001\n"
+            "ID : i131572602\n"
+            "Date : 12/03/2026\n\n"
+            "#### Exécution\n"
+            "- Durée : 90min\n"
+        )
+        ai_analysis_mixin.ai_analyzer.analyze_session.return_value = formatted_analysis
+        ai_analysis_mixin.history_manager.insert_analysis.return_value = True
+        ai_analysis_mixin.history_manager.read_history.return_value = ""
+        ai_analysis_mixin.client.get_wellness.return_value = []
+        ai_analysis_mixin.prompt_generator.load_athlete_context.return_value = {}
+        ai_analysis_mixin.prompt_generator.load_recent_workouts.return_value = []
+        ai_analysis_mixin.prompt_generator.format_activity_data.return_value = {}
+        ai_analysis_mixin.prompt_generator.load_periodization_context.return_value = {}
+        ai_analysis_mixin.prompt_generator.generate_prompt.return_value = "prompt"
+
+        activity = _make_activity()
+
+        with (
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.load_current_metrics",
+                return_value={},
+            ),
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.build_prompt",
+                return_value=("system", ""),
+            ),
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.planning_tower",
+            ),
+        ):
+            ai_analysis_mixin.analyze_activity(activity)
+
+        # insert_analysis should receive the original (already formatted) analysis
+        call_args = ai_analysis_mixin.history_manager.insert_analysis.call_args[0][0]
+        assert call_args == formatted_analysis
+        # No double ### header
+        assert call_args.count("### S084-04") == 1
+
+    def test_header_uses_french_date(self, ai_analysis_mixin):
+        """Prepended header uses DD/MM/YYYY date format, not ISO."""
+        raw_analysis = "#### Exécution\n- Durée : 60min\n"
+        ai_analysis_mixin.ai_analyzer.analyze_session.return_value = raw_analysis
+        ai_analysis_mixin.history_manager.insert_analysis.return_value = True
+        ai_analysis_mixin.history_manager.read_history.return_value = ""
+        ai_analysis_mixin.client.get_wellness.return_value = []
+        ai_analysis_mixin.prompt_generator.load_athlete_context.return_value = {}
+        ai_analysis_mixin.prompt_generator.load_recent_workouts.return_value = []
+        ai_analysis_mixin.prompt_generator.format_activity_data.return_value = {}
+        ai_analysis_mixin.prompt_generator.load_periodization_context.return_value = {}
+        ai_analysis_mixin.prompt_generator.generate_prompt.return_value = "prompt"
+
+        activity = _make_activity()
+
+        with (
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.load_current_metrics",
+                return_value={},
+            ),
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.build_prompt",
+                return_value=("system", ""),
+            ),
+            patch(
+                "magma_cycling.workflows.sync.ai_analysis.planning_tower",
+            ),
+        ):
+            ai_analysis_mixin.analyze_activity(activity)
+
+        call_args = ai_analysis_mixin.history_manager.insert_analysis.call_args[0][0]
+        # Date should be DD/MM/YYYY (French format), not 2026-03-12 (ISO)
+        assert "Date : 12/03/2026" in call_args
+        assert "2026-03-12" not in call_args

--- a/tests/test_mcp_coach_analysis.py
+++ b/tests/test_mcp_coach_analysis.py
@@ -119,6 +119,7 @@ def mock_data_config(tmp_path):
 
     config = MagicMock()
     config.workouts_history_path = history_file
+    config.data_repo_path = tmp_path
 
     with patch(
         "magma_cycling.config.get_data_config",
@@ -135,6 +136,7 @@ def mock_data_config_empty(tmp_path):
 
     config = MagicMock()
     config.workouts_history_path = history_file
+    config.data_repo_path = tmp_path
 
     with patch(
         "magma_cycling.config.get_data_config",
@@ -148,6 +150,7 @@ def mock_data_config_missing(tmp_path):
     """Mock with non-existent history file."""
     config = MagicMock()
     config.workouts_history_path = tmp_path / "nonexistent.md"
+    config.data_repo_path = tmp_path
 
     with patch(
         "magma_cycling.config.get_data_config",

--- a/tests/test_mcp_handlers.py
+++ b/tests/test_mcp_handlers.py
@@ -1414,5 +1414,165 @@ async def test_get_activity_streams_api_error(mock_intervals_client):
         assert r["activity_id"] == "i123456"
 
 
+# ---------------------------------------------------------------------------
+# Tests: get-coach-analysis fallback to daily reports
+# ---------------------------------------------------------------------------
+
+SAMPLE_DAILY_REPORT = """\
+# Rapport Quotidien - 12/03/2026
+
+**Généré le**: 13/03/2026 à 06:46
+
+---
+
+## 📊 Activités Complétées
+
+**1 nouvelle(s) activité(s) détectée(s)**
+
+### S084-04-END-EnduranceLongue-V001
+
+- **ID**: i131572602
+- **Type**: Ride
+- **TSS**: 175 (réalisé)
+- **Durée**: 174 min
+- **Activité liée**: N/A
+
+#### 🤖 Analyse AI
+
+##### Métriques Pré-séance
+- CTL : 45
+- ATL : 57
+- TSB : -12
+
+##### Exécution
+- Durée : 174min
+- IF : 0.78
+- TSS : 175
+
+##### Exécution Technique
+La séance visait une endurance longue en zone 2.
+
+---
+
+## 📅 Modifications Planning
+
+*Aucune modification détectée dans le planning*
+"""
+
+
+@pytest.mark.asyncio
+async def test_get_coach_analysis_fallback_daily_report(tmp_path):
+    """When workouts-history.md has no match, fallback finds it in daily report."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    # Create empty workouts-history.md
+    history_path = tmp_path / "workouts-history.md"
+    history_path.write_text("")
+
+    # Create daily report with an analysis
+    reports_dir = tmp_path / "daily-reports"
+    reports_dir.mkdir()
+    report_file = reports_dir / "daily_report_2026-03-12.md"
+    report_file.write_text(SAMPLE_DAILY_REPORT)
+
+    mock_config = Mock()
+    mock_config.workouts_history_path = history_path
+    mock_config.data_repo_path = tmp_path
+
+    with patch("magma_cycling.config.get_data_config", return_value=mock_config):
+        result = await handle_get_coach_analysis({"activity_id": "i131572602", "section": "full"})
+
+    result_json = json.loads(result[0].text)
+
+    assert result_json["count"] == 1
+    assert result_json["source"] == "daily_report"
+    assert result_json["analyses"][0]["activity_id"] == "i131572602"
+    assert result_json["analyses"][0]["activity_name"] == "S084-04-END-EnduranceLongue-V001"
+    assert result_json["analyses"][0]["date"] == "12/03/2026"
+
+
+@pytest.mark.asyncio
+async def test_get_coach_analysis_no_fallback_when_found(tmp_path):
+    """When workouts-history.md has results, daily reports are NOT searched."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    # Create workouts-history.md with matching entry
+    history_content = (
+        "### S084-04-END-EnduranceLongue-V001\n"
+        "ID : i131572602\n"
+        "Date : 12/03/2026\n\n"
+        "#### Exécution\n"
+        "- Durée : 174min\n"
+        "- IF : 0.78\n"
+    )
+    history_path = tmp_path / "workouts-history.md"
+    history_path.write_text(history_content)
+
+    mock_config = Mock()
+    mock_config.workouts_history_path = history_path
+    mock_config.data_repo_path = tmp_path
+
+    with patch("magma_cycling.config.get_data_config", return_value=mock_config):
+        result = await handle_get_coach_analysis({"activity_id": "i131572602", "section": "full"})
+
+    result_json = json.loads(result[0].text)
+
+    assert result_json["count"] == 1
+    assert result_json["source"] == "workouts_history"
+    assert result_json["analyses"][0]["activity_id"] == "i131572602"
+
+
+@pytest.mark.asyncio
+async def test_get_coach_analysis_fallback_by_session_id(tmp_path):
+    """Fallback to daily report works with session_id filter."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    # Empty history
+    history_path = tmp_path / "workouts-history.md"
+    history_path.write_text("")
+
+    reports_dir = tmp_path / "daily-reports"
+    reports_dir.mkdir()
+    (reports_dir / "daily_report_2026-03-12.md").write_text(SAMPLE_DAILY_REPORT)
+
+    mock_config = Mock()
+    mock_config.workouts_history_path = history_path
+    mock_config.data_repo_path = tmp_path
+
+    with patch("magma_cycling.config.get_data_config", return_value=mock_config):
+        result = await handle_get_coach_analysis({"session_id": "S084-04", "section": "full"})
+
+    result_json = json.loads(result[0].text)
+
+    assert result_json["count"] == 1
+    assert result_json["source"] == "daily_report"
+    assert "S084-04" in result_json["analyses"][0]["activity_name"]
+
+
+@pytest.mark.asyncio
+async def test_get_coach_analysis_fallback_by_date(tmp_path):
+    """Fallback to daily report works with date filter."""
+    from magma_cycling._mcp.handlers.analysis import handle_get_coach_analysis
+
+    history_path = tmp_path / "workouts-history.md"
+    history_path.write_text("")
+
+    reports_dir = tmp_path / "daily-reports"
+    reports_dir.mkdir()
+    (reports_dir / "daily_report_2026-03-12.md").write_text(SAMPLE_DAILY_REPORT)
+
+    mock_config = Mock()
+    mock_config.workouts_history_path = history_path
+    mock_config.data_repo_path = tmp_path
+
+    with patch("magma_cycling.config.get_data_config", return_value=mock_config):
+        result = await handle_get_coach_analysis({"date": "2026-03-12", "section": "full"})
+
+    result_json = json.loads(result[0].text)
+
+    assert result_json["count"] == 1
+    assert result_json["source"] == "daily_report"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- **Volet 1**: Prepend standard `### header` (name, ID, date FR) before `insert_analysis()` when AI response lacks it — fixes entries invisible to `get-coach-analysis`
- **Volet 2**: Add fallback in `get-coach-analysis` to search `daily_report_*.md` files when `workouts-history.md` has no match (response includes `source` field)
- Fix `activity_date_str` variable shadowing (renamed to `activity_date_fr`)

## Test plan

- [x] `test_daily_sync_analysis_header.py` — 3 tests: raw analysis gets header, no double header, French date format
- [x] `test_mcp_handlers.py` — 4 new tests: fallback activated, fallback inhibited, search by session_id, by date
- [x] `test_mcp_coach_analysis.py` — fixture fix for `data_repo_path` (12 existing tests pass)
- [x] Full suite: 2110 passed, 0 failed
- [x] Pre-commit hooks: all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)