### PR TITLE
fix(planner): clipboard copies full prompt, fallback if not macOS

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import subprocess
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -227,11 +228,19 @@ async def handle_weekly_planner(args: dict) -> list[TextContent]:
         ]
 
     elif provider == "clipboard":
-        result["prompt"] = prompt[:500] + "..." if len(prompt) > 500 else prompt
+        try:
+            subprocess.run(["pbcopy"], input=prompt.encode("utf-8"), check=True)
+            result["status"] = "copied_to_clipboard"
+            result["message"] = f"Prompt ({len(prompt):,} chars) copied to clipboard for {week_id}"
+        except Exception as e:
+            result["status"] = "clipboard_error"
+            result["message"] = f"Failed to copy to clipboard: {e}"
+            result["prompt"] = prompt  # Fallback: return full prompt
+
         result["next_steps"] = [
-            f"Copy prompt and paste to {provider}",
-            "Generate 7 workouts",
-            "Save workouts to file",
+            "Paste prompt into your AI provider (Cmd+V)",
+            "Generate 7 workouts with === WORKOUT ... === delimiters",
+            f"Save to {week_id}_workouts.txt",
             "Run upload-workouts to sync to Intervals.icu",
         ]
     else:

--- a/tests/_mcp/test_weekly_planner_prompt_exposure.py
+++ b/tests/_mcp/test_weekly_planner_prompt_exposure.py
@@ -52,16 +52,32 @@ BASE_ARGS = {
 class TestWeeklyPlannerPromptExposure:
     """Test prompt exposure in weekly planner MCP handler."""
 
-    def test_clipboard_provider_truncates_prompt(self):
-        """Clipboard provider returns prompt truncated to 500 chars."""
+    @patch("magma_cycling._mcp.handlers.planning.subprocess")
+    def test_clipboard_provider_copies_to_clipboard(self, mock_subprocess):
+        """Clipboard provider copies full prompt via pbcopy."""
+        mock_subprocess.run.return_value = None
         args = {**BASE_ARGS, "provider": "clipboard"}
         result = _run(handle_weekly_planner(args))
 
         import json
 
         data = json.loads(result[0].text)
-        assert data["prompt"].endswith("...")
-        assert len(data["prompt"]) == 503  # 500 chars + "..."
+        assert data["status"] == "copied_to_clipboard"
+        assert "prompt" not in data  # Full prompt NOT in response
+        mock_subprocess.run.assert_called_once()
+
+    @patch("magma_cycling._mcp.handlers.planning.subprocess")
+    def test_clipboard_fallback_on_error(self, mock_subprocess):
+        """Clipboard fallback returns full prompt when pbcopy fails."""
+        mock_subprocess.run.side_effect = OSError("pbcopy not found")
+        args = {**BASE_ARGS, "provider": "clipboard"}
+        result = _run(handle_weekly_planner(args))
+
+        import json
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "clipboard_error"
+        assert data["prompt"] == FAKE_PROMPT
 
     def test_claude_api_returns_full_prompt(self):
         """claude_api provider returns the complete prompt."""


### PR DESCRIPTION
## Summary
- Replace arbitrary 500-char truncation with actual `pbcopy` call for full prompt copy
- Graceful fallback: if `pbcopy` fails (non-macOS), returns full prompt in response instead
- Keeps the clipboard provider platform-agnostic via error handling

## Test plan
- [x] `test_clipboard_provider_copies_to_clipboard` — verifies pbcopy call
- [x] `test_clipboard_fallback_on_error` — verifies full prompt fallback
- [x] Full suite: 2184 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)