### PR TITLE
fix(pid): treat PID output as delta on Peaks base, not absolute

### DIFF
--- a/magma_cycling/workflows/pid_peaks_integration.py
+++ b/magma_cycling/workflows/pid_peaks_integration.py
@@ -46,10 +46,12 @@ class IntegratedRecommendation:
         ctl_projection_6weeks: Estimated CTL after 6 weeks
         phase: Peaks Coaching training phase
         rationale: Explanation of recommendation
-        pid_suggestion: Original PID suggestion (for reference)
+        pid_suggestion: PID absolute suggestion (peaks_base + pid_delta)
         peaks_suggestion: Peaks recommendation (for reference)
         override_active: Whether Peaks override is active
         warnings: List of warnings
+        confidence: Recommendation confidence level (low/medium/high)
+        pid_delta: Raw PID delta before adding to Peaks base
     """
 
     mode: ControlMode
@@ -61,6 +63,8 @@ class IntegratedRecommendation:
     peaks_suggestion: int | None
     override_active: bool
     warnings: list[str]
+    confidence: str = "medium"
+    pid_delta: int | None = None
 
 
 def compute_integrated_correction(
@@ -121,8 +125,13 @@ def compute_integrated_correction(
     peaks_tss_suggestion = phase_rec.weekly_tss_load
     peaks_phase = phase_rec.phase.value
 
-    # Calculate PID suggestion if controller provided
-    pid_tss_suggestion = None
+    # Calculate PID delta if controller provided
+    # PID output is a DELTA (+/-N TSS/week), NOT an absolute target.
+    # Absolute = peaks_base + pid_delta.
+    pid_delta = None
+    pid_tss_absolute = None
+    pid_confidence = "low"
+
     if pid_controller:
         try:
             pid_correction = pid_controller.compute_cycle_correction_enhanced(
@@ -132,74 +141,109 @@ def compute_integrated_correction(
                 avg_cardiovascular_coupling=avg_cardiovascular_coupling,
                 tss_completion_rate=tss_completion_rate,
             )
-            pid_tss_suggestion = pid_correction["tss_per_week_adjusted"]
+            pid_delta = pid_correction["tss_per_week_adjusted"]
+            pid_tss_absolute = peaks_tss_suggestion + pid_delta
+
+            # Guard rails: clamp to [150, 450] (Masters 50+)
+            if pid_tss_absolute < 150:
+                warnings.append(f"PID output aberrant ({pid_tss_absolute} TSS) — fallback Peaks")
+                pid_tss_absolute = peaks_tss_suggestion
+                pid_confidence = "low"
+            elif pid_tss_absolute > 450:
+                warnings.append(f"PID output trop élevé ({pid_tss_absolute} TSS) — plafonné 400")
+                pid_tss_absolute = 400
+                pid_confidence = "medium"
+            else:
+                # Determine confidence based on PID validation
+                validation = pid_correction.get("validation", {})
+                if validation.get("validated", False):
+                    pid_confidence = "high"
+                elif validation.get("confidence", 0) >= 0.7:
+                    pid_confidence = "medium"
+                else:
+                    pid_confidence = "low"
 
             # Add PID validation warnings
-            if not pid_correction["validation"]["validated"]:
-                warnings.extend(pid_correction["validation"]["red_flags"])
+            validation = pid_correction.get("validation", {})
+            if not validation.get("validated", True):
+                warnings.extend(validation.get("red_flags", []))
 
         except Exception as e:
             warnings.append(f"PID calculation failed: {e}")
-            pid_tss_suggestion = None
+            pid_tss_absolute = None
+            pid_delta = None
+
+    # Reactivation rule: PID takes over when within ±15% of Peaks target
+    peaks_low = int(peaks_tss_suggestion * 0.85)
+    peaks_high = int(peaks_tss_suggestion * 1.15)
+    pid_in_range = pid_tss_absolute is not None and peaks_low <= pid_tss_absolute <= peaks_high
 
     # Decision logic: CTL-based override rules
     if ctl_current < 50:
-        # OVERRIDE RULE 1: CTL CRITIQUE (<50)
-        # Peaks takes full control, PID suspended
-        mode = ControlMode.PEAKS_OVERRIDE
-        tss_final = peaks_tss_suggestion
-        override_active = True
+        if pid_in_range and pid_confidence != "low":
+            # PID recalibré dans la plage → PID actif avec Peaks constraint
+            mode = ControlMode.PID_CONSTRAINED
+            tss_final = pid_tss_absolute
+            override_active = False
 
-        rationale = (
-            f"🚨 CTL CRITIQUE ({ctl_current:.1f} < 50)\n"
-            f"→ PEAKS COACHING OVERRIDE actif\n"
-            f"→ Phase: {peaks_phase.upper()}\n"
-            f"→ PID suspendu (trop conservateur pour reconstruction)\n"
-            f"→ Peaks recommande: {peaks_tss_suggestion} TSS/semaine\n"
-        )
+            rationale = (
+                f"🎛️ PID RECALIBRÉ (CTL {ctl_current:.1f}, Peaks Override levé)\n"
+                f"→ Peaks base: {peaks_tss_suggestion} TSS/semaine\n"
+                f"→ PID delta: {pid_delta:+d} TSS/semaine\n"
+                f"→ PID absolu: {pid_tss_absolute} TSS/semaine (dans plage [{peaks_low}-{peaks_high}])\n"
+                f"→ Phase: {peaks_phase.upper()}\n"
+            )
+        else:
+            # PID hors plage ou non disponible → Peaks Override
+            mode = ControlMode.PEAKS_OVERRIDE
+            tss_final = peaks_tss_suggestion
+            override_active = True
 
-        # Only show PID if it's giving reasonable values (> 100 TSS/week)
-        # Values < 100 indicate PID is not yet calibrated properly
-        if pid_tss_suggestion and pid_tss_suggestion >= 100:
-            rationale += (
-                f"→ PID suggérait: {pid_tss_suggestion} TSS/semaine (ignoré)\n"
-                f"→ Écart: +{peaks_tss_suggestion - pid_tss_suggestion} TSS/semaine Peaks vs PID\n"
+            rationale = (
+                f"🚨 CTL CRITIQUE ({ctl_current:.1f} < 50)\n"
+                f"→ PEAKS COACHING OVERRIDE actif\n"
+                f"→ Phase: {peaks_phase.upper()}\n"
+                f"→ Peaks recommande: {peaks_tss_suggestion} TSS/semaine\n"
             )
-        elif pid_tss_suggestion and pid_tss_suggestion < 100:
-            rationale += (
-                f"→ PID non calibré ({pid_tss_suggestion} TSS/semaine) - Sprint R10 en cours\n"
-            )
+
+            if pid_tss_absolute is not None and pid_confidence != "low":
+                rationale += (
+                    f"→ PID: {pid_tss_absolute} TSS/semaine "
+                    f"(hors plage [{peaks_low}-{peaks_high}], ignoré)\n"
+                )
+            elif pid_delta is not None:
+                rationale += (
+                    f"→ PID delta: {pid_delta:+d} TSS → "
+                    f"confiance {pid_confidence} (insuffisante)\n"
+                )
 
     elif ctl_current < (phase_rec.ctl_target * 0.85):
-        # OVERRIDE RULE 2: CTL SOUS-OPTIMAL (50-85% target)
-        # PID active but constrained by Peaks minimums
+        # CTL SOUS-OPTIMAL (50-85% target): PID active with Peaks constraints
         mode = ControlMode.PID_CONSTRAINED
         override_active = True
 
-        # Take max(PID, Peaks minimum)
-        if pid_tss_suggestion and pid_tss_suggestion > peaks_tss_suggestion:
-            tss_final = pid_tss_suggestion
+        if pid_tss_absolute and pid_tss_absolute >= peaks_tss_suggestion:
+            tss_final = pid_tss_absolute
             rationale = (
                 f"✅ PID ACTIF (CTL {ctl_current:.1f} ≥ 50)\n"
-                f"→ PID suggestion: {pid_tss_suggestion} TSS/semaine\n"
-                f"→ Peaks minimum: {peaks_tss_suggestion} TSS/semaine\n"
+                f"→ Peaks base: {peaks_tss_suggestion} TSS/semaine\n"
+                f"→ PID delta: {pid_delta:+d} → absolu: {pid_tss_absolute} TSS/semaine\n"
                 f"→ PID dépasse Peaks → Appliqué"
             )
         else:
             tss_final = peaks_tss_suggestion
             rationale = (
                 f"⚖️  PID + PEAKS CONSTRAINT\n"
-                f"→ PID suggestion: {pid_tss_suggestion or 'N/A'} TSS/semaine\n"
+                f"→ PID absolu: {pid_tss_absolute or 'N/A'} TSS/semaine\n"
                 f"→ Peaks minimum: {peaks_tss_suggestion} TSS/semaine\n"
-                f"→ Peaks minimum appliqué (PID trop conservateur)"
+                f"→ Peaks minimum appliqué"
             )
 
     else:
-        # RULE 3: CTL OPTIMAL (≥85% target)
-        # PID fully autonomous (future implementation)
+        # CTL OPTIMAL (≥85% target): PID autonomous
         mode = ControlMode.PID_CONSTRAINED  # Still constrained for safety
         override_active = False
-        tss_final = pid_tss_suggestion or peaks_tss_suggestion
+        tss_final = pid_tss_absolute or peaks_tss_suggestion
 
         rationale = (
             f"✅ CTL OPTIMAL ({ctl_current:.1f} ≥ 85% target)\n"
@@ -207,10 +251,14 @@ def compute_integrated_correction(
             f"→ Suggestion: {tss_final} TSS/semaine"
         )
 
+    # Determine final confidence
+    confidence = pid_confidence if pid_tss_absolute else "low"
+    if override_active and mode == ControlMode.PEAKS_OVERRIDE:
+        confidence = "medium"  # Peaks Override is a known-good fallback
+
     # Project CTL gain over 6 weeks
-    # Simplified: +1 TSS/day sustained ≈ +0.14 CTL/week (rough estimate)
-    tss_increase = tss_final - (ctl_current * 7)  # Rough current TSS from CTL
-    ctl_gain_per_week = tss_increase / 7 * 0.14  # Conservative multiplier
+    tss_increase = tss_final - (ctl_current * 7)
+    ctl_gain_per_week = tss_increase / 7 * 0.14
     ctl_projection = ctl_current + (ctl_gain_per_week * 6)
 
     # Add warnings for critical states
@@ -232,10 +280,12 @@ def compute_integrated_correction(
         ctl_projection_6weeks=ctl_projection,
         phase=peaks_phase,
         rationale=rationale,
-        pid_suggestion=pid_tss_suggestion,
+        pid_suggestion=pid_tss_absolute,
         peaks_suggestion=peaks_tss_suggestion,
         override_active=override_active,
         warnings=warnings,
+        confidence=confidence,
+        pid_delta=pid_delta,
     )
 
 
@@ -267,19 +317,27 @@ def format_integrated_recommendation(rec: IntegratedRecommendation) -> str:
     """
     output = []
 
-    # Header with mode
+    # Header with mode and confidence
+    confidence_label = {"low": "faible", "medium": "moyenne", "high": "haute"}.get(
+        rec.confidence, rec.confidence
+    )
+
     if rec.override_active:
         if rec.mode == ControlMode.PEAKS_OVERRIDE:
             output.append("## 🚨 PEAKS COACHING OVERRIDE ACTIF")
         else:
             output.append("## ⚖️  PID + PEAKS CONSTRAINT")
     else:
-        output.append("## ✅ PID AUTONOME")
+        output.append("## 🎛️ PID ACTIF")
 
     output.append("")
 
     # Recommendation details
     output.append(f"**TSS recommandé**: {rec.tss_per_week} TSS/semaine")
+    output.append(f"**Confiance**: {confidence_label}")
+    if rec.pid_delta is not None:
+        source = "PID actif" if not rec.override_active else "Peaks Override"
+        output.append(f"**Source**: {source}")
     output.append(f"**Phase**: {rec.phase.replace('_', ' ').title()}")
     output.append(f"**CTL projeté (6 sem)**: {rec.ctl_projection_6weeks:.1f}")
     output.append("")
@@ -295,14 +353,15 @@ def format_integrated_recommendation(rec: IntegratedRecommendation) -> str:
     if rec.pid_suggestion and rec.peaks_suggestion:
         output.append("**Comparaison PID vs Peaks**:")
         output.append("")
-        output.append("| Source | TSS/semaine | Appliqué |")
-        output.append("|--------|-------------|----------|")
+        output.append("| Source | TSS/semaine | Delta | Appliqué |")
+        output.append("|--------|-------------|-------|----------|")
+        delta_str = f"{rec.pid_delta:+d}" if rec.pid_delta is not None else "—"
         output.append(
-            f"| PID    | {rec.pid_suggestion:>11} | "
+            f"| PID    | {rec.pid_suggestion:>11} | {delta_str:>5} | "
             f"{'✅' if rec.tss_per_week == rec.pid_suggestion else '❌'} |"
         )
         output.append(
-            f"| Peaks  | {rec.peaks_suggestion:>11} | "
+            f"| Peaks  | {rec.peaks_suggestion:>11} |   —   | "
             f"{'✅' if rec.tss_per_week == rec.peaks_suggestion else '❌'} |"
         )
         output.append("")

--- a/magma_cycling/workflows/sync/ctl_peaks.py
+++ b/magma_cycling/workflows/sync/ctl_peaks.py
@@ -116,8 +116,8 @@ class CTLPeaksMixin:
                 alerts.append(f"TSB élevé: {tsb_current:+.1f} (déconditionnement possible)")
                 recommendations.append("Augmenter volume progressivement: +2-3 CTL points/semaine")
 
-            # NEW: Initialize PID controller with calibrated gains (Sprint R10)
-            print("\n🎛️  Initialisation PID Controller (Sprint R10 calibration)...")
+            # Initialize PID controller with calibrated gains (Masters 50+)
+            print("\n🎛️  Initialisation PID Controller...")
             pid_controller = DiscretePIDController(
                 kp=0.008,  # Proportional gain (Masters 50+ adjusted)
                 ki=0.001,  # Integral gain (Masters 50+ adjusted)
@@ -136,7 +136,6 @@ class CTLPeaksMixin:
                         state_data = json.load(f)
                         pid_state = state_data.get("pid_state", {})
 
-                        # Restore PID internal state
                         pid_controller.integral = pid_state.get("integral", 0.0)
                         pid_controller.prev_error = pid_state.get("prev_error", 0.0)
                         pid_controller.prev_ftp = pid_state.get("prev_ftp", 0)
@@ -149,21 +148,20 @@ class CTLPeaksMixin:
                 except Exception as e:
                     print(f"  ⚠️  Erreur restauration état PID: {e}")
 
-            # NEW: Compute integrated PID + Peaks recommendation
+            # Compute integrated PID + Peaks recommendation
+            # PID output = delta TSS, added to Peaks base for absolute recommendation
             print("🔄 Calcul recommandation intégrée PID + Peaks...")
 
-            # Calculate recent adherence and quality metrics
-            # TODO: Extract from recent week data (for now use defaults)
-            adherence_rate = 0.85  # Target adherence
-            avg_coupling = 0.065  # Target quality (découplage)
-            tss_completion = 0.90  # Target completion
+            adherence_rate = 0.85
+            avg_coupling = 0.065
+            tss_completion = 0.90
 
             try:
                 pid_peaks_rec = compute_integrated_correction(
                     ctl_current=ctl_current,
                     ftp_current=ftp_current,
                     ftp_target=ftp_target,
-                    athlete_age=54,  # Masters 50+
+                    athlete_age=54,
                     pid_controller=pid_controller,
                     adherence_rate=adherence_rate,
                     avg_cardiovascular_coupling=avg_coupling,
@@ -172,11 +170,18 @@ class CTLPeaksMixin:
 
                 print(
                     f"  ✅ Recommandation: {pid_peaks_rec.tss_per_week} TSS/semaine "
-                    f"(mode: {pid_peaks_rec.mode.value})"
+                    f"(mode: {pid_peaks_rec.mode.value}, "
+                    f"confiance: {pid_peaks_rec.confidence})"
                 )
 
                 if pid_peaks_rec.override_active:
                     print(f"  🚨 OVERRIDE ACTIF: {pid_peaks_rec.mode.value}")
+                elif pid_peaks_rec.pid_delta is not None:
+                    print(
+                        f"  🎛️ PID actif: Peaks {pid_peaks_rec.peaks_suggestion} "
+                        f"+ delta {pid_peaks_rec.pid_delta:+d} "
+                        f"= {pid_peaks_rec.tss_per_week} TSS/semaine"
+                    )
 
             except Exception as e:
                 print(f"  ⚠️  Erreur calcul PID+Peaks: {e}")

--- a/magma_cycling/workflows/sync/reporting.py
+++ b/magma_cycling/workflows/sync/reporting.py
@@ -274,17 +274,16 @@ class ReportingMixin:
                     f.write("---\n\n")
                     f.write(format_phase_recommendation(phase_rec))
 
-                # PID + Peaks integrated recommendation (NEW)
+                # PID + Peaks integrated recommendation
                 pid_peaks_rec = ctl_analysis.get("pid_peaks_recommendation")
                 if pid_peaks_rec:
-                    f.write("---\n\n")
-                    f.write("## 🎛️ Recommandation Intégrée PID + Peaks (Sprint R10)\n\n")
-                    f.write(
-                        "*Architecture hiérarchique multi-niveaux: Peaks Coaching (stratégique) → "
-                        "PID Discret (tactique) → Daily execution (opérationnel)*\n\n"
-                    )
-                    formatted_rec = format_integrated_recommendation(pid_peaks_rec)
-                    f.write(formatted_rec)
+                    # Only show in report if confidence >= medium
+                    # Low confidence (aberrant PID values) → debug logs only
+                    if getattr(pid_peaks_rec, "confidence", "low") != "low":
+                        f.write("---\n\n")
+                        f.write("## 🎛️ Recommandation Intégrée PID + Peaks\n\n")
+                        formatted_rec = format_integrated_recommendation(pid_peaks_rec)
+                        f.write(formatted_rec)
 
             f.write("---\n\n")
             f.write(

--- a/tests/test_pid_recalibration.py
+++ b/tests/test_pid_recalibration.py
@@ -1,0 +1,266 @@
+"""Tests for PID recalibration — delta+base integration, guard rails, reactivation."""
+
+from __future__ import annotations
+
+from magma_cycling.intelligence.discrete_pid_controller import DiscretePIDController
+from magma_cycling.workflows.pid_peaks_integration import (
+    ControlMode,
+    IntegratedRecommendation,
+    compute_integrated_correction,
+    format_integrated_recommendation,
+)
+
+
+def _make_pid(setpoint: float = 230, ftp_measured: float = 223) -> DiscretePIDController:
+    """Create a PID controller with standard gains and one cycle of history."""
+    pid = DiscretePIDController(kp=0.008, ki=0.001, kd=0.12, setpoint=setpoint)
+    # Warm up with one cycle so integral is non-zero
+    pid.compute_cycle_correction(measured_ftp=ftp_measured, cycle_duration_weeks=6)
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Core fix: PID delta + Peaks base
+# ---------------------------------------------------------------------------
+
+
+class TestPIDDeltaIntegration:
+    """Test that PID output is treated as delta on Peaks base, not absolute."""
+
+    def test_pid_delta_added_to_peaks_base(self):
+        """PID delta is added to Peaks base, not used as absolute."""
+        pid = _make_pid()
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=pid,
+        )
+
+        # PID should have a small delta, not be the absolute recommendation
+        assert rec.pid_delta is not None
+        assert abs(rec.pid_delta) < 50  # Delta should be small
+        # The absolute suggestion should be close to Peaks (around 350)
+        assert rec.pid_suggestion > 100  # Never aberrant
+        # tss_per_week should be close to Peaks base (not 1)
+        assert rec.tss_per_week >= 300
+
+    def test_pid_delta_field_populated(self):
+        """pid_delta field is populated in recommendation."""
+        pid = _make_pid()
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=pid,
+        )
+        assert rec.pid_delta is not None
+        assert isinstance(rec.pid_delta, int)
+
+    def test_no_pid_controller_falls_back_to_peaks(self):
+        """Without PID controller, Peaks recommendation is used."""
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=None,
+        )
+        assert rec.pid_suggestion is None
+        assert rec.pid_delta is None
+        assert rec.tss_per_week == rec.peaks_suggestion
+
+
+# ---------------------------------------------------------------------------
+# Guard rails
+# ---------------------------------------------------------------------------
+
+
+class TestGuardRails:
+    """Test guard rails prevent aberrant PID recommendations."""
+
+    def test_guard_rail_low_clamp(self):
+        """PID output below 150 TSS triggers Peaks fallback."""
+        from unittest.mock import MagicMock
+
+        # Mock PID to return an extreme negative delta
+        pid = MagicMock()
+        pid.compute_cycle_correction_enhanced.return_value = {
+            "tss_per_week_adjusted": -250,  # Extreme: 350 + (-250) = 100 < 150
+            "validation": {"validated": True, "red_flags": [], "confidence": 0.9},
+        }
+
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=pid,
+        )
+
+        # Should have fallen back to Peaks, never below 150
+        assert rec.tss_per_week >= 150
+        assert any("aberrant" in w for w in rec.warnings)
+
+    def test_guard_rail_high_clamp(self):
+        """PID output above 450 TSS is clamped to 400."""
+        from unittest.mock import MagicMock
+
+        # Mock PID to return an extreme positive delta
+        pid = MagicMock()
+        pid.compute_cycle_correction_enhanced.return_value = {
+            "tss_per_week_adjusted": 150,  # Extreme: 350 + 150 = 500 > 450
+            "validation": {"validated": True, "red_flags": [], "confidence": 0.9},
+        }
+
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=pid,
+        )
+
+        # Should be clamped at 400 max
+        assert rec.tss_per_week <= 400
+        assert any("trop élevé" in w for w in rec.warnings)
+
+    def test_pid_internal_saturation_stays_in_range(self):
+        """With real PID (±30 saturation), output stays in [320, 380]."""
+        pid = _make_pid()
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=pid,
+        )
+        # PID delta clamped to ±30 by internal saturation
+        # Peaks base ~350, so 320 <= absolute <= 380
+        assert rec.tss_per_week >= 300
+        assert rec.tss_per_week <= 400
+
+
+# ---------------------------------------------------------------------------
+# Reactivation rule
+# ---------------------------------------------------------------------------
+
+
+class TestReactivation:
+    """Test PID reactivation within ±15% of Peaks target."""
+
+    def test_pid_reactivates_when_in_range(self):
+        """PID takes over when within ±15% of Peaks target, even at CTL < 50."""
+        pid = _make_pid()
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=pid,
+        )
+
+        # PID delta is small, so absolute is close to Peaks → within range
+        peaks_base = rec.peaks_suggestion
+        if rec.pid_suggestion:
+            low = int(peaks_base * 0.85)
+            high = int(peaks_base * 1.15)
+            if low <= rec.pid_suggestion <= high:
+                # PID should be active, override should be lifted
+                assert not rec.override_active
+                assert rec.mode == ControlMode.PID_CONSTRAINED
+
+    def test_peaks_override_when_pid_out_of_range(self):
+        """Peaks Override stays active when PID is out of ±15% range."""
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=None,
+        )
+        # Without PID, Peaks Override should be active (CTL < 50)
+        assert rec.override_active
+        assert rec.mode == ControlMode.PEAKS_OVERRIDE
+
+
+# ---------------------------------------------------------------------------
+# Confidence levels
+# ---------------------------------------------------------------------------
+
+
+class TestConfidence:
+    """Test confidence levels in recommendations."""
+
+    def test_confidence_field_exists(self):
+        """IntegratedRecommendation has confidence field."""
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+        )
+        assert hasattr(rec, "confidence")
+        assert rec.confidence in ("low", "medium", "high")
+
+    def test_peaks_override_has_medium_confidence(self):
+        """Peaks Override (known-good fallback) has at least medium confidence."""
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=None,
+        )
+        assert rec.confidence == "medium"
+
+    def test_pid_active_confidence_not_low(self):
+        """When PID is active and in range, confidence should not be low."""
+        pid = _make_pid()
+        rec = compute_integrated_correction(
+            ctl_current=42.0,
+            ftp_current=223,
+            ftp_target=230,
+            pid_controller=pid,
+        )
+        if not rec.override_active:
+            assert rec.confidence in ("medium", "high")
+
+
+# ---------------------------------------------------------------------------
+# Format output
+# ---------------------------------------------------------------------------
+
+
+class TestFormatRecommendation:
+    """Test formatted output includes new fields."""
+
+    def test_format_includes_confidence(self):
+        """Formatted recommendation includes confidence label."""
+        rec = IntegratedRecommendation(
+            mode=ControlMode.PID_CONSTRAINED,
+            tss_per_week=351,
+            ctl_projection_6weeks=48.0,
+            phase="reconstruction_base",
+            rationale="PID recalibrated",
+            pid_suggestion=351,
+            peaks_suggestion=350,
+            override_active=False,
+            warnings=[],
+            confidence="medium",
+            pid_delta=1,
+        )
+        formatted = format_integrated_recommendation(rec)
+        assert "moyenne" in formatted  # confidence label in French
+        assert "PID ACTIF" in formatted
+
+    def test_format_shows_delta_in_table(self):
+        """Formatted comparison table shows PID delta."""
+        rec = IntegratedRecommendation(
+            mode=ControlMode.PID_CONSTRAINED,
+            tss_per_week=351,
+            ctl_projection_6weeks=48.0,
+            phase="reconstruction_base",
+            rationale="test",
+            pid_suggestion=351,
+            peaks_suggestion=350,
+            override_active=False,
+            warnings=[],
+            confidence="high",
+            pid_delta=1,
+        )
+        formatted = format_integrated_recommendation(rec)
+        assert "+1" in formatted
+        assert "Delta" in formatted


### PR DESCRIPTION
## Summary

- **Root cause**: `compute_integrated_correction()` used PID's `tss_per_week_adjusted` as absolute value (e.g. 1 TSS) instead of delta on Peaks base (350+1=351 TSS)
- **Guard rails**: clamp PID absolute to [150, 450] TSS with fallback/warnings
- **Reactivation rule**: PID takes over when within ±15% of Peaks target, even at CTL < 50
- **Confidence field**: `low`/`medium`/`high` on `IntegratedRecommendation`; low-confidence filtered from daily report
- **13 new tests**: delta integration, guard rails (mocked extremes), reactivation, confidence, formatted output

## Test plan

- [x] 13/13 new tests pass (`test_pid_recalibration.py`)
- [x] 2197/2197 full suite passes (0 failures)
- [x] Pre-commit hooks pass (black, ruff, isort, pydocstyle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)