### PR TITLE
feat(validator): detect mono-bloc warmup/cooldown

### DIFF
--- a/magma_cycling/_mcp/handlers/workouts.py
+++ b/magma_cycling/_mcp/handlers/workouts.py
@@ -123,6 +123,7 @@ async def handle_validate_workout(args: dict) -> list[TextContent]:
             # Si auto_fix demandé et qu'il y a des warnings
             if auto_fix and (errors or warnings):
                 corrected_text = validator.fix_repetition_format(workout_text)
+                corrected_text = validator.fix_warmup_cooldown(corrected_text)
 
                 # Revalider le texte corrigé
                 is_valid_after, errors_after, warnings_after = validator.validate_workout(

--- a/magma_cycling/intervals_format_validator.py
+++ b/magma_cycling/intervals_format_validator.py
@@ -74,6 +74,9 @@ class IntervalsFormatValidator:
 
     # Sections valides
     VALID_SECTIONS = ["Warmup", "Main set", "Cooldown", "Block"]
+    SECTION_TITLE_PATTERN = re.compile(
+        r"^(Warmup|Main\s+set|Cooldown|Block)(\s+\d+x)?\.?\s*$", re.IGNORECASE
+    )
 
     def __init__(self):
         """Initialize intervals format validator."""
@@ -109,6 +112,9 @@ class IntervalsFormatValidator:
 
         # Check 4: Structure minimale
         self._check_minimal_structure(lines)
+
+        # Check 5: Warmup/Cooldown mono-bloc sans justification
+        self._check_warmup_cooldown_ramp(lines)
 
         return (len(self.errors) == 0, self.errors, self.warnings)
 
@@ -201,6 +207,123 @@ class IntervalsFormatValidator:
                 "(format attendu: '- Xm Y% Zrpm'). "
                 "Le texte libre n'est pas un format workout valide."
             )
+
+    def _parse_sections(self, lines: list[str]) -> dict[str, list[str]]:
+        """Parse workout text into named sections."""
+        sections = {}
+        current = None
+        for line in lines:
+            stripped = line.strip()
+            match = self.SECTION_TITLE_PATTERN.match(stripped)
+            if match:
+                current = match.group(1).strip().lower().replace(" ", "_")
+                sections[current] = []
+            elif current is not None:
+                sections[current].append(stripped)
+        return sections
+
+    def _check_warmup_cooldown_ramp(self, lines: list[str]):
+        """Detect mono-bloc warmup/cooldown without justification."""
+        sections = self._parse_sections(lines)
+
+        for section_key, label in [("warmup", "Warmup"), ("cooldown", "Cooldown")]:
+            if section_key not in sections:
+                continue
+            section_lines = sections[section_key]
+
+            interval_lines = [ln for ln in section_lines if re.match(self.INTERVAL_PATTERN, ln)]
+            if len(interval_lines) != 1:
+                continue
+
+            has_justification = any(ln.startswith("\u2699\ufe0f") for ln in section_lines)
+            if has_justification:
+                continue
+
+            intensity = ""
+            pct_match = re.search(r"(\d+(?:-\d+)?%)", interval_lines[0])
+            if pct_match:
+                intensity = pct_match.group(1)
+
+            if label == "Warmup":
+                self.warnings.append(
+                    f"{label} mono-bloc d\u00e9tect\u00e9 (1 palier \u00e0 {intensity}). "
+                    f"Ramp progressive recommand\u00e9e (3 paliers min). "
+                    f"Si intentionnel, ajouter une ligne \u2699\ufe0f avec la justification."
+                )
+            else:
+                self.warnings.append(
+                    f"{label} mono-bloc d\u00e9tect\u00e9 (1 palier \u00e0 {intensity}). "
+                    f"Ramp descendante recommand\u00e9e. "
+                    f"Si intentionnel, ajouter une ligne \u2699\ufe0f avec la justification."
+                )
+
+    def fix_warmup_cooldown(self, workout_text: str) -> str:
+        """Replace mono-bloc warmup/cooldown with 3-step ramp."""
+        lines = workout_text.split("\n")
+        sections = self._parse_sections(lines)
+        result = []
+        i = 0
+        while i < len(lines):
+            stripped = lines[i].strip()
+            match = self.SECTION_TITLE_PATTERN.match(stripped)
+            if match:
+                section_key = match.group(1).strip().lower().replace(" ", "_")
+                if section_key in ("warmup", "cooldown") and section_key in sections:
+                    section_lines = sections[section_key]
+                    intervals = [ln for ln in section_lines if re.match(self.INTERVAL_PATTERN, ln)]
+                    has_just = any(ln.startswith("\u2699\ufe0f") for ln in section_lines)
+                    if len(intervals) == 1 and not has_just:
+                        result.append(lines[i])
+                        ramp = self._generate_ramp(intervals[0], section_key == "cooldown")
+                        # Skip original section content
+                        i += 1
+                        while i < len(lines):
+                            s = lines[i].strip()
+                            if self.SECTION_TITLE_PATTERN.match(s) or (
+                                not s
+                                and i + 1 < len(lines)
+                                and self.SECTION_TITLE_PATTERN.match(lines[i + 1].strip())
+                            ):
+                                break
+                            i += 1
+                        for rl in ramp:
+                            result.append(rl)
+                        result.append("")
+                        continue
+            result.append(lines[i])
+            i += 1
+        return "\n".join(result)
+
+    @staticmethod
+    def _generate_ramp(interval_line: str, descending: bool) -> list[str]:
+        """Generate a 3-step ramp from a mono-bloc interval line."""
+        dur_match = re.search(r"(\d+)([msh])", interval_line)
+        pct_match = re.search(r"(\d+)%", interval_line)
+        rpm_match = re.search(r"(\d+)rpm", interval_line)
+
+        total_dur = int(dur_match.group(1)) if dur_match else 15
+        dur_unit = dur_match.group(2) if dur_match else "m"
+        target_pct = int(pct_match.group(1)) if pct_match else 65
+        rpm_str = f" {rpm_match.group(0)}" if rpm_match else ""
+
+        d1 = total_dur // 3
+        d2 = total_dur // 3
+        d3 = total_dur - d1 - d2
+
+        base_pct = min(50, target_pct - 10)
+        mid_pct = (base_pct + target_pct) // 2
+
+        if descending:
+            return [
+                f"- {d1}{dur_unit} {target_pct}%{rpm_str}",
+                f"- {d2}{dur_unit} {mid_pct}%{rpm_str}",
+                f"- {d3}{dur_unit} {base_pct}%{rpm_str}",
+            ]
+        return [
+            f"- {d1}{dur_unit} {base_pct}%{rpm_str}",
+            f"- {d2}{dur_unit} {mid_pct}%{rpm_str}",
+            f"- {d3}{dur_unit} {target_pct}%{rpm_str}",
+        ]
 
     def fix_repetition_format(self, workout_text: str) -> str:
         """

--- a/tests/test_intervals_format_validator.py
+++ b/tests/test_intervals_format_validator.py
@@ -65,3 +65,92 @@ class TestRampValidation:
         is_valid, errors, _warnings = validator.validate_workout(workout)
         assert not is_valid
         assert any("ramp" in e.lower() for e in errors)
+
+
+class TestWarmupCooldownMonoBloc:
+    """Tests for mono-bloc warmup/cooldown detection."""
+
+    def test_warmup_mono_bloc_warns(self):
+        """Single warmup block without justification triggers warning."""
+        v = IntervalsFormatValidator()
+        workout = "Warmup\n- 15m 65% 85rpm\n\nMain set\n- 20m 90% 92rpm\n\nCooldown\n- 5m 50% 85rpm\n- 5m 45% 80rpm"
+        is_valid, _errors, warnings = v.validate_workout(workout)
+        assert is_valid
+        assert any("Warmup mono-bloc" in w for w in warnings)
+
+    def test_cooldown_mono_bloc_warns(self):
+        """Single cooldown block without justification triggers warning."""
+        v = IntervalsFormatValidator()
+        workout = "Warmup\n- 5m 50% 85rpm\n- 5m 58% 85rpm\n- 5m 65% 85rpm\n\nMain set\n- 20m 90% 92rpm\n\nCooldown\n- 13m 55% 85rpm"
+        is_valid, _errors, warnings = v.validate_workout(workout)
+        assert is_valid
+        assert any("Cooldown mono-bloc" in w for w in warnings)
+
+    def test_warmup_ramp_no_warning(self):
+        """Multi-step warmup does not trigger warning."""
+        v = IntervalsFormatValidator()
+        workout = "Warmup\n- 5m 50% 85rpm\n- 5m 58% 85rpm\n- 5m 65% 85rpm\n\nMain set\n- 20m 90%\n\nCooldown\n- 5m 60%\n- 5m 50%"
+        _valid, _errors, warnings = v.validate_workout(workout)
+        assert not any("mono-bloc" in w for w in warnings)
+
+    def test_warmup_mono_bloc_with_justification_no_warning(self):
+        """Mono-bloc warmup with gear justification does not warn."""
+        v = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 15m 65% 85rpm\n"
+            "\u2699\ufe0f Bloc plat intentionnel \u2014 pr\u00e9servation fra\u00eecheur\n"
+            "\nMain set\n- 20m 90%\n\nCooldown\n- 5m 60%\n- 5m 50%"
+        )
+        _valid, _errors, warnings = v.validate_workout(workout)
+        assert not any("Warmup mono-bloc" in w for w in warnings)
+
+    def test_cooldown_mono_bloc_with_justification_no_warning(self):
+        """Mono-bloc cooldown with gear justification does not warn."""
+        v = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 5m 50%\n- 5m 60%\n\nMain set\n- 20m 90%\n"
+            "\nCooldown\n- 10m 55% 85rpm\n"
+            "\u2699\ufe0f Cooldown court intentionnel"
+        )
+        _valid, _errors, warnings = v.validate_workout(workout)
+        assert not any("Cooldown mono-bloc" in w for w in warnings)
+
+    def test_mono_bloc_is_warning_not_error(self):
+        """Mono-bloc detection is a warning, not an error (non-blocking)."""
+        v = IntervalsFormatValidator()
+        workout = "Warmup\n- 15m 65% 85rpm\n\nMain set\n- 20m 90%\n\nCooldown\n- 10m 55%"
+        is_valid, errors, warnings = v.validate_workout(workout)
+        assert is_valid
+        assert len(errors) == 0
+        assert len(warnings) == 2  # both warmup and cooldown
+
+    def test_auto_fix_warmup_mono_bloc(self):
+        """Auto-fix replaces mono-bloc warmup with 3-step ramp."""
+        v = IntervalsFormatValidator()
+        workout = "Warmup\n- 15m 65% 85rpm\n\nMain set\n- 20m 90%\n\nCooldown\n- 5m 60%\n- 5m 50%"
+        fixed = v.fix_warmup_cooldown(workout)
+        warmup_lines = []
+        in_warmup = False
+        for line in fixed.split("\n"):
+            s = line.strip()
+            if s.lower().startswith("warmup"):
+                in_warmup = True
+                continue
+            if in_warmup and s.lower().startswith(("main", "cooldown", "block")):
+                break
+            if in_warmup and s.startswith("- "):
+                warmup_lines.append(s)
+        assert len(warmup_lines) == 3
+        assert "50%" in warmup_lines[0]
+        assert "65%" in warmup_lines[2]
+
+    def test_auto_fix_no_change_with_justification(self):
+        """Auto-fix does not modify mono-bloc with justification."""
+        v = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 15m 65% 85rpm\n"
+            "\u2699\ufe0f Intentionnel\n"
+            "\nMain set\n- 20m 90%\n\nCooldown\n- 5m 60%\n- 5m 50%"
+        )
+        fixed = v.fix_warmup_cooldown(workout)
+        assert "- 15m 65% 85rpm" in fixed

--- a/tests/test_mcp_new_handlers.py
+++ b/tests/test_mcp_new_handlers.py
@@ -812,6 +812,7 @@ class TestHandleValidateWorkout:
             (True, [], []),
         ]
         mock_validator.fix_repetition_format.return_value = "fixed workout text"
+        mock_validator.fix_warmup_cooldown.return_value = "fixed workout text"
 
         with patch(
             "magma_cycling.intervals_format_validator.IntervalsFormatValidator",


### PR DESCRIPTION
## Summary

- Add Check 5 to `IntervalsFormatValidator`: emit a non-blocking warning when Warmup or Cooldown sections contain a single interval block without a ⚙️ justification line
- Add `fix_warmup_cooldown()` auto-fix that generates 3-step progressive ramps (ascending for warmup, descending for cooldown)
- Integrate auto-fix in MCP `handle_validate_workout` handler

## Test plan

- [x] 8 new tests in `TestWarmupCooldownMonoBloc` covering warnings, justification bypass, and auto-fix
- [x] All 15 validator tests pass
- [x] All 7 MCP validate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)