### PR TITLE
refactor(sprint2): extract 8 PID evaluation mixins from god class

### DIFF
--- a/magma_cycling/workflows/pid_eval/__init__.py
+++ b/magma_cycling/workflows/pid_eval/__init__.py
@@ -1,0 +1,1 @@
+"""PIDDailyEvaluator mixin modules for god class decomposition."""

--- a/magma_cycling/workflows/pid_eval/adherence.py
+++ b/magma_cycling/workflows/pid_eval/adherence.py
@@ -1,0 +1,40 @@
+"""Adherence data loading mixin for PID evaluation."""
+
+import json
+from datetime import date, datetime
+from typing import Any
+
+
+class AdherenceMixin:
+    """Load workout adherence records from JSONL file."""
+
+    def load_adherence_data(self, start_date: date, end_date: date) -> list[dict[str, Any]]:
+        """Load adherence data for date range.
+
+        Args:
+            start_date: Start date (inclusive)
+            end_date: End date (inclusive)
+
+        Returns:
+            List of adherence records
+        """
+        if not self.adherence_file.exists():
+            print(f"⚠️  No adherence data at {self.adherence_file}")
+            return []
+
+        print(f"\n📥 Loading adherence data ({start_date} → {end_date})")
+
+        records = []
+        with open(self.adherence_file, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    record = json.loads(line.strip())
+                    record_date = datetime.strptime(record["date"], "%Y-%m-%d").date()
+
+                    if start_date <= record_date <= end_date:
+                        records.append(record)
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    continue
+
+        print(f"   ✅ {len(records)} records loaded")
+        return records

--- a/magma_cycling/workflows/pid_eval/cardiovascular.py
+++ b/magma_cycling/workflows/pid_eval/cardiovascular.py
@@ -1,0 +1,51 @@
+"""Cardiovascular coupling extraction mixin for PID evaluation."""
+
+import re
+from datetime import date
+
+
+class CardiovascularQualityMixin:
+    """Extract cardiovascular coupling from weekly workout history files."""
+
+    def extract_cardiovascular_coupling(self, start_date: date, end_date: date) -> list[float]:
+        """Extract cardiovascular coupling (decouplage) from weekly report files.
+
+        Scans logs/weekly_reports/S0XX/workout_history_S0XX.md files for decouplage values.
+
+        Args:
+            start_date: Start date
+            end_date: End date
+
+        Returns:
+            List of decouplage percentages (as decimals, e.g., 0.062 for 6.2%)
+        """
+        if not self.workouts_history.exists():
+            print(f"⚠️  Weekly reports directory not found at {self.workouts_history}")
+            return []
+
+        print(f"\n📥 Extracting cardiovascular coupling ({start_date} → {end_date})")
+
+        coupling_values = []
+
+        # Regex patterns for decouplage extraction
+        patterns = [
+            r"découplage\s+cardiovasculaire\s+\w+\s*\((\d+\.?\d*)\s*%\)",
+            r"découplage\s+(\d+\.?\d*)\s*%",
+        ]
+
+        # Scan all weekly workout history files
+        workout_files = sorted(self.workouts_history.glob("*/workout_history_*.md"))
+        print(f"   📁 Found {len(workout_files)} weekly files")
+
+        for workout_file in workout_files:
+            with open(workout_file, encoding="utf-8") as f:
+                content = f.read()
+
+            for pattern in patterns:
+                matches = re.finditer(pattern, content, re.IGNORECASE)
+                for match in matches:
+                    coupling_pct = float(match.group(1))
+                    coupling_values.append(abs(coupling_pct) / 100.0)
+
+        print(f"   ✅ {len(coupling_values)} cardiovascular coupling values extracted")
+        return coupling_values

--- a/magma_cycling/workflows/pid_eval/cycle_metrics.py
+++ b/magma_cycling/workflows/pid_eval/cycle_metrics.py
@@ -1,0 +1,54 @@
+"""Cycle metrics aggregation mixin for PID evaluation."""
+
+from datetime import date
+from typing import Any
+
+
+class CycleMetricsAggregationMixin:
+    """Orchestrate metrics calculation from all data sources."""
+
+    def calculate_cycle_metrics(self, start_date: date, end_date: date) -> dict[str, Any]:
+        """Calculate all metrics needed for PID evaluation.
+
+        Args:
+            start_date: Cycle start
+            end_date: Cycle end
+
+        Returns:
+            Dict with adherence_rate, avg_cardiovascular_coupling,
+            tss_completion_rate, days_with_data, total_workouts
+        """
+        print(f"\n{'=' * 60}")
+        print("📊 Calculating Cycle Metrics")
+        print(f"{'=' * 60}")
+        print(f"Period: {start_date} → {end_date}")
+
+        # 1. Adherence (discipline)
+        adherence_records = self.load_adherence_data(start_date, end_date)
+        total_planned = sum(r["planned_workouts"] for r in adherence_records)
+        total_completed = sum(r["completed_activities"] for r in adherence_records)
+        adherence_rate = total_completed / total_planned if total_planned > 0 else 1.0
+
+        # 2. Cardiovascular coupling (quality)
+        coupling_values = self.extract_cardiovascular_coupling(start_date, end_date)
+        avg_coupling = sum(coupling_values) / len(coupling_values) if coupling_values else 0.05
+
+        # 3. TSS completion (capacity)
+        tss_completion = self.calculate_tss_completion(start_date, end_date)
+
+        metrics = {
+            "adherence_rate": adherence_rate,
+            "avg_cardiovascular_coupling": avg_coupling,
+            "tss_completion_rate": tss_completion,
+            "days_with_data": len(adherence_records),
+            "total_workouts": total_completed,
+        }
+
+        print("\n📊 Metrics Summary:")
+        print(f"   Adherence Rate: {adherence_rate * 100:.1f}% (discipline)")
+        print(f"   Avg Cardiovascular Coupling: {avg_coupling * 100:.1f}% (quality)")
+        print(f"   TSS Completion: {tss_completion * 100:.1f}% (capacity)")
+        print(f"   Workouts: {total_completed} completed")
+        print(f"   Days: {len(adherence_records)} with data")
+
+        return metrics

--- a/magma_cycling/workflows/pid_eval/evaluation_logging.py
+++ b/magma_cycling/workflows/pid_eval/evaluation_logging.py
@@ -1,0 +1,51 @@
+"""Evaluation logging mixin for PID evaluation."""
+
+import json
+from datetime import date, datetime
+from typing import Any
+
+
+class LoggingMixin:
+    """Log evaluations and save intelligence state."""
+
+    def log_evaluation(
+        self,
+        start_date: date,
+        end_date: date,
+        metrics: dict[str, Any],
+        pid_result: dict[str, Any] | None = None,
+    ) -> None:
+        """Log evaluation to pid_evaluation.jsonl.
+
+        Args:
+            start_date: Cycle start
+            end_date: Cycle end
+            metrics: Cycle metrics
+            pid_result: PID correction result (None if not cycle completion)
+        """
+        log_entry = {
+            "timestamp": datetime.now().isoformat(),
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "metrics": metrics,
+            "pid_correction": pid_result,
+            "learnings_count": len(self.intelligence.learnings),
+            "patterns_count": len(self.intelligence.patterns),
+        }
+
+        if not self.dry_run:
+            self.evaluation_log.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.evaluation_log, "a", encoding="utf-8") as f:
+                f.write(json.dumps(log_entry) + "\n")
+            print(f"\n📝 Evaluation logged to {self.evaluation_log}")
+        else:
+            print("\n🔍 DRY-RUN: Skipping log save")
+
+    def save_intelligence(self) -> None:
+        """Save intelligence to file."""
+        if not self.dry_run:
+            self.intelligence_file.parent.mkdir(parents=True, exist_ok=True)
+            self.intelligence.save_to_file(self.intelligence_file)
+            print(f"💾 Intelligence saved to {self.intelligence_file}")
+        else:
+            print("🔍 DRY-RUN: Skipping intelligence save")

--- a/magma_cycling/workflows/pid_eval/intelligence_learnings.py
+++ b/magma_cycling/workflows/pid_eval/intelligence_learnings.py
@@ -1,0 +1,126 @@
+"""Training intelligence learnings mixin for PID evaluation."""
+
+from datetime import date
+from typing import Any
+
+from magma_cycling.intelligence.training_intelligence import AnalysisLevel, ConfidenceLevel
+
+
+class TrainingIntelligenceLearningsMixin:
+    """Convert metrics into learnings in TrainingIntelligence."""
+
+    def create_intelligence_learnings(
+        self,
+        metrics: dict[str, Any],
+        start_date: date,
+        end_date: date,
+    ) -> None:
+        """Create learnings in TrainingIntelligence from metrics.
+
+        Args:
+            metrics: Cycle metrics dict
+            start_date: Period start
+            end_date: Period end
+        """
+        print(f"\n{'=' * 60}")
+        print("🧠 Creating Intelligence Learnings")
+        print(f"{'=' * 60}")
+
+        days = metrics["days_with_data"]
+        adherence = metrics["adherence_rate"]
+        coupling = metrics["avg_cardiovascular_coupling"]
+        tss_completion = metrics["tss_completion_rate"]
+
+        # Learning 1: Adherence (discipline)
+        adherence_evidence = [
+            f"Période: {start_date} → {end_date} ({days} jours)",
+            f"Taux adhérence: {adherence * 100:.1f}%",
+            f"Workouts complétés: {metrics['total_workouts']}",
+        ]
+
+        if adherence >= 0.90:
+            adherence_desc = f"Discipline excellente: {adherence * 100:.1f}% adhérence"
+            impact = "LOW"
+        elif adherence >= 0.80:
+            adherence_desc = f"Discipline correcte: {adherence * 100:.1f}% adhérence"
+            impact = "MEDIUM"
+        else:
+            adherence_desc = f"Discipline faible: {adherence * 100:.1f}% - Action requise"
+            impact = "HIGH"
+
+        learning_adh = self.intelligence.add_learning(
+            category="adherence",
+            description=adherence_desc,
+            evidence=adherence_evidence,
+            level=AnalysisLevel.WEEKLY,
+        )
+        learning_adh.impact = impact
+
+        # Set confidence based on data quantity
+        if days >= 35:
+            learning_adh.confidence = ConfidenceLevel.VALIDATED
+        elif days >= 21:
+            learning_adh.confidence = ConfidenceLevel.HIGH
+        elif days >= 14:
+            learning_adh.confidence = ConfidenceLevel.MEDIUM
+        else:
+            learning_adh.confidence = ConfidenceLevel.LOW
+
+        print(f"   ✅ Adherence learning: {learning_adh.confidence.value}")
+
+        # Learning 2: Cardiovascular quality
+        coupling_evidence = [
+            f"Période: {start_date} → {end_date}",
+            f"Découplage moyen: {coupling * 100:.1f}%",
+            "Seuil optimal: <7.5%",
+        ]
+
+        if coupling <= 0.075:
+            coupling_desc = f"Qualité cardiovasculaire excellente: {coupling * 100:.1f}% découplage"
+            impact = "LOW"
+        elif coupling <= 0.085:
+            coupling_desc = f"Qualité cardiovasculaire dégradée: {coupling * 100:.1f}%"
+            impact = "MEDIUM"
+        else:
+            coupling_desc = (
+                f"Surcharge détectée: {coupling * 100:.1f}% découplage - Repos nécessaire"
+            )
+            impact = "HIGH"
+
+        learning_cv = self.intelligence.add_learning(
+            category="cardiovascular_quality",
+            description=coupling_desc,
+            evidence=coupling_evidence,
+            level=AnalysisLevel.WEEKLY,
+        )
+        learning_cv.impact = impact
+        learning_cv.confidence = learning_adh.confidence  # Same confidence
+
+        print(f"   ✅ Cardiovascular learning: {learning_cv.confidence.value}")
+
+        # Learning 3: TSS capacity
+        tss_evidence = [
+            f"Période: {start_date} → {end_date}",
+            f"Taux complétion TSS: {tss_completion * 100:.1f}%",
+        ]
+
+        if tss_completion >= 0.90:
+            tss_desc = f"Capacité TSS excellente: {tss_completion * 100:.1f}%"
+            impact = "LOW"
+        elif tss_completion >= 0.85:
+            tss_desc = f"Capacité TSS limite: {tss_completion * 100:.1f}%"
+            impact = "MEDIUM"
+        else:
+            tss_desc = f"Capacité TSS insuffisante: {tss_completion * 100:.1f}%"
+            impact = "HIGH"
+
+        learning_tss = self.intelligence.add_learning(
+            category="tss_capacity",
+            description=tss_desc,
+            evidence=tss_evidence,
+            level=AnalysisLevel.WEEKLY,
+        )
+        learning_tss.impact = impact
+        learning_tss.confidence = learning_adh.confidence
+
+        print(f"   ✅ TSS capacity learning: {learning_tss.confidence.value}")

--- a/magma_cycling/workflows/pid_eval/pid_correction.py
+++ b/magma_cycling/workflows/pid_eval/pid_correction.py
@@ -1,0 +1,80 @@
+"""PID correction evaluation mixin for PID evaluation."""
+
+from typing import Any
+
+from magma_cycling.intelligence.discrete_pid_controller import (
+    DiscretePIDController,
+    compute_discrete_pid_gains_from_intelligence,
+)
+
+
+class PIDCorrectionMixin:
+    """Run discrete PID controller with enhanced validation."""
+
+    def evaluate_pid_correction(
+        self,
+        measured_ftp: float,
+        cycle_duration_weeks: int,
+        metrics: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Evaluate PID correction with enhanced validation.
+
+        Args:
+            measured_ftp: FTP measured (W)
+            cycle_duration_weeks: Cycle duration (weeks)
+            metrics: Cycle metrics dict
+
+        Returns:
+            PID correction result dict
+        """
+        print(f"\n{'=' * 60}")
+        print("🎛️  PID Correction Evaluation")
+        print(f"{'=' * 60}")
+
+        # Calculate adaptive gains from intelligence
+        gains = compute_discrete_pid_gains_from_intelligence(self.intelligence)
+        print("\nAdaptive PID Gains:")
+        print(f"   Kp: {gains['kp']:.4f}")
+        print(f"   Ki: {gains['ki']:.4f}")
+        print(f"   Kd: {gains['kd']:.4f}")
+
+        # Get FTP setpoint from athlete profile (fallback to measured)
+        try:
+            from magma_cycling.config import AthleteProfile
+
+            setpoint = AthleteProfile.from_env().ftp
+        except Exception:
+            setpoint = measured_ftp
+
+        # Create PID controller
+        controller = DiscretePIDController(
+            kp=gains["kp"],
+            ki=gains["ki"],
+            kd=gains["kd"],
+            setpoint=setpoint,
+        )
+
+        # Compute enhanced correction
+        result = controller.compute_cycle_correction_enhanced(
+            measured_ftp=measured_ftp,
+            cycle_duration_weeks=cycle_duration_weeks,
+            adherence_rate=metrics["adherence_rate"],
+            avg_cardiovascular_coupling=metrics["avg_cardiovascular_coupling"],
+            tss_completion_rate=metrics["tss_completion_rate"],
+        )
+
+        print("\n📊 PID Results:")
+        print(f"   FTP Error: {result['error']:.1f}W")
+        print(f"   TSS Adjustment: {result['tss_per_week_adjusted']} TSS/week")
+        print(f"   Validated: {'✅' if result['validation']['validated'] else '⚠️ '}")
+        print(f"   Confidence: {result['validation']['confidence']}")
+
+        if result["validation"]["red_flags"]:
+            print("\n🚨 Red Flags:")
+            for flag in result["validation"]["red_flags"]:
+                print(f"   • {flag}")
+
+        print("\n💡 Recommendation:")
+        print(f"   {result['recommendation']}")
+
+        return result

--- a/magma_cycling/workflows/pid_eval/test_opportunity.py
+++ b/magma_cycling/workflows/pid_eval/test_opportunity.py
@@ -1,0 +1,246 @@
+"""Test opportunity and CTL monitoring mixin for PID evaluation."""
+
+import traceback
+from datetime import date, datetime, timedelta
+from typing import Any
+
+
+class TestOpportunityMixin:
+    """Check FTP test opportunities and monitor CTL progression."""
+
+    def check_test_opportunity(self) -> dict[str, Any] | None:
+        """Check if FTP test is recommended based on PID discrete cycle timing.
+
+        Returns:
+            Dict with recommendation details if test is due, None otherwise
+        """
+        # Get current wellness for TSB
+        try:
+            wellness_data = self.client.get_wellness(
+                date.today().isoformat(), date.today().isoformat()
+            )
+            if not wellness_data:
+                return None
+
+            wellness = wellness_data[0]
+            tsb = wellness.get("tsb", 0)
+            ctl = wellness.get("ctl", 0)
+
+        except Exception as e:
+            print(f"  ⚠️  Could not fetch wellness data: {e}")
+            return None
+
+        # Check time since last test (look for high IF activities in past 16 weeks)
+        weeks_back = 16
+        start_check = date.today() - timedelta(weeks=weeks_back)
+
+        try:
+            activities = self.client.get_activities(
+                start_check.isoformat(), date.today().isoformat()
+            )
+
+            # Look for test-like activities (IF > 0.90, duration 35-65 min)
+            test_activities = [
+                a
+                for a in activities
+                if a.get("icu_intensity", 0) > 0.90 and 35 <= a.get("moving_time", 0) / 60 <= 65
+            ]
+
+            if test_activities:
+                last_test = max(test_activities, key=lambda x: x.get("start_date_local", ""))
+                last_test_date_str = last_test.get("start_date_local", "")[:10]
+                last_test_date = datetime.strptime(last_test_date_str, "%Y-%m-%d").date()
+                weeks_since_test = (date.today() - last_test_date).days / 7
+            else:
+                weeks_since_test = 16
+
+        except Exception:
+            weeks_since_test = 8
+
+        # Decision logic
+        test_overdue = weeks_since_test >= 6
+        form_ready = tsb >= 5
+        form_neutral = -5 <= tsb <= 5
+        fitness_adequate = ctl >= 40
+
+        recommendation = None
+
+        if test_overdue and form_ready and fitness_adequate:
+            recommendation = {
+                "status": "READY",
+                "weeks_since_test": weeks_since_test,
+                "tsb": tsb,
+                "ctl": ctl,
+                "message": f"Test FTP recommandé (dernier test: {weeks_since_test:.1f} sem)",
+                "timing": "Cette semaine (TSB acceptable)",
+            }
+        elif test_overdue and form_neutral and fitness_adequate:
+            recommendation = {
+                "status": "NEEDS_TAPER",
+                "weeks_since_test": weeks_since_test,
+                "tsb": tsb,
+                "ctl": ctl,
+                "message": (
+                    f"Test FTP recommandé avec affûtage (dernier: {weeks_since_test:.1f} sem)"
+                ),
+                "timing": "Semaine prochaine après réduction volume (-40% TSS)",
+            }
+        elif test_overdue:
+            recommendation = {
+                "status": "OVERDUE_LOW_FITNESS",
+                "weeks_since_test": weeks_since_test,
+                "tsb": tsb,
+                "ctl": ctl,
+                "message": f"Test overdue ({weeks_since_test:.1f} sem) mais condition limitée",
+                "timing": "Prévoir après 2 semaines de préparation",
+            }
+
+        return recommendation
+
+    def monitor_ctl_progression_vs_peaks(self) -> dict[str, Any] | None:
+        """Monitor CTL progression vs Peaks Coaching targets.
+
+        Returns:
+            Dict with CTL monitoring results or None if failed
+        """
+        print(f"\n{'=' * 60}")
+        print("📈 CTL Progression Monitoring (Peaks Coaching)")
+        print(f"{'=' * 60}")
+
+        try:
+            # Get current wellness for CTL
+            wellness_data = self.client.get_wellness(
+                date.today().isoformat(), date.today().isoformat()
+            )
+            if not wellness_data:
+                print("  ⚠️  No wellness data available")
+                return None
+
+            wellness = wellness_data[0]
+            ctl_current = wellness.get("ctl", 0)
+            atl_current = wellness.get("atl", 0)
+            tsb_current = wellness.get("tsb", 0)
+
+            # Load athlete profile from env for FTP and age
+            from magma_cycling.config.athlete_profile import AthleteProfile
+
+            athlete_profile = AthleteProfile.from_env()
+            ftp_current = athlete_profile.ftp
+            ftp_target = athlete_profile.ftp_target
+            athlete_age = athlete_profile.age
+
+            # Calculate Peaks Coaching thresholds
+            ctl_minimum = (ftp_current / 220) * 55
+            ctl_optimal = (ftp_current / 220) * 70
+
+            # Calculate CTL progression rate (last 7 days)
+            week_ago = date.today() - timedelta(days=7)
+            wellness_week_ago = self.client.get_wellness(week_ago.isoformat(), week_ago.isoformat())
+
+            if wellness_week_ago:
+                ctl_week_ago = wellness_week_ago[0].get("ctl", ctl_current)
+                ctl_weekly_change = ctl_current - ctl_week_ago
+            else:
+                ctl_weekly_change = 0
+
+            # Estimate weeks to reach targets
+            if ctl_weekly_change > 0:
+                weeks_to_minimum = max(0, (ctl_minimum - ctl_current) / ctl_weekly_change)
+                weeks_to_optimal = max(0, (ctl_optimal - ctl_current) / ctl_weekly_change)
+            else:
+                weeks_to_minimum = float("inf")
+                weeks_to_optimal = float("inf")
+
+            # Determine status
+            if ctl_current < 50:
+                status = "CRITICAL"
+                status_emoji = "🚨"
+                message = "CTL critique < 50 - Reconstruction base urgente"
+            elif ctl_current < ctl_minimum:
+                status = "LOW"
+                status_emoji = "⚠️"
+                message = f"CTL sous minimum Peaks ({ctl_minimum:.0f})"
+            elif ctl_current < (ctl_optimal * 0.85):
+                status = "SUBOPTIMAL"
+                status_emoji = "📊"
+                message = f"CTL sous-optimal (< 85% de {ctl_optimal:.0f})"
+            else:
+                status = "OPTIMAL"
+                status_emoji = "✅"
+                message = "CTL dans la zone optimale Peaks"
+
+            print(f"\n{status_emoji} Status: {status}")
+            print(f"   {message}")
+            print("\n📊 Métriques Actuelles:")
+            print(f"   CTL: {ctl_current:.1f}")
+            print(f"   ATL: {atl_current:.1f}")
+            print(f"   TSB: {tsb_current:+.1f}")
+            print(f"   FTP: {ftp_current}W")
+            print(f"\n🎯 Seuils Peaks (FTP {ftp_current}W):")
+            print(f"   CTL minimum: {ctl_minimum:.0f}")
+            print(f"   CTL optimal: {ctl_optimal:.0f}")
+            print("\n📈 Progression:")
+            print(f"   Changement 7 jours: {ctl_weekly_change:+.1f} points")
+
+            if weeks_to_minimum < float("inf"):
+                print(f"   Semaines → minimum: {weeks_to_minimum:.1f} semaines")
+            if weeks_to_optimal < float("inf"):
+                print(f"   Semaines → optimal: {weeks_to_optimal:.1f} semaines")
+
+            # Determine Peaks phase
+            from magma_cycling.planning.peaks_phases import determine_training_phase
+
+            phase_rec = determine_training_phase(
+                ctl_current=ctl_current,
+                ftp_current=ftp_current,
+                ftp_target=ftp_target,
+                athlete_age=athlete_age,
+            )
+
+            print(f"\n🎯 Phase Peaks Coaching: {phase_rec.phase.value.upper()}")
+            print(f"   TSS recommandé: {phase_rec.weekly_tss_load} TSS/semaine (charge)")
+            print(f"   TSS recovery: {phase_rec.weekly_tss_recovery} TSS/semaine")
+
+            # Recommendations
+            recommendations = []
+            if status == "CRITICAL":
+                recommendations.append("🚨 PEAKS OVERRIDE actif (CTL < 50)")
+                recommendations.append("Focus Tempo (35%) + Sweet-Spot (20%)")
+                recommendations.append(f"Target: {phase_rec.weekly_tss_load} TSS/semaine")
+            elif status == "LOW":
+                recommendations.append("Reconstruction base progressive")
+                recommendations.append(f"Maintenir {phase_rec.weekly_tss_load} TSS/semaine")
+                recommendations.append(f"CTL target: {ctl_minimum:.0f} minimum")
+            elif status == "SUBOPTIMAL":
+                recommendations.append("PID peut devenir actif si CTL ≥ 50")
+                recommendations.append("Continuer progression régulière")
+            else:
+                recommendations.append("Maintenir CTL à 90% du maximum (Masters 50+)")
+                recommendations.append("PID autonome recommandé")
+
+            if recommendations:
+                print("\n💡 Recommandations:")
+                for rec in recommendations:
+                    print(f"   • {rec}")
+
+            return {
+                "ctl_current": ctl_current,
+                "atl_current": atl_current,
+                "tsb_current": tsb_current,
+                "ftp_current": ftp_current,
+                "ctl_minimum": ctl_minimum,
+                "ctl_optimal": ctl_optimal,
+                "ctl_weekly_change": ctl_weekly_change,
+                "weeks_to_minimum": (weeks_to_minimum if weeks_to_minimum < float("inf") else None),
+                "weeks_to_optimal": (weeks_to_optimal if weeks_to_optimal < float("inf") else None),
+                "status": status,
+                "message": message,
+                "phase": phase_rec.phase.value,
+                "weekly_tss_recommended": phase_rec.weekly_tss_load,
+                "recommendations": recommendations,
+            }
+
+        except Exception as e:
+            print(f"  ❌ Erreur monitoring CTL: {e}")
+            traceback.print_exc()
+            return None

--- a/magma_cycling/workflows/pid_eval/tss_capacity.py
+++ b/magma_cycling/workflows/pid_eval/tss_capacity.py
@@ -1,0 +1,52 @@
+"""TSS capacity calculation mixin for PID evaluation."""
+
+from datetime import date
+
+
+class TSSCapacityMixin:
+    """Calculate TSS completion rate from Intervals.icu API."""
+
+    def calculate_tss_completion(self, start_date: date, end_date: date) -> float:
+        """Calculate TSS completion rate from Intervals.icu.
+
+        Compares planned TSS (events) vs realized TSS (activities).
+
+        Args:
+            start_date: Start date
+            end_date: End date
+
+        Returns:
+            TSS completion rate (0.0 - 1.0)
+        """
+        print(f"\n📥 Calculating TSS completion ({start_date} → {end_date})")
+
+        start_str = start_date.strftime("%Y-%m-%d")
+        end_str = end_date.strftime("%Y-%m-%d")
+
+        try:
+            # Get planned workouts
+            events = self.client.get_events(oldest=start_str, newest=end_str)
+            planned_workouts = [
+                e
+                for e in events
+                if e.get("category") == "WORKOUT" and not e.get("name", "").startswith("[")
+            ]
+
+            # Get completed activities
+            activities = self.client.get_activities(oldest=start_str, newest=end_str)
+
+            # Calculate TSS
+            planned_tss = sum(e.get("icu_training_load", 0) for e in planned_workouts)
+            realized_tss = sum(a.get("icu_training_load", 0) for a in activities)
+
+            completion_rate = realized_tss / planned_tss if planned_tss > 0 else 1.0
+
+            print(f"   Planned TSS: {planned_tss:.0f}")
+            print(f"   Realized TSS: {realized_tss:.0f}")
+            print(f"   Completion: {completion_rate * 100:.1f}%")
+
+            return completion_rate
+
+        except Exception as e:
+            print(f"   ⚠️  Error calculating TSS: {e}")
+            return 1.0

--- a/tests/workflows/pid_eval/__init__.py
+++ b/tests/workflows/pid_eval/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for PID evaluation mixin modules."""

--- a/tests/workflows/pid_eval/test_adherence.py
+++ b/tests/workflows/pid_eval/test_adherence.py
@@ -1,0 +1,81 @@
+"""Tests for AdherenceMixin."""
+
+import json
+from datetime import date
+from pathlib import Path
+
+from magma_cycling.workflows.pid_eval.adherence import AdherenceMixin
+
+
+class StubAdherence(AdherenceMixin):
+    """Stub class to test AdherenceMixin in isolation."""
+
+    def __init__(self, adherence_file):
+        """Initialize stub with adherence file path."""
+        self.adherence_file = Path(adherence_file)
+
+
+def _write_jsonl(path, records):
+    with open(path, "w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+class TestLoadAdherenceData:
+    """Tests for load_adherence_data."""
+
+    def test_loads_records_in_range(self, tmp_path):
+        """Records within date range are returned."""
+        path = tmp_path / "adherence.jsonl"
+        _write_jsonl(
+            path,
+            [
+                {"date": "2026-01-10", "planned_workouts": 1, "completed_activities": 1},
+                {"date": "2026-01-15", "planned_workouts": 2, "completed_activities": 1},
+                {"date": "2026-01-20", "planned_workouts": 1, "completed_activities": 0},
+            ],
+        )
+        stub = StubAdherence(path)
+        result = stub.load_adherence_data(date(2026, 1, 10), date(2026, 1, 15))
+        assert len(result) == 2
+
+    def test_excludes_records_outside_range(self, tmp_path):
+        """Records outside date range are excluded."""
+        path = tmp_path / "adherence.jsonl"
+        _write_jsonl(
+            path,
+            [
+                {"date": "2026-01-01", "planned_workouts": 1, "completed_activities": 1},
+                {"date": "2026-02-01", "planned_workouts": 1, "completed_activities": 1},
+            ],
+        )
+        stub = StubAdherence(path)
+        result = stub.load_adherence_data(date(2026, 1, 10), date(2026, 1, 20))
+        assert len(result) == 0
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        """Empty file returns empty list."""
+        path = tmp_path / "adherence.jsonl"
+        path.write_text("")
+        stub = StubAdherence(path)
+        result = stub.load_adherence_data(date(2026, 1, 1), date(2026, 12, 31))
+        assert result == []
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Missing file returns empty list without crash."""
+        path = tmp_path / "nonexistent.jsonl"
+        stub = StubAdherence(path)
+        result = stub.load_adherence_data(date(2026, 1, 1), date(2026, 12, 31))
+        assert result == []
+
+    def test_malformed_json_skipped(self, tmp_path):
+        """Malformed JSON lines are silently skipped."""
+        path = tmp_path / "adherence.jsonl"
+        path.write_text(
+            '{"date": "2026-01-10", "planned_workouts": 1, "completed_activities": 1}\n'
+            "NOT_JSON\n"
+            '{"date": "2026-01-11", "planned_workouts": 2, "completed_activities": 2}\n'
+        )
+        stub = StubAdherence(path)
+        result = stub.load_adherence_data(date(2026, 1, 1), date(2026, 12, 31))
+        assert len(result) == 2

--- a/tests/workflows/pid_eval/test_cardiovascular.py
+++ b/tests/workflows/pid_eval/test_cardiovascular.py
@@ -1,0 +1,65 @@
+"""Tests for CardiovascularQualityMixin."""
+
+from datetime import date
+from pathlib import Path
+
+from magma_cycling.workflows.pid_eval.cardiovascular import CardiovascularQualityMixin
+
+
+class StubCardio(CardiovascularQualityMixin):
+    """Stub class to test CardiovascularQualityMixin in isolation."""
+
+    def __init__(self, workouts_history):
+        """Initialize stub with workouts_history path."""
+        self.workouts_history = Path(workouts_history)
+
+
+class TestExtractCardiovascularCoupling:
+    """Tests for extract_cardiovascular_coupling."""
+
+    def test_extracts_parenthesized_format(self, tmp_path):
+        """Extracts 'decouplage cardiovasculaire excellent (1.6%)' format."""
+        week_dir = tmp_path / "S073"
+        week_dir.mkdir()
+        (week_dir / "workout_history_S073.md").write_text(
+            "Bon découplage cardiovasculaire excellent (1.6%)\n"
+        )
+        stub = StubCardio(tmp_path)
+        values = stub.extract_cardiovascular_coupling(date(2026, 1, 1), date(2026, 12, 31))
+        assert len(values) == 1
+        assert abs(values[0] - 0.016) < 0.001
+
+    def test_extracts_simple_format(self, tmp_path):
+        """Extracts 'decouplage 4.1%' format."""
+        week_dir = tmp_path / "S074"
+        week_dir.mkdir()
+        (week_dir / "workout_history_S074.md").write_text("Découplage 4.1%\n")
+        stub = StubCardio(tmp_path)
+        values = stub.extract_cardiovascular_coupling(date(2026, 1, 1), date(2026, 12, 31))
+        assert len(values) >= 1
+        assert any(abs(v - 0.041) < 0.001 for v in values)
+
+    def test_no_files_returns_empty(self, tmp_path):
+        """No workout files returns empty list."""
+        stub = StubCardio(tmp_path)
+        values = stub.extract_cardiovascular_coupling(date(2026, 1, 1), date(2026, 12, 31))
+        assert values == []
+
+    def test_missing_directory_returns_empty(self, tmp_path):
+        """Missing workouts_history directory returns empty list."""
+        stub = StubCardio(tmp_path / "nonexistent")
+        values = stub.extract_cardiovascular_coupling(date(2026, 1, 1), date(2026, 12, 31))
+        assert values == []
+
+    def test_multiple_values_from_file(self, tmp_path):
+        """Multiple coupling values extracted from single file."""
+        week_dir = tmp_path / "S075"
+        week_dir.mkdir()
+        (week_dir / "workout_history_S075.md").write_text(
+            "Découplage cardiovasculaire bon (3.5%)\n"
+            "Découplage 7.2%\n"
+            "Découplage cardiovasculaire excellent (2.1%)\n"
+        )
+        stub = StubCardio(tmp_path)
+        values = stub.extract_cardiovascular_coupling(date(2026, 1, 1), date(2026, 12, 31))
+        assert len(values) >= 3

--- a/tests/workflows/pid_eval/test_cycle_metrics.py
+++ b/tests/workflows/pid_eval/test_cycle_metrics.py
@@ -1,0 +1,104 @@
+"""Tests for CycleMetricsAggregationMixin."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from magma_cycling.workflows.pid_eval.adherence import AdherenceMixin
+from magma_cycling.workflows.pid_eval.cardiovascular import CardiovascularQualityMixin
+from magma_cycling.workflows.pid_eval.cycle_metrics import CycleMetricsAggregationMixin
+from magma_cycling.workflows.pid_eval.tss_capacity import TSSCapacityMixin
+
+
+class StubMetrics(
+    CycleMetricsAggregationMixin,
+    AdherenceMixin,
+    CardiovascularQualityMixin,
+    TSSCapacityMixin,
+):
+    """Stub combining all data source mixins with aggregation."""
+
+    def __init__(self):
+        """Initialize stub."""
+        self.client = MagicMock()
+        self.adherence_file = MagicMock()
+        self.adherence_file.exists.return_value = False
+        self.workouts_history = MagicMock()
+        self.workouts_history.exists.return_value = False
+
+
+class TestCalculateCycleMetrics:
+    """Tests for calculate_cycle_metrics."""
+
+    def test_returns_all_expected_keys(self):
+        """Result dict contains all required keys."""
+        stub = StubMetrics()
+        stub.client.get_events.return_value = []
+        stub.client.get_activities.return_value = []
+        result = stub.calculate_cycle_metrics(date(2026, 1, 1), date(2026, 1, 7))
+        expected_keys = {
+            "adherence_rate",
+            "avg_cardiovascular_coupling",
+            "tss_completion_rate",
+            "days_with_data",
+            "total_workouts",
+        }
+        assert expected_keys == set(result.keys())
+
+    def test_no_data_defaults(self):
+        """Empty data sources produce sensible defaults."""
+        stub = StubMetrics()
+        stub.client.get_events.return_value = []
+        stub.client.get_activities.return_value = []
+        result = stub.calculate_cycle_metrics(date(2026, 1, 1), date(2026, 1, 7))
+        assert result["adherence_rate"] == 1.0  # no planned = 100%
+        assert result["avg_cardiovascular_coupling"] == 0.05  # default
+        assert result["tss_completion_rate"] == 1.0  # no planned = 100%
+        assert result["days_with_data"] == 0
+        assert result["total_workouts"] == 0
+
+    def test_adherence_rate_calculation(self, tmp_path):
+        """Adherence rate calculated correctly from records."""
+        import json
+
+        adherence_file = tmp_path / "adherence.jsonl"
+        records = [
+            {"date": "2026-01-10", "planned_workouts": 2, "completed_activities": 2},
+            {"date": "2026-01-11", "planned_workouts": 1, "completed_activities": 0},
+        ]
+        with open(adherence_file, "w") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+
+        stub = StubMetrics()
+        stub.adherence_file = adherence_file
+        stub.client.get_events.return_value = []
+        stub.client.get_activities.return_value = []
+
+        result = stub.calculate_cycle_metrics(date(2026, 1, 1), date(2026, 1, 31))
+        # 2 completed / 3 planned = 0.667
+        assert abs(result["adherence_rate"] - 2 / 3) < 0.01
+
+    def test_coupling_integrated(self, tmp_path):
+        """Cardiovascular coupling values integrated when available."""
+        week_dir = tmp_path / "S073"
+        week_dir.mkdir()
+        (week_dir / "workout_history_S073.md").write_text("Découplage 6.0%\n")
+
+        stub = StubMetrics()
+        stub.workouts_history = tmp_path
+        stub.client.get_events.return_value = []
+        stub.client.get_activities.return_value = []
+
+        result = stub.calculate_cycle_metrics(date(2026, 1, 1), date(2026, 1, 31))
+        assert abs(result["avg_cardiovascular_coupling"] - 0.06) < 0.01
+
+    def test_tss_completion_integrated(self):
+        """TSS completion rate from API integrated correctly."""
+        stub = StubMetrics()
+        stub.client.get_events.return_value = [
+            {"category": "WORKOUT", "name": "Endurance", "icu_training_load": 200},
+        ]
+        stub.client.get_activities.return_value = [{"icu_training_load": 180}]
+
+        result = stub.calculate_cycle_metrics(date(2026, 1, 1), date(2026, 1, 7))
+        assert abs(result["tss_completion_rate"] - 0.9) < 0.01

--- a/tests/workflows/pid_eval/test_evaluation_logging.py
+++ b/tests/workflows/pid_eval/test_evaluation_logging.py
@@ -1,0 +1,68 @@
+"""Tests for LoggingMixin."""
+
+import json
+from datetime import date
+from pathlib import Path
+
+from magma_cycling.intelligence.training_intelligence import TrainingIntelligence
+from magma_cycling.workflows.pid_eval.evaluation_logging import LoggingMixin
+
+
+class StubLogging(LoggingMixin):
+    """Stub class to test LoggingMixin."""
+
+    def __init__(self, evaluation_log, intelligence_file, dry_run=False):
+        """Initialize stub with paths."""
+        self.evaluation_log = Path(evaluation_log)
+        self.intelligence_file = Path(intelligence_file)
+        self.intelligence = TrainingIntelligence()
+        self.dry_run = dry_run
+
+
+class TestLogEvaluation:
+    """Tests for log_evaluation."""
+
+    def test_writes_jsonl_entry(self, tmp_path):
+        """Log entry written as JSONL."""
+        log_file = tmp_path / "pid_evaluation.jsonl"
+        stub = StubLogging(log_file, tmp_path / "intel.json")
+        metrics = {"adherence_rate": 0.9, "tss_completion_rate": 0.85}
+        stub.log_evaluation(date(2026, 1, 1), date(2026, 1, 7), metrics)
+        assert log_file.exists()
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["metrics"]["adherence_rate"] == 0.9
+        assert entry["pid_correction"] is None
+
+    def test_dry_run_no_write(self, tmp_path):
+        """Dry run does not write to file."""
+        log_file = tmp_path / "pid_evaluation.jsonl"
+        stub = StubLogging(log_file, tmp_path / "intel.json", dry_run=True)
+        stub.log_evaluation(date(2026, 1, 1), date(2026, 1, 7), {})
+        assert not log_file.exists()
+
+    def test_pid_result_included(self, tmp_path):
+        """PID result included when provided."""
+        log_file = tmp_path / "pid_evaluation.jsonl"
+        stub = StubLogging(log_file, tmp_path / "intel.json")
+        pid_result = {"error": -5.0, "tss_per_week_adjusted": 320}
+        stub.log_evaluation(date(2026, 1, 1), date(2026, 1, 7), {}, pid_result=pid_result)
+        entry = json.loads(log_file.read_text().strip())
+        assert entry["pid_correction"]["error"] == -5.0
+
+
+class TestSaveIntelligence:
+    """Tests for save_intelligence."""
+
+    def test_saves_to_file(self, tmp_path):
+        """Intelligence saved to file path."""
+        intel_file = tmp_path / "intelligence.json"
+        stub = StubLogging(tmp_path / "log.jsonl", intel_file)
+        stub.save_intelligence()
+        assert intel_file.exists()
+
+    def test_dry_run_no_save(self, tmp_path):
+        """Dry run does not save intelligence."""
+        intel_file = tmp_path / "intelligence.json"
+        stub = StubLogging(tmp_path / "log.jsonl", intel_file, dry_run=True)
+        stub.save_intelligence()
+        assert not intel_file.exists()

--- a/tests/workflows/pid_eval/test_intelligence_learnings.py
+++ b/tests/workflows/pid_eval/test_intelligence_learnings.py
@@ -1,0 +1,87 @@
+"""Tests for TrainingIntelligenceLearningsMixin."""
+
+from datetime import date
+
+from magma_cycling.intelligence.training_intelligence import (
+    ConfidenceLevel,
+    TrainingIntelligence,
+)
+from magma_cycling.workflows.pid_eval.intelligence_learnings import (
+    TrainingIntelligenceLearningsMixin,
+)
+
+
+class StubLearnings(TrainingIntelligenceLearningsMixin):
+    """Stub class to test TrainingIntelligenceLearningsMixin."""
+
+    def __init__(self):
+        """Initialize stub with fresh TrainingIntelligence."""
+        self.intelligence = TrainingIntelligence()
+
+
+def _make_metrics(adherence=0.95, coupling=0.06, tss=0.92, days=30, workouts=25):
+    return {
+        "adherence_rate": adherence,
+        "avg_cardiovascular_coupling": coupling,
+        "tss_completion_rate": tss,
+        "days_with_data": days,
+        "total_workouts": workouts,
+    }
+
+
+class TestCreateIntelligenceLearnings:
+    """Tests for create_intelligence_learnings."""
+
+    def test_creates_three_learnings(self):
+        """Three learnings created (adherence, cardiovascular, tss)."""
+        stub = StubLearnings()
+        stub.create_intelligence_learnings(_make_metrics(), date(2026, 1, 1), date(2026, 1, 31))
+        assert len(stub.intelligence.learnings) == 3
+
+    def test_excellent_adherence_low_impact(self):
+        """Adherence >= 90% produces LOW impact."""
+        stub = StubLearnings()
+        stub.create_intelligence_learnings(
+            _make_metrics(adherence=0.95), date(2026, 1, 1), date(2026, 1, 31)
+        )
+        learnings = list(stub.intelligence.learnings.values())
+        adh = [lr for lr in learnings if lr.category == "adherence"][0]
+        assert adh.impact == "LOW"
+
+    def test_poor_adherence_high_impact(self):
+        """Adherence < 80% produces HIGH impact."""
+        stub = StubLearnings()
+        stub.create_intelligence_learnings(
+            _make_metrics(adherence=0.70), date(2026, 1, 1), date(2026, 1, 31)
+        )
+        learnings = list(stub.intelligence.learnings.values())
+        adh = [lr for lr in learnings if lr.category == "adherence"][0]
+        assert adh.impact == "HIGH"
+
+    def test_confidence_validated_for_35_plus_days(self):
+        """35+ days of data yields VALIDATED confidence."""
+        stub = StubLearnings()
+        stub.create_intelligence_learnings(
+            _make_metrics(days=40), date(2026, 1, 1), date(2026, 2, 10)
+        )
+        learnings = list(stub.intelligence.learnings.values())
+        assert all(lr.confidence == ConfidenceLevel.VALIDATED for lr in learnings)
+
+    def test_confidence_low_for_few_days(self):
+        """< 14 days yields LOW confidence."""
+        stub = StubLearnings()
+        stub.create_intelligence_learnings(
+            _make_metrics(days=10), date(2026, 1, 1), date(2026, 1, 10)
+        )
+        learnings = list(stub.intelligence.learnings.values())
+        assert all(lr.confidence == ConfidenceLevel.LOW for lr in learnings)
+
+    def test_high_coupling_high_impact(self):
+        """Coupling > 8.5% produces HIGH impact cardiovascular learning."""
+        stub = StubLearnings()
+        stub.create_intelligence_learnings(
+            _make_metrics(coupling=0.10), date(2026, 1, 1), date(2026, 1, 31)
+        )
+        learnings = list(stub.intelligence.learnings.values())
+        cv = [lr for lr in learnings if lr.category == "cardiovascular_quality"][0]
+        assert cv.impact == "HIGH"

--- a/tests/workflows/pid_eval/test_pid_correction.py
+++ b/tests/workflows/pid_eval/test_pid_correction.py
@@ -1,0 +1,159 @@
+"""Tests for PIDCorrectionMixin."""
+
+from unittest.mock import MagicMock, patch
+
+from magma_cycling.intelligence.training_intelligence import TrainingIntelligence
+from magma_cycling.workflows.pid_eval.pid_correction import PIDCorrectionMixin
+
+
+class StubPID(PIDCorrectionMixin):
+    """Stub class to test PIDCorrectionMixin."""
+
+    def __init__(self):
+        """Initialize stub with fresh TrainingIntelligence."""
+        self.intelligence = TrainingIntelligence()
+
+
+def _make_metrics():
+    return {
+        "adherence_rate": 0.90,
+        "avg_cardiovascular_coupling": 0.06,
+        "tss_completion_rate": 0.92,
+    }
+
+
+class TestEvaluatePIDCorrection:
+    """Tests for evaluate_pid_correction."""
+
+    @patch("magma_cycling.workflows.pid_eval.pid_correction.DiscretePIDController")
+    @patch(
+        "magma_cycling.workflows.pid_eval.pid_correction"
+        ".compute_discrete_pid_gains_from_intelligence"
+    )
+    def test_returns_expected_keys(self, mock_gains, mock_controller_class):
+        """Result dict contains expected keys."""
+        mock_gains.return_value = {"kp": 0.1, "ki": 0.01, "kd": 0.02}
+        mock_instance = MagicMock()
+        mock_instance.compute_cycle_correction_enhanced.return_value = {
+            "error": -10.0,
+            "tss_per_week_adjusted": 320,
+            "validation": {"validated": True, "confidence": "HIGH", "red_flags": []},
+            "recommendation": "Increase TSS slightly",
+        }
+        mock_controller_class.return_value = mock_instance
+
+        stub = StubPID()
+        result = stub.evaluate_pid_correction(210.0, 6, _make_metrics())
+
+        assert "error" in result
+        assert "tss_per_week_adjusted" in result
+        assert "validation" in result
+        assert "recommendation" in result
+
+    @patch("magma_cycling.workflows.pid_eval.pid_correction.DiscretePIDController")
+    @patch(
+        "magma_cycling.workflows.pid_eval.pid_correction"
+        ".compute_discrete_pid_gains_from_intelligence"
+    )
+    def test_uses_adaptive_gains(self, mock_gains, mock_controller_class):
+        """Controller created with adaptive gains from intelligence."""
+        mock_gains.return_value = {"kp": 0.15, "ki": 0.02, "kd": 0.03}
+        mock_instance = MagicMock()
+        mock_instance.compute_cycle_correction_enhanced.return_value = {
+            "error": 0,
+            "tss_per_week_adjusted": 300,
+            "validation": {"validated": True, "confidence": "HIGH", "red_flags": []},
+            "recommendation": "Maintain",
+        }
+        mock_controller_class.return_value = mock_instance
+
+        stub = StubPID()
+        stub.evaluate_pid_correction(220.0, 6, _make_metrics())
+
+        mock_controller_class.assert_called_once()
+        call_kwargs = mock_controller_class.call_args[1]
+        assert call_kwargs["kp"] == 0.15
+        assert call_kwargs["ki"] == 0.02
+
+    @patch("magma_cycling.workflows.pid_eval.pid_correction.DiscretePIDController")
+    @patch(
+        "magma_cycling.workflows.pid_eval.pid_correction"
+        ".compute_discrete_pid_gains_from_intelligence"
+    )
+    def test_passes_metrics_to_correction(self, mock_gains, mock_controller_class):
+        """Metrics forwarded to compute_cycle_correction_enhanced."""
+        mock_gains.return_value = {"kp": 0.1, "ki": 0.01, "kd": 0.02}
+        mock_instance = MagicMock()
+        mock_instance.compute_cycle_correction_enhanced.return_value = {
+            "error": 0,
+            "tss_per_week_adjusted": 300,
+            "validation": {"validated": True, "confidence": "HIGH", "red_flags": []},
+            "recommendation": "OK",
+        }
+        mock_controller_class.return_value = mock_instance
+
+        metrics = _make_metrics()
+        stub = StubPID()
+        stub.evaluate_pid_correction(220.0, 6, metrics)
+
+        call_kwargs = mock_instance.compute_cycle_correction_enhanced.call_args[1]
+        assert call_kwargs["adherence_rate"] == 0.90
+        assert call_kwargs["measured_ftp"] == 220.0
+
+    @patch("magma_cycling.workflows.pid_eval.pid_correction.DiscretePIDController")
+    @patch(
+        "magma_cycling.workflows.pid_eval.pid_correction"
+        ".compute_discrete_pid_gains_from_intelligence"
+    )
+    def test_fallback_setpoint_when_no_profile(self, mock_gains, mock_controller_class):
+        """When AthleteProfile fails, setpoint falls back to measured_ftp."""
+        mock_gains.return_value = {"kp": 0.1, "ki": 0.01, "kd": 0.02}
+        mock_instance = MagicMock()
+        mock_instance.compute_cycle_correction_enhanced.return_value = {
+            "error": 0,
+            "tss_per_week_adjusted": 300,
+            "validation": {"validated": True, "confidence": "HIGH", "red_flags": []},
+            "recommendation": "OK",
+        }
+        mock_controller_class.return_value = mock_instance
+
+        stub = StubPID()
+        # AthleteProfile is imported lazily inside the method via
+        # "from magma_cycling.config import AthleteProfile"
+        # so we patch at the source module
+        with patch(
+            "magma_cycling.config.AthleteProfile",
+        ) as mock_ap:
+            mock_ap.from_env.side_effect = Exception("no env")
+            stub.evaluate_pid_correction(215.0, 6, _make_metrics())
+
+        call_kwargs = mock_controller_class.call_args[1]
+        assert call_kwargs["setpoint"] == 215.0
+
+    @patch("magma_cycling.workflows.pid_eval.pid_correction.DiscretePIDController")
+    @patch(
+        "magma_cycling.workflows.pid_eval.pid_correction"
+        ".compute_discrete_pid_gains_from_intelligence"
+    )
+    def test_red_flags_printed(self, mock_gains, mock_controller_class, capsys):
+        """Red flags from validation are printed."""
+        mock_gains.return_value = {"kp": 0.1, "ki": 0.01, "kd": 0.02}
+        mock_instance = MagicMock()
+        mock_instance.compute_cycle_correction_enhanced.return_value = {
+            "error": -50.0,
+            "tss_per_week_adjusted": 400,
+            "validation": {
+                "validated": False,
+                "confidence": "LOW",
+                "red_flags": ["FTP drop too large"],
+            },
+            "recommendation": "Investigate",
+        }
+        mock_controller_class.return_value = mock_instance
+
+        stub = StubPID()
+        stub.evaluate_pid_correction(180.0, 6, _make_metrics())
+
+        captured = capsys.readouterr()
+        assert "Red Flags" in captured.out
+        assert "FTP drop too large" in captured.out

--- a/tests/workflows/pid_eval/test_test_opportunity.py
+++ b/tests/workflows/pid_eval/test_test_opportunity.py
@@ -1,0 +1,137 @@
+"""Tests for TestOpportunityMixin."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from magma_cycling.workflows.pid_eval.test_opportunity import TestOpportunityMixin
+
+
+class StubTestOpp(TestOpportunityMixin):
+    """Stub class to test TestOpportunityMixin."""
+
+    def __init__(self, client):
+        """Initialize stub with mock client."""
+        self.client = client
+
+
+class TestCheckTestOpportunity:
+    """Tests for check_test_opportunity."""
+
+    def test_ready_when_overdue_and_form_ready(self):
+        """READY status when test overdue + TSB >= 5 + CTL >= 40."""
+        client = MagicMock()
+        client.get_wellness.return_value = [{"tsb": 10, "ctl": 55}]
+        client.get_activities.return_value = []  # no recent tests → 16 weeks
+        stub = StubTestOpp(client)
+        result = stub.check_test_opportunity()
+        assert result is not None
+        assert result["status"] == "READY"
+
+    def test_needs_taper_when_form_neutral(self):
+        """NEEDS_TAPER when test overdue + form neutral (-5 to 5)."""
+        client = MagicMock()
+        client.get_wellness.return_value = [{"tsb": 2, "ctl": 55}]
+        client.get_activities.return_value = []
+        stub = StubTestOpp(client)
+        result = stub.check_test_opportunity()
+        assert result is not None
+        assert result["status"] == "NEEDS_TAPER"
+
+    def test_overdue_low_fitness(self):
+        """OVERDUE_LOW_FITNESS when test overdue but low CTL."""
+        client = MagicMock()
+        client.get_wellness.return_value = [{"tsb": -10, "ctl": 30}]
+        client.get_activities.return_value = []
+        stub = StubTestOpp(client)
+        result = stub.check_test_opportunity()
+        assert result is not None
+        assert result["status"] == "OVERDUE_LOW_FITNESS"
+
+    def test_none_when_not_overdue(self):
+        """None when last test was recent (< 6 weeks)."""
+        client = MagicMock()
+        client.get_wellness.return_value = [{"tsb": 10, "ctl": 55}]
+        # Recent test-like activity (high IF, 45min)
+        client.get_activities.return_value = [
+            {
+                "icu_intensity": 0.95,
+                "moving_time": 2700,  # 45 min
+                "start_date_local": date.today().isoformat(),
+            }
+        ]
+        stub = StubTestOpp(client)
+        result = stub.check_test_opportunity()
+        assert result is None
+
+    def test_none_when_no_wellness(self):
+        """None when wellness data unavailable."""
+        client = MagicMock()
+        client.get_wellness.return_value = []
+        stub = StubTestOpp(client)
+        result = stub.check_test_opportunity()
+        assert result is None
+
+    def test_none_when_wellness_api_fails(self):
+        """None when wellness API raises exception."""
+        client = MagicMock()
+        client.get_wellness.side_effect = Exception("API error")
+        stub = StubTestOpp(client)
+        result = stub.check_test_opportunity()
+        assert result is None
+
+
+class TestMonitorCTLProgressionVsPeaks:
+    """Tests for monitor_ctl_progression_vs_peaks (basic cases)."""
+
+    def _run_monitor(self, ctl):
+        """Helper to run monitor with given CTL."""
+        client = MagicMock()
+        client.get_wellness.return_value = [{"ctl": ctl, "atl": 50, "tsb": 5}]
+
+        mock_profile = MagicMock()
+        mock_profile.ftp = 220
+        mock_profile.ftp_target = 260
+        mock_profile.age = 54
+
+        mock_phase_rec = MagicMock()
+        mock_phase_rec.phase.value = "base"
+        mock_phase_rec.weekly_tss_load = 300
+        mock_phase_rec.weekly_tss_recovery = 200
+
+        stub = StubTestOpp(client)
+        # Patch lazy imports at their source modules
+        with (
+            patch("magma_cycling.config.athlete_profile.AthleteProfile") as mock_profile_class,
+            patch("magma_cycling.planning.peaks_phases.determine_training_phase") as mock_phase,
+        ):
+            mock_profile_class.from_env.return_value = mock_profile
+            mock_phase.return_value = mock_phase_rec
+            return stub.monitor_ctl_progression_vs_peaks()
+
+    def test_critical_status_low_ctl(self):
+        """CTL < 50 returns CRITICAL status."""
+        result = self._run_monitor(40)
+        assert result is not None
+        assert result["status"] == "CRITICAL"
+
+    def test_optimal_status_high_ctl(self):
+        """High CTL returns OPTIMAL status."""
+        result = self._run_monitor(75)
+        assert result is not None
+        assert result["status"] == "OPTIMAL"
+
+    def test_returns_none_on_error(self):
+        """Returns None when API fails."""
+        client = MagicMock()
+        client.get_wellness.side_effect = Exception("fail")
+        stub = StubTestOpp(client)
+        result = stub.monitor_ctl_progression_vs_peaks()
+        assert result is None
+
+    def test_returns_none_no_wellness(self):
+        """Returns None when no wellness data."""
+        client = MagicMock()
+        client.get_wellness.return_value = []
+        stub = StubTestOpp(client)
+        result = stub.monitor_ctl_progression_vs_peaks()
+        assert result is None

--- a/tests/workflows/pid_eval/test_tss_capacity.py
+++ b/tests/workflows/pid_eval/test_tss_capacity.py
@@ -1,0 +1,73 @@
+"""Tests for TSSCapacityMixin."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from magma_cycling.workflows.pid_eval.tss_capacity import TSSCapacityMixin
+
+
+class StubTSS(TSSCapacityMixin):
+    """Stub class to test TSSCapacityMixin in isolation."""
+
+    def __init__(self, client):
+        """Initialize stub with mock client."""
+        self.client = client
+
+
+class TestCalculateTSSCompletion:
+    """Tests for calculate_tss_completion."""
+
+    def test_full_completion(self):
+        """100% TSS completion rate."""
+        client = MagicMock()
+        client.get_events.return_value = [
+            {"category": "WORKOUT", "name": "Endurance", "icu_training_load": 100},
+        ]
+        client.get_activities.return_value = [
+            {"icu_training_load": 100},
+        ]
+        stub = StubTSS(client)
+        rate = stub.calculate_tss_completion(date(2026, 1, 1), date(2026, 1, 7))
+        assert abs(rate - 1.0) < 0.01
+
+    def test_partial_completion(self):
+        """50% TSS completion rate."""
+        client = MagicMock()
+        client.get_events.return_value = [
+            {"category": "WORKOUT", "name": "Intervals", "icu_training_load": 100},
+        ]
+        client.get_activities.return_value = [
+            {"icu_training_load": 50},
+        ]
+        stub = StubTSS(client)
+        rate = stub.calculate_tss_completion(date(2026, 1, 1), date(2026, 1, 7))
+        assert abs(rate - 0.5) < 0.01
+
+    def test_no_planned_returns_one(self):
+        """No planned workouts returns 1.0."""
+        client = MagicMock()
+        client.get_events.return_value = []
+        client.get_activities.return_value = [{"icu_training_load": 50}]
+        stub = StubTSS(client)
+        rate = stub.calculate_tss_completion(date(2026, 1, 1), date(2026, 1, 7))
+        assert rate == 1.0
+
+    def test_skipped_events_excluded(self):
+        """Events with name starting with '[' are excluded from planned."""
+        client = MagicMock()
+        client.get_events.return_value = [
+            {"category": "WORKOUT", "name": "[SAUTÉE] Rest", "icu_training_load": 80},
+            {"category": "WORKOUT", "name": "Endurance", "icu_training_load": 100},
+        ]
+        client.get_activities.return_value = [{"icu_training_load": 100}]
+        stub = StubTSS(client)
+        rate = stub.calculate_tss_completion(date(2026, 1, 1), date(2026, 1, 7))
+        assert abs(rate - 1.0) < 0.01
+
+    def test_api_error_returns_one(self):
+        """API error returns 1.0 fallback."""
+        client = MagicMock()
+        client.get_events.side_effect = Exception("API down")
+        stub = StubTSS(client)
+        rate = stub.calculate_tss_completion(date(2026, 1, 1), date(2026, 1, 7))
+        assert rate == 1.0


### PR DESCRIPTION
## Summary
- Extract `PIDDailyEvaluator` (1029 LOC god class) into 8 focused mixins in `workflows/pid_eval/`
- **Mixins 1-4 (data collection)**: `AdherenceMixin`, `CardiovascularQualityMixin`, `TSSCapacityMixin`, `CycleMetricsAggregationMixin`
- **Mixins 5-8 (intelligence + PID)**: `TrainingIntelligenceLearningsMixin`, `PIDCorrectionMixin`, `TestOpportunityMixin`, `LoggingMixin`
- Source file `pid_daily_evaluation.py` unchanged — facade rewire deferred to Sprint 3

## Test plan
- [x] 46 new tests across 8 test files
- [x] Full suite: 2262 passed, 0 failed
- [x] pre-commit: all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)