### PR TITLE
fix(zwift): deduplicate HTTP session + add missing docstring

### DIFF
--- a/magma_cycling/external/zwift_service.py
+++ b/magma_cycling/external/zwift_service.py
@@ -64,22 +64,20 @@ class ZwiftService:
         cache_db_path: Path | None = None,
         cache_ttl_days: int = 60,
     ):
+        """Initialize Zwift service facade.
+
+        Args:
+            cache_db_path: Path to SQLite cache database.
+            cache_ttl_days: Number of days to cache workout data.
+        """
         self._client = ZwiftWorkoutClient(
             cache_db_path=cache_db_path,
             cache_ttl_days=cache_ttl_days,
         )
         self._scraper = ZwiftWorkoutScraper()
         self._converter = ZwiftWorkoutConverter()
-        self._session = requests.Session()
-        self._session.headers.update(
-            {
-                "User-Agent": (
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/91.0.4472.124 Safari/537.36"
-                )
-            }
-        )
+        # Reuse client's HTTP session (same User-Agent, shared connection pool)
+        self._session = self._client.session
         self._seen_names: set[str] = set()
         self._load_existing_names()
 


### PR DESCRIPTION
## Summary
- **Deduplicate HTTP session**: `ZwiftService` now reuses `ZwiftWorkoutClient.session` instead of creating a separate `requests.Session()` with identical headers
- **Fix pydocstyle D107**: Add missing `__init__` docstring to `ZwiftService`

## Test plan
- [x] 35 Zwift tests pass (`test_zwift_service.py` + `test_zwift_planner_integration.py`)
- [x] `pre-commit run --all-files` all green (including pydocstyle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)