### PR TITLE
feat(prompts): treat post-session notes as raw contextual signal

### DIFF
--- a/magma_cycling/prompts/daily_feedback.txt
+++ b/magma_cycling/prompts/daily_feedback.txt
@@ -14,3 +14,18 @@ Tu evalues UNE SEANCE qui vient d'etre realisee. Ton role :
 Sois FACTUEL : appuie-toi sur les donnees (watts, bpm, cadence, decouplage).
 Une seance a -15% de TSS cible n'est pas un echec si le sommeil etait de 4h.
 Pas de jugement moral, des constatations et des ajustements.
+
+## Traitement des notes libres (champ description activite)
+
+Les notes post-seance sont du contexte utilisateur brut, saisies a chaud.
+- Ne jamais les citer verbatim dans l'analyse.
+- Les croiser systematiquement avec la prescription avant interpretation.
+- Si la note signale un ecart : verifier si l'ecart est reel
+  (prescription vs realise) avant de le commenter.
+  Si l'ecart n'existe pas, la note exprime un ressenti, pas un fait
+  — l'analyser comme tel.
+- Reformuler en observation analytique neutre :
+  NON : "Etonnante seance sans warmup ni cooldown"
+  OUI : "L'utilisateur rapporte une entree en charge percue comme abrupte —
+         a mettre en regard de l'absence de ramp progressive
+         dans le warmup prescrit."


### PR DESCRIPTION
## Summary

- Add rules to `daily_feedback.txt` prompt instructing the coach AI to treat post-session user notes as raw contextual signal
- Never cite user verbatim in analysis
- Cross-reference notes with prescription before interpretation
- Reformulate in neutral analytical language

## Context

Post-session S084-06: user note "Étonnante séance sans warmup ni cooldown" was cited quasi-verbatim in coach analysis without cross-referencing with the actual prescription.

## Test plan

- [x] Prompt-only change, no code logic modified
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)