### PR TITLE
refactor(sprint3): migrate 20 CLI scripts to @cli_main

### DIFF
--- a/magma_cycling/check_activity_sources.py
+++ b/magma_cycling/check_activity_sources.py
@@ -17,6 +17,7 @@ import requests
 
 from magma_cycling.api.intervals_client import IntervalsClient
 from magma_cycling.config import create_intervals_client
+from magma_cycling.utils.cli import cli_main
 
 
 def format_source_icon(source):
@@ -30,6 +31,7 @@ def format_source_icon(source):
     return icons.get(source, "❓ ")
 
 
+@cli_main
 def main():
     """Command-line entry point for checking activity sources."""
     parser = argparse.ArgumentParser(description="Vérifier les sources des activités récentes")
@@ -140,12 +142,6 @@ def main():
         print(f"❌ Erreur API: {e}")
         if e.response.status_code == 401:
             print("   → Vérifier l'API key et l'athlete_id")
-        sys.exit(1)
-    except Exception as e:
-        print(f"❌ Erreur: {e}")
-        import traceback
-
-        traceback.print_exc()
         sys.exit(1)
 
 

--- a/magma_cycling/collect_athlete_feedback.py
+++ b/magma_cycling/collect_athlete_feedback.py
@@ -19,6 +19,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from magma_cycling.utils.cli import cli_main
+
 
 class AthleteFeedbackCollector:
     """Collecteur de feedback athlète."""
@@ -296,6 +298,7 @@ class AthleteFeedbackCollector:
         print("\n" + "=" * 60)
 
 
+@cli_main
 def main():
     """Command-line entry point for collecting athlete feedback."""
     parser = argparse.ArgumentParser(description="Collecter le retour athlète après séance")

--- a/magma_cycling/daily_sync.py
+++ b/magma_cycling/daily_sync.py
@@ -47,6 +47,7 @@ from magma_cycling.config import (
 )
 from magma_cycling.insert_analysis import WorkoutHistoryManager
 from magma_cycling.prepare_analysis import PromptGenerator
+from magma_cycling.utils.cli import cli_main
 from magma_cycling.utils.hot_reload import (
     hot_reload_if_needed,
     mark_modules_loaded,
@@ -345,6 +346,7 @@ class DailySync(
         print("=" * 80)
 
 
+@cli_main
 def main():
     """CLI entry point."""
     # Establish baseline for hot-reload detection (first run only)

--- a/magma_cycling/insert_analysis.py
+++ b/magma_cycling/insert_analysis.py
@@ -69,6 +69,7 @@ from magma_cycling.core.duplicate_detector import (
     check_and_handle_duplicates,
 )
 from magma_cycling.core.timeline_injector import TimelineInjector
+from magma_cycling.utils.cli import cli_main
 
 logger = logging.getLogger(__name__)
 
@@ -424,6 +425,7 @@ class WorkoutHistoryManager:
             return False
 
 
+@cli_main
 def main():
     """Command-line entry point for inserting analysis into weekly reports."""
     parser = argparse.ArgumentParser(

--- a/magma_cycling/manage_workflow_state.py
+++ b/magma_cycling/manage_workflow_state.py
@@ -59,6 +59,7 @@ import argparse
 import sys
 from datetime import datetime
 
+from magma_cycling.utils.cli import cli_main
 from magma_cycling.workflow_state import WorkflowState
 
 
@@ -199,6 +200,7 @@ def reset_state(state: WorkflowState):
     return True
 
 
+@cli_main
 def main():
     """Command-line entry point for managing workflow state."""
     parser = argparse.ArgumentParser(

--- a/magma_cycling/organize_weekly_report.py
+++ b/magma_cycling/organize_weekly_report.py
@@ -25,6 +25,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from magma_cycling.utils.cli import cli_main
+
 
 class WeeklyReportOrganizer:
     """Organisateur des fichiers de bilan hebdomadaire."""
@@ -205,6 +207,7 @@ class WeeklyReportOrganizer:
             return False
 
 
+@cli_main
 def main():
     """Command-line entry point for organizing weekly report files."""
     parser = argparse.ArgumentParser(description="Organiser les fichiers du bilan hebdomadaire")

--- a/magma_cycling/planned_sessions_checker.py
+++ b/magma_cycling/planned_sessions_checker.py
@@ -58,6 +58,7 @@ from datetime import datetime, timedelta
 
 from magma_cycling.api.intervals_client import IntervalsClient
 from magma_cycling.config import get_data_config, get_logger
+from magma_cycling.utils.cli import cli_main
 
 logger = get_logger(__name__)
 
@@ -332,6 +333,7 @@ Séance planifiée non exécutée. Raison à documenter.
         return markdown
 
 
+@cli_main
 def main():
     """Mode interactif : détection des séances sautées + réconciliation avec planning JSON local."""
     from magma_cycling.config import create_intervals_client

--- a/magma_cycling/scripts/backfill_history.py
+++ b/magma_cycling/scripts/backfill_history.py
@@ -62,6 +62,7 @@ from datetime import datetime
 from requests.exceptions import HTTPError
 
 from magma_cycling.config import create_intervals_client, get_data_config
+from magma_cycling.utils.cli import cli_main
 from magma_cycling.workflow_state import WorkflowState
 
 
@@ -561,6 +562,7 @@ class HistoryBackfiller:
         print("\n" + "=" * 70)
 
 
+@cli_main
 def main():
     """Run entry point."""
     parser = argparse.ArgumentParser(
@@ -669,12 +671,6 @@ Examples:
         print(f"   Analysées: {backfiller.analyzed_success}")
         print(f"   Échecs: {backfiller.analyzed_failed}")
         sys.exit(130)
-    except Exception as e:
-        print(f"\n❌ ERREUR FATALE: {e}")
-        import traceback
-
-        traceback.print_exc()
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/magma_cycling/scripts/backfill_intelligence.py
+++ b/magma_cycling/scripts/backfill_intelligence.py
@@ -38,6 +38,7 @@ from magma_cycling.intelligence.training_intelligence import (
     ConfidenceLevel,
     TrainingIntelligence,
 )
+from magma_cycling.utils.cli import cli_main
 
 # Load environment
 env_file = Path(__file__).parent.parent.parent / ".env"
@@ -605,6 +606,7 @@ class IntervalsICUBackfiller:
         print(f"   Saved to: {output_path}")
 
 
+@cli_main
 def main():
     """Run entry point."""
     parser = argparse.ArgumentParser(
@@ -648,16 +650,8 @@ def main():
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Run backfill
-    try:
-        backfiller = IntervalsICUBackfiller(athlete_id=athlete_id, api_key=api_key)
-        backfiller.run(args.start_date, args.end_date, output_path)
-        sys.exit(0)
-    except Exception as e:
-        print(f"\n❌ Error: {e}")
-        import traceback
-
-        traceback.print_exc()
-        sys.exit(1)
+    backfiller = IntervalsICUBackfiller(athlete_id=athlete_id, api_key=api_key)
+    backfiller.run(args.start_date, args.end_date, output_path)
 
 
 if __name__ == "__main__":

--- a/magma_cycling/scripts/initialize_pid_controller.py
+++ b/magma_cycling/scripts/initialize_pid_controller.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from pathlib import Path
 
 from magma_cycling.intelligence.discrete_pid_controller import DiscretePIDController
+from magma_cycling.utils.cli import cli_main
 
 
 def load_historical_data():
@@ -265,6 +266,7 @@ def compute_s081_s086_correction(controller: DiscretePIDController):
     }
 
 
+@cli_main
 def main():
     """Main execution."""
     print()

--- a/magma_cycling/scripts/populate_zwift_cache.py
+++ b/magma_cycling/scripts/populate_zwift_cache.py
@@ -13,8 +13,10 @@ from pathlib import Path
 
 from magma_cycling.external.zwift_collections import KNOWN_COLLECTIONS
 from magma_cycling.external.zwift_service import ZwiftService
+from magma_cycling.utils.cli import cli_main
 
 
+@cli_main
 def main():
     """Main CLI entrypoint."""
     parser = argparse.ArgumentParser(

--- a/magma_cycling/scripts/search_zwift_workouts.py
+++ b/magma_cycling/scripts/search_zwift_workouts.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from magma_cycling.external.zwift_models import WorkoutSearchCriteria
 from magma_cycling.external.zwift_service import ZwiftService
+from magma_cycling.utils.cli import cli_main
 
 # ---------------------------------------------------------------------------
 # Display helpers (pure formatting, no business logic)
@@ -119,6 +120,7 @@ def _print_sample_workout(service):
 # ---------------------------------------------------------------------------
 
 
+@cli_main
 def main():
     """Main CLI entrypoint."""
     parser = argparse.ArgumentParser(

--- a/magma_cycling/scripts/seed_zwift_workouts.py
+++ b/magma_cycling/scripts/seed_zwift_workouts.py
@@ -12,8 +12,10 @@ import sys
 from pathlib import Path
 
 from magma_cycling.external.zwift_service import ZwiftService
+from magma_cycling.utils.cli import cli_main
 
 
+@cli_main
 def main():
     """Main CLI entrypoint."""
     parser = argparse.ArgumentParser(

--- a/magma_cycling/scripts/setup_withings.py
+++ b/magma_cycling/scripts/setup_withings.py
@@ -40,6 +40,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlparse
 
 from magma_cycling.config import create_withings_client, get_withings_config
+from magma_cycling.utils.cli import cli_main
 
 # Global variable to store authorization code
 authorization_code = None
@@ -232,6 +233,7 @@ def start_callback_server(port: int = 8080) -> str | None:
     return authorization_code
 
 
+@cli_main
 def main():
     """Main setup flow for Withings OAuth authentication."""
     print("\n" + "=" * 50)
@@ -371,14 +373,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        print("\n\nSetup cancelled by user.")
-        sys.exit(1)
-    except Exception as e:
-        print(f"\n❌ Unexpected error: {e}")
-        import traceback
-
-        traceback.print_exc()
-        sys.exit(1)
+    main()

--- a/magma_cycling/scripts/validate_templates.py
+++ b/magma_cycling/scripts/validate_templates.py
@@ -8,8 +8,10 @@ import json
 from pathlib import Path
 
 from magma_cycling.intervals_format_validator import IntervalsFormatValidator
+from magma_cycling.utils.cli import cli_main
 
 
+@cli_main
 def main():
     """Command-line entry point for validating workout templates."""
     templates_dir = Path("data/workout_templates")

--- a/magma_cycling/scripts/withings_presync.py
+++ b/magma_cycling/scripts/withings_presync.py
@@ -6,8 +6,9 @@ Also called by session_monitor before triggering daily-sync.
 Exit 0 in all cases — LaunchAgent should not retry on its own.
 """
 
-import sys
 from datetime import date, datetime, timedelta
+
+from magma_cycling.utils.cli import cli_main
 
 PREFIX = "[withings-presync]"
 
@@ -18,6 +19,7 @@ def log(msg: str) -> None:
     print(f"{PREFIX} {ts} - {msg}")
 
 
+@cli_main
 def main() -> int:
     """Entry point."""
     try:
@@ -60,4 +62,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/magma_cycling/shift_sessions.py
+++ b/magma_cycling/shift_sessions.py
@@ -23,7 +23,6 @@ Created: 2026-02-19
 """
 
 import argparse
-import sys
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
@@ -31,6 +30,7 @@ from magma_cycling.api.intervals_client import IntervalsClient
 from magma_cycling.config import create_intervals_client, get_data_config
 from magma_cycling.planning.control_tower import planning_tower
 from magma_cycling.planning.models import Session, WeeklyPlan
+from magma_cycling.utils.cli import cli_main
 
 
 class SessionShifter:
@@ -493,6 +493,7 @@ class SessionShifter:
                 print(f"   S{self.week_id[1:]}-{i:02d}: {day_name:10} ({day_date}) - VIDE")
 
 
+@cli_main
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -574,97 +575,89 @@ Examples:
 
     args = parser.parse_args()
 
-    try:
-        # Build operation description for audit log
-        operation_parts = []
-        if args.insert_rest_day:
-            operation_parts.append(f"insert rest day {args.insert_rest_day}")
-        elif args.swap:
-            operation_parts.append(f"swap {args.swap[0]} ↔ {args.swap[1]}")
-        elif args.swap_days:
-            operation_parts.append(f"swap days {args.swap_days[0]} ↔ {args.swap_days[1]}")
-        elif args.remove_session:
-            operation_parts.append(f"remove {args.remove_session}")
-        elif args.from_session:
-            operation_parts.append(
-                f"shift from {args.from_session} by {args.shift_days} days"
-                + (" (renumber)" if args.renumber else "")
-            )
-        elif args.from_day:
-            operation_parts.append(
-                f"shift from day {args.from_day} by {args.shift_days} days"
-                + (" (renumber)" if args.renumber else "")
-            )
-        else:
-            print(
-                "\n❌ Must specify --insert-rest-day, --swap, --swap-days, "
-                "--remove-session, or shift options"
-            )
-            return 1
-
-        operation_description = ", ".join(operation_parts)
-
-        print(f"\n{'🔍 DRY RUN MODE' if args.dry_run else '🔧 SHIFT SESSIONS'}")
-        print("=" * 70)
-
-        # 🚦 USE CONTROL TOWER for permission + backup + audit
-        with planning_tower.modify_week(
-            args.week_id,
-            requesting_script="shift-sessions",
-            reason=operation_description,
-            auto_save=not args.dry_run,  # Only save if not dry-run
-        ) as plan:
-            # Create shifter in Control Tower mode
-            shifter = SessionShifter(week_id=args.week_id, plan=plan)
-
-            # Display current state
-            shifter.display_summary()
-
-            # Perform operation
-            if args.insert_rest_day:
-                shifter.insert_rest_day(args.insert_rest_day)
-
-            elif args.swap:
-                shifter.swap_sessions(session1_id=args.swap[0], session2_id=args.swap[1])
-
-            elif args.swap_days:
-                shifter.swap_sessions(day1=args.swap_days[0], day2=args.swap_days[1])
-
-            elif args.remove_session:
-                shifter.remove_session(args.remove_session)
-
-            elif args.from_session or args.from_day:
-                shifter.shift_sessions(
-                    from_session_id=args.from_session,
-                    from_day=args.from_day,
-                    shift_days=args.shift_days,
-                    renumber=args.renumber,
-                )
-
-            # Display final state
-            shifter.display_summary()
-
-            # Handle sync (save will be automatic via Control Tower)
-            if not args.dry_run and args.sync:
-                shifter.save(dry_run=False, sync=True)
-
-        # Success messages
-        if args.dry_run:
-            print("\n💡 Run without --dry-run to apply changes")
-        elif args.sync:
-            print("\n✅ Changes saved and synced with Intervals.icu")
-        else:
-            print("\n✅ Changes saved")
-
-        return 0
-
-    except Exception as e:
-        print(f"\n❌ Error: {e}")
-        import traceback
-
-        traceback.print_exc()
+    # Build operation description for audit log
+    operation_parts = []
+    if args.insert_rest_day:
+        operation_parts.append(f"insert rest day {args.insert_rest_day}")
+    elif args.swap:
+        operation_parts.append(f"swap {args.swap[0]} ↔ {args.swap[1]}")
+    elif args.swap_days:
+        operation_parts.append(f"swap days {args.swap_days[0]} ↔ {args.swap_days[1]}")
+    elif args.remove_session:
+        operation_parts.append(f"remove {args.remove_session}")
+    elif args.from_session:
+        operation_parts.append(
+            f"shift from {args.from_session} by {args.shift_days} days"
+            + (" (renumber)" if args.renumber else "")
+        )
+    elif args.from_day:
+        operation_parts.append(
+            f"shift from day {args.from_day} by {args.shift_days} days"
+            + (" (renumber)" if args.renumber else "")
+        )
+    else:
+        print(
+            "\n❌ Must specify --insert-rest-day, --swap, --swap-days, "
+            "--remove-session, or shift options"
+        )
         return 1
+
+    operation_description = ", ".join(operation_parts)
+
+    print(f"\n{'🔍 DRY RUN MODE' if args.dry_run else '🔧 SHIFT SESSIONS'}")
+    print("=" * 70)
+
+    # 🚦 USE CONTROL TOWER for permission + backup + audit
+    with planning_tower.modify_week(
+        args.week_id,
+        requesting_script="shift-sessions",
+        reason=operation_description,
+        auto_save=not args.dry_run,  # Only save if not dry-run
+    ) as plan:
+        # Create shifter in Control Tower mode
+        shifter = SessionShifter(week_id=args.week_id, plan=plan)
+
+        # Display current state
+        shifter.display_summary()
+
+        # Perform operation
+        if args.insert_rest_day:
+            shifter.insert_rest_day(args.insert_rest_day)
+
+        elif args.swap:
+            shifter.swap_sessions(session1_id=args.swap[0], session2_id=args.swap[1])
+
+        elif args.swap_days:
+            shifter.swap_sessions(day1=args.swap_days[0], day2=args.swap_days[1])
+
+        elif args.remove_session:
+            shifter.remove_session(args.remove_session)
+
+        elif args.from_session or args.from_day:
+            shifter.shift_sessions(
+                from_session_id=args.from_session,
+                from_day=args.from_day,
+                shift_days=args.shift_days,
+                renumber=args.renumber,
+            )
+
+        # Display final state
+        shifter.display_summary()
+
+        # Handle sync (save will be automatic via Control Tower)
+        if not args.dry_run and args.sync:
+            shifter.save(dry_run=False, sync=True)
+
+    # Success messages
+    if args.dry_run:
+        print("\n💡 Run without --dry-run to apply changes")
+    elif args.sync:
+        print("\n✅ Changes saved and synced with Intervals.icu")
+    else:
+        print("\n✅ Changes saved")
+
+    return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/magma_cycling/sync_intervals.py
+++ b/magma_cycling/sync_intervals.py
@@ -59,6 +59,7 @@ import requests
 
 from magma_cycling.api.intervals_client import IntervalsClient
 from magma_cycling.config import create_intervals_client
+from magma_cycling.utils.cli import cli_main
 
 # Alias for backwards compatibility
 IntervalsAPI = IntervalsClient
@@ -273,6 +274,7 @@ _Pour une mise à jour complète des tableaux, voir le fichier original._.
         print(f"   CTL/ATL/TSB: {ctl:.0f}/{atl:.0f}/{tsb:+.0f}")
 
 
+@cli_main
 def main():
     """Command-line entry point for syncing with Intervals.icu."""
     parser = argparse.ArgumentParser(

--- a/magma_cycling/update_session_status.py
+++ b/magma_cycling/update_session_status.py
@@ -41,6 +41,7 @@ import sys
 from magma_cycling.api.intervals_client import IntervalsClient
 from magma_cycling.config import create_intervals_client
 from magma_cycling.planning.control_tower import planning_tower
+from magma_cycling.utils.cli import cli_main
 
 # Statuses that should remove the event from Intervals.icu
 STATUSES_TO_DELETE = ["cancelled", "skipped", "replaced", "rest_day"]
@@ -252,6 +253,7 @@ def sync_with_intervals(
         return True
 
 
+@cli_main
 def main():
     """Run entry point."""
     parser = argparse.ArgumentParser(
@@ -316,112 +318,103 @@ Valid statuses:
     if args.status in ["cancelled", "skipped", "replaced"] and not args.reason:
         parser.error(f"Status '{args.status}' requires --reason")
 
+    print(f"\n📝 Updating session {args.session}")
+    print(f"   Week: {args.week_id}")
+    print(f"   Status: {args.status}")
+    if args.reason:
+        print(f"   Reason: {args.reason}")
+
+    # 🚦 UPDATE VIA CONTROL TOWER (automatic backup + audit)
     try:
-        print(f"\n📝 Updating session {args.session}")
-        print(f"   Week: {args.week_id}")
-        print(f"   Status: {args.status}")
-        if args.reason:
-            print(f"   Reason: {args.reason}")
-
-        # 🚦 UPDATE VIA CONTROL TOWER (automatic backup + audit)
-        try:
-            with planning_tower.modify_week(
-                args.week_id,
-                requesting_script="update-session-status",
-                reason=f"Update {args.session} to {args.status}: {args.reason or 'N/A'}",
-            ) as plan:
-                # Find and update session
-                session_found = False
-                for session in plan.planned_sessions:
-                    if session.session_id == args.session:
-                        # Set skip_reason BEFORE status (Pydantic validator requirement)
-                        if args.reason and args.status in ("skipped", "cancelled", "replaced"):
-                            session.skip_reason = args.reason
-
-                        session.status = args.status
-                        session_found = True
-                        break
-
-                if not session_found:
-                    print(f"\n❌ Session {args.session} not found in planning")
-                    sys.exit(1)
-
-                print(f"\n✅ Session {args.session} updated to: {args.status}")
-                if args.reason:
-                    print(f"   Reason: {args.reason}")
-                # Auto-saved by Control Tower with backup + audit log
-
-        except Exception as e:
-            print(f"\n❌ Failed to update via Control Tower: {e}")
-            sys.exit(1)
-
-        # Sync with Intervals.icu if requested (Sprint R9.B Phase 2 - centralized)
-        if args.sync:
-            # Create Intervals.icu client
-            try:
-                client = create_intervals_client()
-            except ValueError:
-                print("\n⚠️  Warning: Intervals.icu credentials not configured")
-                print(
-                    "   Set VITE_INTERVALS_ATHLETE_ID and VITE_INTERVALS_API_KEY environment variables"
-                )
-                print("   Skipping sync with Intervals.icu")
-                sys.exit(0)
-
-            # Get session date from planning (read-only via Control Tower)
-            try:
-                plan = planning_tower.read_week(args.week_id)
-            except FileNotFoundError:
-                print("\n⚠️  Warning: Could not find planning file to get session date")
-                print(f"   Week: {args.week_id}")
-                print("   Skipping sync with Intervals.icu")
-                sys.exit(0)
-
-            session_date = None
-            session_info = None
+        with planning_tower.modify_week(
+            args.week_id,
+            requesting_script="update-session-status",
+            reason=f"Update {args.session} to {args.status}: {args.reason or 'N/A'}",
+        ) as plan:
+            # Find and update session
+            session_found = False
             for session in plan.planned_sessions:
                 if session.session_id == args.session:
-                    session_date = str(session.session_date)
-                    # Convert Session model to dict for compatibility with sync function
-                    session_info = {
-                        "name": session.name,
-                        "type": session.session_type,
-                        "version": session.version,
-                        "description": session.description,
-                        "tss_planned": session.tss_planned,
-                        "duration_min": session.duration_min,
-                    }
+                    # Set skip_reason BEFORE status (Pydantic validator requirement)
+                    if args.reason and args.status in ("skipped", "cancelled", "replaced"):
+                        session.skip_reason = args.reason
+
+                    session.status = args.status
+                    session_found = True
                     break
 
-            if not session_date:
-                print("\n⚠️  Warning: Could not find session date in planning")
-                print("   Skipping sync with Intervals.icu")
-                sys.exit(0)
+            if not session_found:
+                print(f"\n❌ Session {args.session} not found in planning")
+                sys.exit(1)
 
-            # Sync
-            sync_success = sync_with_intervals(
-                client=client,
-                session_id=args.session,
-                session_date=session_date,
-                new_status=args.status,
-                reason=args.reason,
-                session_info=session_info,
-            )
-
-            if sync_success:
-                print("\n✅ Successfully synchronized with Intervals.icu")
-            else:
-                print("\n⚠️  Warning: Sync with Intervals.icu failed (local changes preserved)")
-
-        print("\n✨ Done!")
-        sys.exit(0)
+            print(f"\n✅ Session {args.session} updated to: {args.status}")
+            if args.reason:
+                print(f"   Reason: {args.reason}")
+            # Auto-saved by Control Tower with backup + audit log
 
     except Exception as e:
-        print(f"\n❌ Error: {e}", file=sys.stderr)
-        import traceback
-
-        traceback.print_exc()
+        print(f"\n❌ Failed to update via Control Tower: {e}")
         sys.exit(1)
+
+    # Sync with Intervals.icu if requested (Sprint R9.B Phase 2 - centralized)
+    if args.sync:
+        # Create Intervals.icu client
+        try:
+            client = create_intervals_client()
+        except ValueError:
+            print("\n⚠️  Warning: Intervals.icu credentials not configured")
+            print(
+                "   Set VITE_INTERVALS_ATHLETE_ID and VITE_INTERVALS_API_KEY environment variables"
+            )
+            print("   Skipping sync with Intervals.icu")
+            sys.exit(0)
+
+        # Get session date from planning (read-only via Control Tower)
+        try:
+            plan = planning_tower.read_week(args.week_id)
+        except FileNotFoundError:
+            print("\n⚠️  Warning: Could not find planning file to get session date")
+            print(f"   Week: {args.week_id}")
+            print("   Skipping sync with Intervals.icu")
+            sys.exit(0)
+
+        session_date = None
+        session_info = None
+        for session in plan.planned_sessions:
+            if session.session_id == args.session:
+                session_date = str(session.session_date)
+                # Convert Session model to dict for compatibility with sync function
+                session_info = {
+                    "name": session.name,
+                    "type": session.session_type,
+                    "version": session.version,
+                    "description": session.description,
+                    "tss_planned": session.tss_planned,
+                    "duration_min": session.duration_min,
+                }
+                break
+
+        if not session_date:
+            print("\n⚠️  Warning: Could not find session date in planning")
+            print("   Skipping sync with Intervals.icu")
+            sys.exit(0)
+
+        # Sync
+        sync_success = sync_with_intervals(
+            client=client,
+            session_id=args.session,
+            session_date=session_date,
+            new_status=args.status,
+            reason=args.reason,
+            session_info=session_info,
+        )
+
+        if sync_success:
+            print("\n✅ Successfully synchronized with Intervals.icu")
+        else:
+            print("\n⚠️  Warning: Sync with Intervals.icu failed (local changes preserved)")
+
+    print("\n✨ Done!")
 
 
 if __name__ == "__main__":

--- a/magma_cycling/validate_naming_convention.py
+++ b/magma_cycling/validate_naming_convention.py
@@ -30,6 +30,8 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
+from magma_cycling.utils.cli import cli_main
+
 
 class NamingValidator:
     """Validateur de conventions de nommage weekly_reports."""
@@ -215,6 +217,7 @@ class NamingValidator:
         return json.dumps(report, indent=2, ensure_ascii=False)
 
 
+@cli_main
 def main():
     """Command-line entry point for validating naming conventions."""
     parser = argparse.ArgumentParser(

--- a/tests/test_planned_sessions_checker.py
+++ b/tests/test_planned_sessions_checker.py
@@ -475,9 +475,7 @@ class TestMainFunction:
         mock_config.week_planning_dir = MagicMock()
         mock_get_config.return_value = mock_config
 
-        # Run main (should not raise exception)
-        try:
+        # Run main (@cli_main wraps with sys.exit)
+        with pytest.raises(SystemExit) as exc_info:
             main()
-        except FileNotFoundError:
-            # Expected when config file doesn't actually exist in test environment
-            pass
+        assert exc_info.value.code == 0

--- a/tests/test_sync_intervals.py
+++ b/tests/test_sync_intervals.py
@@ -348,8 +348,10 @@ class TestMainFunction:
         mock_logger = MagicMock()
         mock_logger_class.return_value = mock_logger
 
-        # Run main
-        main()
+        # Run main (@cli_main wraps with sys.exit)
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
 
         # Verify API was initialized with CLI args
         mock_client_class.assert_called_once_with(athlete_id="iXXXXXX", api_key="test_key")
@@ -382,8 +384,10 @@ class TestMainFunction:
         mock_logger = MagicMock()
         mock_logger_class.return_value = mock_logger
 
-        # Run main
-        main()
+        # Run main (@cli_main wraps with sys.exit)
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
 
         # Verify factory was used
         mock_create_client.assert_called_once()


### PR DESCRIPTION
## Summary
- Migrate 20 CLI entry points to use the centralized `@cli_main` decorator from `utils.cli`
- Remove ad-hoc `try/except/traceback/sys.exit` patterns replaced by the decorator
- Fix 3 tests that expected `main()` to return normally (now wrapped with `pytest.raises(SystemExit)`)

## Test plan
- [x] 3 previously failing tests now pass (SystemExit wrapping)
- [x] 2269 tests pass, 20 failures are pre-existing (env/credentials)
- [x] Pre-commit hooks pass (black, ruff, isort, pydocstyle, pycodestyle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)