### PR TITLE
refactor(sprint1): @cli_main decorator + veto_check tests + mock test_create_event

### DIFF
--- a/magma_cycling/dashboard.py
+++ b/magma_cycling/dashboard.py
@@ -23,11 +23,11 @@ Examples:
     poetry run dashboard --intelligence ~/magma-cycling-data/intelligence/backfilled_2024-2025.json.
 """
 import argparse
-import sys
 from datetime import datetime
 from pathlib import Path
 
 from magma_cycling.config import get_logger
+from magma_cycling.utils.cli import cli_main
 
 logger = get_logger(__name__)
 
@@ -216,7 +216,8 @@ def print_dashboard_footer() -> None:
     print()
 
 
-def main() -> int:
+@cli_main
+def main():
     """Run entry point."""
     parser = argparse.ArgumentParser(description="Dashboard - Vue d'ensemble rapide entraînement")
 
@@ -236,20 +237,13 @@ def main() -> int:
     # Get week
     week = args.week or get_current_week()
 
-    # Print dashboard
-    try:
-        print_dashboard_header(week)
-        print_current_week_stats(week)
-        print_ftp_progression(args.intelligence)
-        print_recent_learnings(args.intelligence)
-        print_next_week_plan()
-        print_dashboard_footer()
-        return 0
-    except Exception as e:
-        logger.error(f"Dashboard error: {e}")
-        print(f"\n❌ Error: {e}", file=sys.stderr)
-        return 1
+    print_dashboard_header(week)
+    print_current_week_stats(week)
+    print_ftp_progression(args.intelligence)
+    print_recent_learnings(args.intelligence)
+    print_next_week_plan()
+    print_dashboard_footer()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()  # pragma: no cover

--- a/magma_cycling/debug_detection.py
+++ b/magma_cycling/debug_detection.py
@@ -3,9 +3,11 @@
 from datetime import datetime, timedelta
 
 from magma_cycling.config import create_intervals_client
+from magma_cycling.utils.cli import cli_main
 from magma_cycling.workflow_state import WorkflowState
 
 
+@cli_main
 def main():
     """Command-line entry point for debugging gap detection."""
     # Init API via centralized config
@@ -105,4 +107,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/magma_cycling/fix_weekly_reports_casing.py
+++ b/magma_cycling/fix_weekly_reports_casing.py
@@ -22,9 +22,10 @@ Usage:
 """
 import argparse
 import shutil
-import sys
 from datetime import datetime
 from pathlib import Path
+
+from magma_cycling.utils.cli import cli_main
 
 
 class WeeklyReportsFixing:
@@ -303,6 +304,7 @@ class WeeklyReportsFixing:
             return False
 
 
+@cli_main
 def main():
     """Command-line entry point for fixing weekly reports casing."""
     parser = argparse.ArgumentParser(
@@ -327,20 +329,20 @@ def main():
     # Mode rollback
     if args.rollback:
         fixer.rollback()
-        sys.exit(0)
+        return 0
 
     # Audit initial
     problems = fixer.audit_structure()
 
     if not problems or (not problems["lowercase"] and not problems["duplicates"]):
         print("\n✅ Aucun problème détecté")
-        sys.exit(0)
+        return 0
 
     # Dry-run
     if args.dry_run:
         fixer.run_fixes(dry_run=True)
         print("\n🧪 DRY-RUN terminé (aucune modification effectuée)")
-        sys.exit(0)
+        return 0
 
     # Confirmation utilisateur
     if not args.force:
@@ -358,12 +360,12 @@ def main():
 
         if confirm != "yes":
             print("\n❌ Corrections annulées")
-            sys.exit(0)
+            return 0
 
     # Backup
     if not fixer.backup_weekly_reports():
         print("\n❌ Backup échoué → Abandon")
-        sys.exit(1)
+        return 1
 
     # Corrections
     success = fixer.run_fixes(dry_run=False)
@@ -380,16 +382,16 @@ def main():
             print()
             print(f"Backup disponible : {fixer.backup_dir}")
             print(f"Log détaillé : {fixer.log_file}")
-            sys.exit(0)
+            return 0
         else:
             print("\n❌ Validation finale échouée")
             print(f"⚠️  Utilisez --rollback pour restaurer : {fixer.backup_dir}")
-            sys.exit(1)
+            return 1
     else:
         print("\n❌ Corrections incomplètes")
         print(f"⚠️  Backup disponible : {fixer.backup_dir}")
-        sys.exit(1)
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/magma_cycling/intervals_format_validator.py
+++ b/magma_cycling/intervals_format_validator.py
@@ -61,6 +61,8 @@ Metadata:
 """
 import re
 
+from magma_cycling.utils.cli import cli_main
+
 
 class IntervalsFormatValidator:
     """Validateur format Intervals.icu."""
@@ -419,6 +421,7 @@ Cooldown
         }
 
 
+@cli_main
 def main():
     """Test du validateur."""
     validator = IntervalsFormatValidator()
@@ -504,4 +507,4 @@ Cooldown
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/magma_cycling/normalize_weekly_reports_casing.py
+++ b/magma_cycling/normalize_weekly_reports_casing.py
@@ -14,9 +14,10 @@ Usage:
 """
 import argparse
 import shutil
-import sys
 from datetime import datetime
 from pathlib import Path
+
+from magma_cycling.utils.cli import cli_main
 
 
 class CasingNormalizer:
@@ -294,6 +295,7 @@ class CasingNormalizer:
         return len(self.errors) == 0
 
 
+@cli_main
 def main():
     """Command-line entry point for normalizing weekly reports directory casing."""
     parser = argparse.ArgumentParser(
@@ -321,10 +323,8 @@ def main():
 
     # Exécuter
     success = normalizer.run()
-
-    # Code de sortie
-    sys.exit(0 if success else 1)
+    return 0 if success else 1
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/magma_cycling/utils/cli.py
+++ b/magma_cycling/utils/cli.py
@@ -1,0 +1,24 @@
+"""CLI entry point decorator — handles exceptions and exit codes."""
+
+import functools
+import sys
+import traceback
+
+
+def cli_main(func):
+    """Decorator for CLI entry points — handles exceptions and exit codes."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            result = func(*args, **kwargs)
+            sys.exit(0 if result is None or result == 0 else result)
+        except SystemExit:
+            raise
+        except KeyboardInterrupt:
+            sys.exit(130)
+        except Exception:
+            traceback.print_exc()
+            sys.exit(1)
+
+    return wrapper

--- a/tests/test_create_event.py
+++ b/tests/test_create_event.py
@@ -1,85 +1,51 @@
-#!/usr/bin/env python3
-"""
-Script de test pour la méthode create_event().
-"""
-import json
-import sys
-from pathlib import Path
+"""Tests for create_event API method (mocked, no live calls)."""
+
+from unittest.mock import patch
 
 from magma_cycling.api.intervals_client import IntervalsClient
 
 
-def test_create_event():
-    """Tester create_event avec différents formats."""
-    print("🧪 Test de la méthode create_event()")
+class TestCreateEventDateOnly:
+    """Test create_event with date-only format."""
 
-    print("=" * 70)
-    print()
+    @patch.object(IntervalsClient, "__init__", lambda self, **kw: None)
+    @patch.object(IntervalsClient, "create_event")
+    def test_create_event_date_only(self, mock_create):
+        """Date-only start_date_local is passed correctly to create_event."""
+        mock_create.return_value = {"id": "evt_001", "name": "Test Simple"}
 
-    # Charger credentials
-    config_path = Path.home() / ".intervals_config.json"
-    if not config_path.exists():
-        print("❌ Config non trouvée : ~/.intervals_config.json")
-        return 1
+        api = IntervalsClient()
+        event_data = {
+            "category": "WORKOUT",
+            "name": "Test Simple",
+            "description": "Warmup 10min\nMain set 20min\nCooldown 10min",
+            "start_date_local": "2025-12-01",
+        }
+        result = api.create_event(event_data)
 
-    with open(config_path) as f:
-        config = json.load(f)
-
-    api = IntervalsClient(athlete_id=config.get("athlete_id"), api_key=config.get("api_key"))
-
-    print("✅ API connectée")
-    print()
-
-    # Test 1 : Format minimal
-    print("📋 Test 1 : Format minimal")
-    print("-" * 70)
-
-    test_workout_1 = {
-        "category": "WORKOUT",
-        "name": "Test Simple",
-        "description": "Warmup 10min\nMain set 20min\nCooldown 10min",
-        "start_date_local": "2025-12-01",
-    }
-
-    print(f"Données : {json.dumps(test_workout_1, indent=2)}")
-    print()
-
-    result = api.create_event(test_workout_1)
-
-    if result:
-        print(f"✅ Test 1 RÉUSSI : ID={result.get('id')}")
-    else:
-        print("❌ Test 1 ÉCHOUÉ")
-
-    print()
-    print("=" * 70)
-
-    # Test 2 : Format avec heure
-    print("📋 Test 2 : Format avec heure")
-    print("-" * 70)
-
-    test_workout_2 = {
-        "category": "WORKOUT",
-        "name": "Test Avec Heure",
-        "description": "Warmup 10min\nMain set 20min\nCooldown 10min",
-        "start_date_local": "2025-12-02T08:00:00",
-    }
-
-    print(f"Données : {json.dumps(test_workout_2, indent=2)}")
-    print()
-
-    result = api.create_event(test_workout_2)
-
-    if result:
-        print(f"✅ Test 2 RÉUSSI : ID={result.get('id')}")
-    else:
-        print("❌ Test 2 ÉCHOUÉ")
-
-    print()
-    print("=" * 70)
-
-    return 0
+        mock_create.assert_called_once_with(event_data)
+        assert result["id"] == "evt_001"
+        assert result["name"] == "Test Simple"
 
 
-if __name__ == "__main__":
-    sys.exit(test_create_event())
+class TestCreateEventDatetime:
+    """Test create_event with datetime format."""
+
+    @patch.object(IntervalsClient, "__init__", lambda self, **kw: None)
+    @patch.object(IntervalsClient, "create_event")
+    def test_create_event_datetime(self, mock_create):
+        """Datetime start_date_local (with time) is passed correctly."""
+        mock_create.return_value = {"id": "evt_002", "name": "Test Avec Heure"}
+
+        api = IntervalsClient()
+        event_data = {
+            "category": "WORKOUT",
+            "name": "Test Avec Heure",
+            "description": "Warmup 10min\nMain set 20min\nCooldown 10min",
+            "start_date_local": "2025-12-02T08:00:00",
+        }
+        result = api.create_event(event_data)
+
+        mock_create.assert_called_once_with(event_data)
+        assert result["id"] == "evt_002"
+        assert "T08:00:00" in event_data["start_date_local"]

--- a/tests/test_intervals_format.py
+++ b/tests/test_intervals_format.py
@@ -291,15 +291,11 @@ def test_main_function_runs():
     """
     from magma_cycling.intervals_format_validator import main
 
-    # Should run without exceptions
-    try:
+    # @cli_main wraps with sys.exit(0) on success
+    with pytest.raises(SystemExit) as exc_info:
         main()
-        success = True
-    except Exception as e:
-        success = False
-        error = e
 
-    assert success, f"main() should run without errors, got: {error if not success else None}"
+    assert exc_info.value.code == 0
 
 
 def test_main_function_outputs(capsys):
@@ -309,7 +305,8 @@ def test_main_function_outputs(capsys):
     """
     from magma_cycling.intervals_format_validator import main
 
-    main()
+    with pytest.raises(SystemExit):
+        main()
 
     captured = capsys.readouterr()
     output = captured.out
@@ -346,7 +343,8 @@ def test_script_main_entry_point(monkeypatch, capsys):
     with patch.object(validator_module, "__name__", "__main__"):
         # Manually trigger what would happen at line 353-354
         if validator_module.__name__ == "__main__":
-            validator_module.main()
+            with pytest.raises(SystemExit):
+                validator_module.main()
 
     # Verify main() was called by checking output
     captured = capsys.readouterr()

--- a/tests/utils/test_cli.py
+++ b/tests/utils/test_cli.py
@@ -1,0 +1,112 @@
+"""Tests for CLI entry point decorator."""
+
+import pytest
+
+from magma_cycling.utils.cli import cli_main
+
+
+class TestCliMainSuccess:
+    """Tests for successful exit scenarios."""
+
+    def test_success_returns_none_exits_zero(self):
+        """Function returning None exits with code 0."""
+
+        @cli_main
+        def my_cmd():
+            pass
+
+        with pytest.raises(SystemExit) as exc_info:
+            my_cmd()
+        assert exc_info.value.code == 0
+
+    def test_success_returns_zero_exits_zero(self):
+        """Function returning 0 exits with code 0."""
+
+        @cli_main
+        def my_cmd():
+            return 0
+
+        with pytest.raises(SystemExit) as exc_info:
+            my_cmd()
+        assert exc_info.value.code == 0
+
+    def test_returns_nonzero_int(self):
+        """Function returning non-zero int exits with that code."""
+
+        @cli_main
+        def my_cmd():
+            return 42
+
+        with pytest.raises(SystemExit) as exc_info:
+            my_cmd()
+        assert exc_info.value.code == 42
+
+
+class TestCliMainExceptions:
+    """Tests for exception handling."""
+
+    def test_exception_exits_one(self):
+        """Unhandled exception exits with code 1."""
+
+        @cli_main
+        def my_cmd():
+            raise ValueError("boom")
+
+        with pytest.raises(SystemExit) as exc_info:
+            my_cmd()
+        assert exc_info.value.code == 1
+
+    def test_keyboard_interrupt_exits_130(self):
+        """KeyboardInterrupt exits with code 130."""
+
+        @cli_main
+        def my_cmd():
+            raise KeyboardInterrupt
+
+        with pytest.raises(SystemExit) as exc_info:
+            my_cmd()
+        assert exc_info.value.code == 130
+
+    def test_system_exit_passthrough(self):
+        """SystemExit is re-raised as-is."""
+
+        @cli_main
+        def my_cmd():
+            raise SystemExit(99)
+
+        with pytest.raises(SystemExit) as exc_info:
+            my_cmd()
+        assert exc_info.value.code == 99
+
+
+class TestCliMainMetadata:
+    """Tests for decorator metadata preservation."""
+
+    def test_wrapped_function_name_preserved(self):
+        """functools.wraps preserves __name__."""
+
+        @cli_main
+        def my_special_cmd():
+            """My docstring."""
+
+        assert my_special_cmd.__name__ == "my_special_cmd"
+        assert my_special_cmd.__doc__ == "My docstring."
+
+
+class TestCliMainArgsForwarding:
+    """Tests for argument forwarding."""
+
+    def test_args_forwarded(self):
+        """Arguments are forwarded to the wrapped function."""
+        received = {}
+
+        @cli_main
+        def my_cmd(a, b, key=None):
+            received["a"] = a
+            received["b"] = b
+            received["key"] = key
+
+        with pytest.raises(SystemExit):
+            my_cmd(1, 2, key="val")
+
+        assert received == {"a": 1, "b": 2, "key": "val"}

--- a/tests/workflows/rest/__init__.py
+++ b/tests/workflows/rest/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for rest workflow modules."""

--- a/tests/workflows/rest/test_veto_check.py
+++ b/tests/workflows/rest/test_veto_check.py
@@ -1,0 +1,138 @@
+"""Tests for pre-session VETO check (P0 CRITICAL safety function).
+
+Validates check_pre_session_veto() wrapper:
+- TSB fallback calculation
+- Result dict structure
+- VETO triggers (TSB, sleep, ATL/CTL ratio, combined)
+- Session intensity context
+- Missing data handling
+"""
+
+from magma_cycling.workflows.rest.veto_check import check_pre_session_veto
+
+# Standard master athlete profile for tests
+MASTER_PROFILE = {"age": 54, "category": "master", "sleep_dependent": True}
+
+
+class TestVetoTriggeredCriticalTSB:
+    """TSB < -25 must trigger VETO."""
+
+    def test_veto_triggered_critical_tsb(self):
+        """TSB < -25 triggers cancel=True."""
+        wellness = {"ctl": 65, "atl": 95, "tsb": -30, "sleep_hours": 7.5}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        assert result["cancel"] is True
+        assert result["veto"] is True
+        assert result["risk_level"] == "critical"
+        assert any("TSB" in f for f in result["factors"])
+
+
+class TestVetoTriggeredBadSleep:
+    """Sleep < 5.5h must trigger VETO."""
+
+    def test_veto_triggered_bad_sleep(self):
+        """Sleep < 5.5h triggers veto."""
+        wellness = {"ctl": 65, "atl": 60, "tsb": 5, "sleep_hours": 5.0}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        assert result["cancel"] is True
+        assert result["veto"] is True
+        assert any("leep" in f.lower() for f in result["factors"])
+
+
+class TestVetoTriggeredHighATLRatio:
+    """ATL/CTL > 1.8 must trigger VETO."""
+
+    def test_veto_triggered_high_atl_ratio(self):
+        """ATL/CTL ratio > 1.8 triggers veto."""
+        wellness = {"ctl": 50, "atl": 100, "tsb": -10, "sleep_hours": 7.5}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        assert result["cancel"] is True
+        assert result["risk_level"] == "critical"
+        assert any("ratio" in f.lower() for f in result["factors"])
+
+
+class TestVetoTriggeredCombinedSleepTSB:
+    """Sleep < 6h + TSB < -15 must trigger VETO."""
+
+    def test_veto_triggered_combined_sleep_tsb(self):
+        """Combined low sleep + fatigued TSB triggers veto."""
+        wellness = {"ctl": 65, "atl": 82, "tsb": -17, "sleep_hours": 5.8}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        assert result["cancel"] is True
+        assert result["risk_level"] == "critical"
+        assert any("ombined" in f or "ombined" in f.lower() for f in result["factors"])
+
+
+class TestNoVetoHealthyAthlete:
+    """Normal data must NOT trigger VETO."""
+
+    def test_no_veto_healthy_athlete(self):
+        """Healthy metrics produce cancel=False."""
+        wellness = {"ctl": 65, "atl": 60, "tsb": 5, "sleep_hours": 7.5}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        assert result["cancel"] is False
+        assert result["veto"] is False
+        assert result["risk_level"] == "low"
+
+
+class TestTSBFallback:
+    """TSB fallback calculation when TSB is None."""
+
+    def test_tsb_fallback_from_ctl_atl(self):
+        """TSB=None + CTL>0 calculates TSB as CTL-ATL."""
+        # CTL=65, ATL=95 → TSB = 65-95 = -30 → should veto (< -25)
+        wellness = {"ctl": 65, "atl": 95, "sleep_hours": 7.5}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        assert result["cancel"] is True
+        assert result["risk_level"] == "critical"
+
+    def test_tsb_fallback_zero_no_ctl(self):
+        """TSB=None + CTL=0 defaults TSB to 0 (no crash, no veto)."""
+        wellness = {"ctl": 0, "atl": 0, "sleep_hours": 7.5}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        assert result["cancel"] is False
+
+
+class TestResultDictKeys:
+    """Result dict must contain all expected keys."""
+
+    def test_result_dict_keys(self):
+        """All expected keys present in result."""
+        wellness = {"ctl": 65, "atl": 60, "tsb": 5, "sleep_hours": 7.5}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        expected_keys = {"cancel", "veto", "risk_level", "recommendation", "factors"}
+        assert expected_keys.issubset(result.keys())
+        assert isinstance(result["factors"], list)
+        assert isinstance(result["recommendation"], str)
+
+
+class TestSessionIntensityInResult:
+    """Session intensity added to result when veto triggered."""
+
+    def test_session_intensity_in_result(self):
+        """With intensity + veto, session_intensity key is added."""
+        wellness = {"ctl": 65, "atl": 95, "tsb": -30, "sleep_hours": 7.5}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE, session_intensity=95.0)
+
+        assert result["cancel"] is True
+        assert result["session_intensity"] == 95.0
+
+
+class TestMissingSleepHours:
+    """Missing sleep_hours must not crash."""
+
+    def test_missing_sleep_hours(self):
+        """No sleep_hours in wellness data does not raise."""
+        wellness = {"ctl": 65, "atl": 60, "tsb": 5}
+        result = check_pre_session_veto(wellness, MASTER_PROFILE)
+
+        assert result["cancel"] is False
+        assert "cancel" in result


### PR DESCRIPTION
## Summary
- Add `@cli_main` decorator (`utils/cli.py`) to eliminate `try/except/traceback/sys.exit(1)` boilerplate (8 tests)
- Add 10 tests for `check_pre_session_veto()` — P0 safety function with 0 prior test coverage
- Migrate 5 pilot scripts to `@cli_main`: `debug_detection`, `dashboard`, `normalize_weekly_reports_casing`, `fix_weekly_reports_casing`, `intervals_format_validator`
- Mock `test_create_event.py` — no more live API calls in tests
- Adapt 3 existing tests for `SystemExit(0)` from decorator

## Test plan
- [x] 20 new tests pass (10 veto_check + 8 cli_main + 2 create_event)
- [x] Full suite: 2216 passed, 0 failed
- [x] pre-commit: all hooks pass (pydocstyle failure on zwift_service.py is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)