### PR TITLE
docs: rewrite workflows + MCP documentation post-refactoring Phase 3

### DIFF
--- a/project-docs/MCP_INTEGRATION.md
+++ b/project-docs/MCP_INTEGRATION.md
@@ -1,44 +1,166 @@
 # MCP Integration - Claude Desktop
 
-## 🎯 Vue d'Ensemble
+## Vue d'Ensemble
 
-Le **MCP Server** (Model Context Protocol) expose tous les outils de training logs directement à Claude Desktop et autres clients MCP compatibles.
+Le **MCP Server** (Model Context Protocol) expose 48 tools de gestion d'entrainement directement a Claude Desktop et autres clients MCP compatibles.
 
-**Date de déploiement:** 2026-02-21
-**Status:** ✅ Production Ready
+**Date de deploiement :** 2026-02-21
+**Status :** Production Ready
+**Tools exposes :** 48
 
-## 🏗️ Architecture
+## Architecture
 
 ```
-┌─────────────────────────────────────────┐
-│        Claude Desktop                   │
-│  (ou autre client MCP)                  │
-└─────────────┬───────────────────────────┘
-              │ JSON-RPC 2.0 over stdio
-              ▼
-┌─────────────────────────────────────────┐
-│     MCP Server                          │
-│  magma_cycling.mcp_server      │
-│                                         │
-│  Tools:                                 │
-│  ├── weekly-planner                     │
-│  ├── monthly-analysis                   │
-│  ├── daily-sync                         │
-│  ├── update-session                     │
-│  ├── list-weeks                         │
-│  └── get-metrics                        │
-└─────────────┬───────────────────────────┘
-              │
-              ▼
-┌─────────────────────────────────────────┐
-│    Control Tower + Audit Log            │
-│    + All existing tools                 │
-└─────────────────────────────────────────┘
+                  Claude Desktop
+               (ou autre client MCP)
+                        |
+                        | JSON-RPC 2.0 over stdio
+                        v
+          +-----------------------------+
+          |        MCP Server           |
+          |  magma_cycling.mcp_server   |
+          |                             |
+          |  48 tools / 13 handlers     |
+          +-----------------------------+
+                   |         |
+          +--------+    +--------+
+          |             |
+    Control Tower    IntervalsClient
+    + Audit Log      + Withings API
 ```
 
-## 🚀 Installation
+### Structure handlers
 
-### 1. Vérifier l'Installation
+```
+magma_cycling/_mcp/handlers/
+  planning.py           # 11 tools
+  analysis.py           #  8 tools
+  withings.py           #  8 tools
+  intervals_sync.py     #  3 tools
+  intervals_events.py   #  4 tools
+  intervals_activities.py # 3 tools
+  intervals_analysis.py #  2 tools
+  sessions.py           #  3 tools
+  workouts.py           #  2 tools
+  athlete.py            #  2 tools
+  catalog.py            #  1 tool
+  admin.py              #  1 tool
+  intervals.py          #  (re-export shim)
+```
+
+## Tools par categorie
+
+### Planning (11 tools) — `planning.py`
+
+| Tool | Description |
+|------|-------------|
+| `weekly-planner` | Genere planning hebdomadaire avec recommandations AI |
+| `monthly-analysis` | Analyse mensuelle complete avec stats + insights AI |
+| `daily-sync` | Synchronise activites depuis Intervals.icu |
+| `update-session` | Met a jour statut d'une session |
+| `list-weeks` | Liste les plannings hebdomadaires disponibles |
+| `get-metrics` | Recupere metriques d'entrainement actuelles |
+| `get-week-details` | Details complets d'une semaine (sessions, statuts, TSS) |
+| `modify-session-details` | Modifie les details d'une session (type, nom, description) |
+| `rename-session` | Renomme une session selon la convention de nommage |
+| `create-session` | Cree une nouvelle session dans le planning |
+| `delete-session` | Supprime une session du planning |
+
+### Analysis (8 tools) — `analysis.py`
+
+| Tool | Description |
+|------|-------------|
+| `validate-week-consistency` | Valide la coherence d'un planning hebdomadaire |
+| `get-recommendations` | Recommandations d'entrainement basees sur les metriques |
+| `analyze-session-adherence` | Analyse l'adherence seance planifiee vs realisee |
+| `get-training-statistics` | Statistiques d'entrainement sur une periode |
+| `export-week-to-json` | Exporte un planning en JSON |
+| `restore-week-from-backup` | Restaure un planning depuis un backup |
+| `analyze-training-patterns` | Analyse les patterns d'entrainement |
+| `get-coach-analysis` | Analyse coach AI d'une activite |
+
+### Withings (8 tools) — `withings.py`
+
+| Tool | Description |
+|------|-------------|
+| `withings-auth-status` | Statut d'authentification Withings |
+| `withings-authorize` | Lancer le flow OAuth Withings |
+| `withings-get-sleep` | Donnees de sommeil |
+| `withings-get-weight` | Donnees de poids et composition corporelle |
+| `withings-get-readiness` | Score de readiness |
+| `withings-sync-to-intervals` | Synchronise donnees Withings vers Intervals.icu |
+| `withings-analyze-trends` | Analyse des tendances sante |
+| `withings-enrich-session` | Enrichit une session avec donnees sante |
+
+### Intervals.icu — Sync (3 tools) — `intervals_sync.py`
+
+| Tool | Description |
+|------|-------------|
+| `sync-week-to-intervals` | Synchronise le planning local vers Intervals.icu |
+| `sync-remote-to-local` | Synchronise les events Intervals.icu vers le planning local |
+| `backfill-activities` | Backfill des activites historiques |
+
+### Intervals.icu — Events (4 tools) — `intervals_events.py`
+
+| Tool | Description |
+|------|-------------|
+| `delete-remote-session` | Supprime un event sur Intervals.icu |
+| `list-remote-events` | Liste les events Intervals.icu pour une periode |
+| `update-remote-session` | Met a jour un event sur Intervals.icu |
+| `create-remote-note` | Cree une NOTE sur Intervals.icu |
+
+### Intervals.icu — Activities (3 tools) — `intervals_activities.py`
+
+| Tool | Description |
+|------|-------------|
+| `get-activity-details` | Details complets d'une activite |
+| `get-activity-intervals` | Intervalles d'une activite (laps, segments) |
+| `get-activity-streams` | Streams d'une activite (power, HR, cadence) |
+
+### Intervals.icu — Analysis (2 tools) — `intervals_analysis.py`
+
+| Tool | Description |
+|------|-------------|
+| `compare-intervals` | Compare intervalles planifies vs realises |
+| `apply-workout-intervals` | Applique un workout Intervals.icu format a un event |
+
+### Sessions (3 tools) — `sessions.py`
+
+| Tool | Description |
+|------|-------------|
+| `duplicate-session` | Duplique une session dans le planning |
+| `swap-sessions` | Echange deux sessions dans le planning |
+| `attach-workout` | Attache un fichier workout a une session |
+
+### Workouts (2 tools) — `workouts.py`
+
+| Tool | Description |
+|------|-------------|
+| `get-workout` | Recupere le contenu d'un workout (fichier ou planning) |
+| `validate-workout` | Valide le format d'un workout |
+
+### Athlete (2 tools) — `athlete.py`
+
+| Tool | Description |
+|------|-------------|
+| `get-athlete-profile` | Profil athlete (FTP, poids, zones, objectifs) |
+| `update-athlete-profile` | Met a jour le profil athlete |
+
+### Catalog (1 tool) — `catalog.py`
+
+| Tool | Description |
+|------|-------------|
+| `list-workout-catalog` | Liste le catalogue de workouts Zwift disponibles |
+
+### Admin (1 tool) — `admin.py`
+
+| Tool | Description |
+|------|-------------|
+| `reload-server` | Rechargement a chaud du serveur MCP |
+
+## Installation
+
+### 1. Verifier l'installation
 
 ```bash
 # Tester que le serveur MCP se lance
@@ -46,12 +168,12 @@ poetry run mcp-server
 # Devrait attendre stdin (Ctrl+C pour quitter)
 
 # Tester les imports
-poetry run python -c "from magma_cycling.mcp_server import server; print('✅ OK')"
+poetry run python -c "from magma_cycling.mcp_server import server; print('OK')"
 ```
 
 ### 2. Configuration Claude Desktop
 
-**Localisation:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Localisation :** `~/Library/Application Support/Claude/claude_desktop_config.json`
 
 ```json
 {
@@ -59,369 +181,102 @@ poetry run python -c "from magma_cycling.mcp_server import server; print('✅ OK
     "cyclisme-training": {
       "command": "poetry",
       "args": ["run", "mcp-server"],
-      "cwd": "/Users/stephanejouve/magma-cycling",
+      "cwd": "/chemin/vers/magma-cycling",
       "env": {}
     }
   }
 }
 ```
 
-**Remplacer `/Users/stephanejouve/magma-cycling` par votre chemin absolu au projet.**
+### 3. Redemarrer Claude Desktop
 
-### 3. Redémarrer Claude Desktop
+Quitter completement et relancer. Verifier dans Settings > MCP Servers que "cyclisme-training" est connecte.
 
-```bash
-# Quitter complètement Claude Desktop
-# Relancer l'application
-
-# Vérifier dans les settings que le serveur est connecté
-# Section "MCP Servers" devrait montrer "cyclisme-training" ✅
-```
-
-## 🛠️ Tools Disponibles
-
-### 1. weekly-planner
-
-**Description:** Génère le planning hebdomadaire avec recommandations AI
-
-**Paramètres:**
-```json
-{
-  "week_id": "S082",           // Required: Week ID
-  "start_date": "2026-02-23",  // Required: Monday start date (YYYY-MM-DD)
-  "provider": "clipboard"      // Optional: AI provider (clipboard/claude_api/mistral_api)
-}
-```
-
-**Exemple Claude Desktop:**
-```
-User: "Claude, génère le planning pour la semaine S082 qui commence le 23 février 2026"
-
-Claude: [Calls MCP tool "weekly-planner"]
-{
-  "week_id": "S082",
-  "start_date": "2026-02-23",
-  "status": "prompt_generated",
-  "prompt_length": 15234,
-  "message": "Planning prompt generated for S082"
-}
-```
-
-### 2. monthly-analysis
-
-**Description:** Analyse mensuelle complète avec stats + insights AI
-
-**Paramètres:**
-```json
-{
-  "month": "2026-01",          // Required: Month (YYYY-MM)
-  "provider": "mistral_api",   // Optional: AI provider
-  "no_ai": false               // Optional: Skip AI analysis
-}
-```
-
-**Exemple Claude Desktop:**
-```
-User: "Génère l'analyse mensuelle de janvier 2026"
-
-Claude: [Calls MCP tool "monthly-analysis"]
-{
-  "month": "2026-01",
-  "report_length": 2845,
-  "report": "# 📊 Analyse Mensuelle - January 2026..."
-}
-```
-
-### 3. daily-sync
-
-**Description:** Synchronise les activités depuis Intervals.icu
-
-**Paramètres:**
-```json
-{
-  "date": "2026-02-21",        // Optional: Date to check (default: today)
-  "week_id": "S082"            // Optional: Week ID for planning check
-}
-```
-
-**Exemple Claude Desktop:**
-```
-User: "Synchronise les activités d'aujourd'hui"
-
-Claude: [Calls MCP tool "daily-sync"]
-{
-  "date": "2026-02-21",
-  "activities_found": 1,
-  "status": "completed",
-  "message": "Sync completed for 2026-02-21"
-}
-```
-
-### 4. update-session
-
-**Description:** Met à jour le statut d'une session
-
-**Paramètres:**
-```json
-{
-  "week_id": "S082",           // Required: Week ID
-  "session_id": "S082-03",     // Required: Session ID
-  "status": "completed",       // Required: New status
-  "reason": "...",             // Optional: Reason (required for skipped/cancelled)
-  "sync": false                // Optional: Sync to Intervals.icu
-}
-```
-
-**Statuts valides:**
-- `pending` - En attente
-- `planned` - Planifiée
-- `uploaded` - Uploadée sur Intervals.icu
-- `completed` - Complétée
-- `skipped` - Sautée (reason required)
-- `cancelled` - Annulée (reason required)
-- `rest_day` - Repos
-- `replaced` - Remplacée (reason required)
-- `modified` - Modifiée
-
-**Exemple Claude Desktop:**
-```
-User: "Marque la session S082-03 comme complétée"
-
-Claude: [Calls MCP tool "update-session"]
-{
-  "week_id": "S082",
-  "session_id": "S082-03",
-  "status": "completed",
-  "message": "Session S082-03 updated to completed"
-}
-```
-
-### 5. list-weeks
-
-**Description:** Liste les plannings hebdomadaires disponibles
-
-**Paramètres:**
-```json
-{
-  "limit": 10,                 // Optional: Max weeks to return (1-52)
-  "recent": true               // Optional: Most recent first
-}
-```
-
-**Exemple Claude Desktop:**
-```
-User: "Quelles sont les 5 dernières semaines planifiées?"
-
-Claude: [Calls MCP tool "list-weeks" with limit=5]
-{
-  "total_found": 5,
-  "showing": 5,
-  "weeks": [
-    {
-      "week_id": "S082",
-      "start_date": "2026-02-23",
-      "end_date": "2026-03-01",
-      "tss_target": 385,
-      "sessions": 7
-    },
-    ...
-  ]
-}
-```
-
-### 6. get-metrics
-
-**Description:** Récupère les métriques d'entraînement actuelles
-
-**Paramètres:** Aucun
-
-**Exemple Claude Desktop:**
-```
-User: "Quelles sont mes métriques actuelles?"
-
-Claude: [Calls MCP tool "get-metrics"]
-{
-  "date": "2026-02-21",
-  "ctl": 42,
-  "atl": 46,
-  "tsb": -3,
-  "rampRate": 0.8,
-  "ctlLoad": 245,
-  "atlLoad": 267
-}
-
-Claude: "Tes métriques actuelles:
-- CTL (Chronic Training Load): 42
-- ATL (Acute Training Load): 46
-- TSB (Training Stress Balance): -3 (légère fatigue)
-- Ramp Rate: 0.8
-"
-```
-
-## 📝 Exemples d'Utilisation
-
-### Workflow Complet via Claude Desktop
-
-```
-User: "Claude, je veux planifier ma semaine S082 qui commence lundi 23 février"
-
-Claude: [Calls list-weeks to check existing]
-       [Calls get-metrics to get current state]
-       [Calls weekly-planner with S082, 2026-02-23]
-
-       "Planning généré pour S082! Basé sur tes métriques:
-       - CTL: 42 (bonne forme)
-       - TSB: -3 (légère fatigue)
-
-       Je recommande:
-       - 7 séances
-       - 385 TSS total
-       - Focus endurance avec 1 séance intensité
-
-       Le prompt est prêt dans ton clipboard."
-
-User: "Super! Maintenant marque S081-07 comme repos car j'étais malade"
-
-Claude: [Calls update-session]
-       "✅ Session S081-07 marquée comme repos.
-       Raison: Maladie
-       Backup créé automatiquement par Control Tower."
-
-User: "Montre-moi l'analyse de janvier"
-
-Claude: [Calls monthly-analysis with month=2026-01]
-
-       "📊 Analyse Janvier 2026:
-       - 245 TSS réalisés / 739 cible (33%)
-       - 6 sessions complétées
-       - 50% adhérence
-       - Meilleure semaine: S077 (63.6%)
-
-       💡 Insights:
-       - Tendance: Démarrage progressif post-coupure
-       - Points forts: Régularité S077-S078
-       - À améliorer: Taux de réalisation
-       "
-```
-
-### Monitoring Quotidien
-
-```
-User: "Synchronise mes activités"
-
-Claude: [Calls daily-sync]
-       "✅ Sync terminé:
-       - 1 activité trouvée aujourd'hui
-       - S082-03 marquée 'completed' automatiquement
-       - TSS: 72 enregistré"
-```
-
-## 🔒 Sécurité
+## Securite
 
 ### Permissions
 
-Le MCP server utilise la **Control Tower** pour toutes les modifications:
-- ✅ Backup automatique avant chaque modification
-- ✅ Audit log complet (WHO/WHY/WHEN/WHAT)
-- ✅ Permission system (anti-modifications concurrentes)
-- ✅ Validation Pydantic sur toutes les données
+Le MCP server utilise la **Control Tower** pour toutes les modifications :
+- Backup automatique avant chaque modification
+- Audit log complet (WHO/WHY/WHEN/WHAT)
+- Permission system (anti-modifications concurrentes)
+- Validation Pydantic sur toutes les donnees
 
-### Traçabilité
+### Tracabilite
 
-Toutes les opérations via MCP sont loggées:
+Toutes les operations via MCP sont loguees :
 
 ```json
 {
-  "timestamp": "2026-02-21T15:30:45Z",
+  "timestamp": "2026-03-15T15:30:45Z",
   "operation": "MODIFY",
-  "week_id": "S082",
+  "week_id": "S085",
   "tool": "mcp-server",
-  "username": "stephanejouve",
-  "reason": "MCP: Update S082-03 to completed",
+  "username": "user",
+  "reason": "MCP: Update S085-03 to completed",
   "status": "SUCCESS"
 }
 ```
 
-Audit log: `~/data/.planning_audit.jsonl`
+Audit log : `~/data/.planning_audit.jsonl`
 
-## 🆘 Troubleshooting
+## Troubleshooting
 
-### Serveur MCP ne démarre pas
+### Serveur MCP ne demarre pas
 
 ```bash
-# Vérifier les imports
+# Verifier les imports
 poetry run python -c "from magma_cycling.mcp_server import server"
 
-# Vérifier les dépendances
+# Verifier les dependances
 poetry show mcp
 
-# Réinstaller si besoin
+# Reinstaller si besoin
 poetry install
 ```
 
 ### Claude Desktop ne voit pas le serveur
 
-1. Vérifier le chemin `cwd` dans `claude_desktop_config.json`
-2. Vérifier que `poetry run mcp-server` fonctionne en CLI
-3. Redémarrer complètement Claude Desktop
-4. Checker les logs Claude Desktop: `~/Library/Logs/Claude/`
+1. Verifier le chemin `cwd` dans `claude_desktop_config.json`
+2. Verifier que `poetry run mcp-server` fonctionne en CLI
+3. Redemarrer completement Claude Desktop
+4. Checker les logs Claude Desktop : `~/Library/Logs/Claude/`
 
-### Tool call échoue
+### Tool call echoue
 
-Les erreurs sont retournées en JSON:
+Les erreurs sont retournees en JSON :
 
 ```json
 {
-  "error": "Session S082-03 not found in S082",
+  "error": "Session S085-03 not found in S085",
   "tool": "update-session",
-  "arguments": {...}
+  "arguments": {}
 }
 ```
 
-Vérifier:
-- Format des arguments (week_id, dates, etc.)
-- Que les fichiers existent
-- Permissions filesystem
+Verifier : format des arguments, existence des fichiers, permissions filesystem.
 
-## 📊 Statistiques
+## Statistiques
 
-**Tools exposés:** 6
-**Protocole:** JSON-RPC 2.0 over stdio
-**Transport:** MCP SDK Python
-**Sécurité:** Control Tower + Audit Log
-**Status:** ✅ Production Ready
+| Metrique | Valeur |
+|----------|--------|
+| **Tools exposes** | 48 |
+| **Handlers** | 13 fichiers |
+| **Protocole** | JSON-RPC 2.0 over stdio |
+| **Transport** | MCP SDK Python |
+| **Securite** | Control Tower + Audit Log |
+| **Status** | Production Ready |
 
-## 🔮 Évolutions Futures
+## References
 
-### Phase 2 - Tools Supplémentaires
-
-- `end-of-week` - Workflow complet fin de semaine
-- `backup-rollback` - Gestion backups/rollback
-- `workout-coach` - Coach interactif
-- `intelligence-query` - Interroger training intelligence
-
-### Phase 3 - Notifications
-
-- Push notifications sur activités complétées
-- Alertes sur métriques (TSB critique, etc.)
-- Rappels planification hebdo
-
-### Phase 4 - Intégrations
-
-- Strava sync
-- Garmin Connect sync
-- Wahoo sync
-
-## 📚 Références
-
-- **MCP Spec:** https://modelcontextprotocol.io/
-- **Code Server:** `magma_cycling/mcp_server.py`
-- **Control Tower:** `project-docs/CONTROL_TOWER.md`
-- **Features Feb 2026:** `project-docs/FEATURES_FEB_2026.md`
+- **MCP Spec :** https://modelcontextprotocol.io/
+- **Code Server :** `magma_cycling/mcp_server.py`
+- **Handlers :** `magma_cycling/_mcp/handlers/`
+- **Schemas :** `magma_cycling/_mcp/schemas/`
+- **Control Tower :** `project-docs/CONTROL_TOWER.md`
 
 ---
 
-**Auteur:** Claude Code
-**Date:** 2026-02-21
-**Version:** 1.0.0
-**Status:** ✅ Production Ready
+**Date :** Mars 2026
+**Version :** 2.0.0
+**Status :** Production Ready

--- a/project-docs/workflows/DAILY_WORKFLOW.md
+++ b/project-docs/workflows/DAILY_WORKFLOW.md
@@ -1,499 +1,257 @@
-# Workflow Quotidien - Cyclisme Training Logs
+# Workflow Quotidien - Magma Cycling
 
-**Documentation complète du workflow d'analyse journalière**
-
----
-
-## 📋 Vue d'Ensemble
-
-Ce document décrit les 4 workflows quotidiens disponibles pour traiter tes séances d'entraînement cyclisme.
-
-**Principe**: Chaque séance doit être analysée avec l'un de ces workflows selon le contexte.
+**Version** : 2.0
+**Date** : Mars 2026
+**Architecture** : Facades + mixins (post-refactoring Phase 3)
 
 ---
 
-## 🎯 Les 4 Workflows
+## Vue d'Ensemble
 
-### 1️⃣ Workflow Standard (Le Plus Courant)
+Ce document decrit les 4 workflows quotidiens disponibles pour traiter les seances d'entrainement cyclisme.
 
-**Alias**: `train`
+**Principe** : Chaque seance doit etre analysee avec l'un de ces workflows selon le contexte.
 
-**Quand l'utiliser**:
-- Après chaque séance normale (Lun/Mar/Jeu/Sam/Dim)
-- Quand tu veux un traitement complet avec feedback
+**Regle Control Tower** : Toute modification de planning passe par `PlanningControlTower` — backup automatique, audit, atomicite. Ne jamais editer les fichiers planning manuellement.
 
-**Ce qu'il fait**:
-1. ✅ Collecte ton feedback athlète (RPE, sensations, HRRc)
-2. ✅ Génère l'analyse AI de la séance (via Claude.ai)
-3. ✅ Met à jour `logs/workouts-history.md`
-4. ✅ Crée un commit git avec l'analyse
-5. ✅ Affiche un résumé de la séance
+---
 
-**Durée**: 3-5 minutes (interaction AI requise)
+## Les 4 Workflows
 
-**Exemple**:
+### 1. Workflow Standard
+
+**Alias** : `train` | **Commande** : `poetry run workflow-coach`
+**Facade** : `WorkflowCoach` | **Mixins** : `FeedbackMixin`, `AIAnalysisMixin`, `HistoryMixin`, `GitOpsMixin`
+
+**Quand l'utiliser** :
+- Apres chaque seance normale (Lun/Mar/Jeu/Sam/Dim)
+- Traitement complet avec feedback
+
+**Ce qu'il fait** :
+1. Collecte le feedback athlete (RPE, sensations, HRRc)
+2. Genere l'analyse AI de la seance via AI provider
+3. Met a jour `workouts-history.md`
+4. Cree un commit git avec l'analyse
+5. Affiche un resume de la seance
+
+**Duree** : 3-5 minutes
+
 ```bash
-# Après ta séance Zwift du lundi soir
 train
 ```
 
-**Interaction requise**:
-- Copier le prompt généré → Claude.ai
-- Copier la réponse de Claude → Terminal
-- Confirmer le commit git (o/n)
-
 ---
 
-### 2️⃣ Workflow avec Asservissement Planning
+### 2. Workflow avec Asservissement Planning
 
-**Alias**: `trains --week-id SXXX`
+**Alias** : `trains --week-id SXXX` | **Commande** : `poetry run workflow-coach --servo-mode --week-id SXXX`
+**Facade** : `WorkflowCoach` | **Mixins** : les memes + `ServoControlMixin`, `IntervalsAPIMixin`
 
-**Quand l'utiliser**:
+**Quand l'utiliser** :
 - Mercredi soir (milieu de semaine)
 - Vendredi soir (avant weekend)
-- Quand tu sens de la fatigue et veux ajuster le planning
+- Quand fatigue ressentie et ajustement planning necessaire
 
-**Ce qu'il fait**:
-1. ✅ Tout du workflow standard (feedback + analyse + commit)
-2. ✅ **Analyse les signaux de fatigue** (HRV, RPE, TSB)
-3. ✅ **Propose des ajustements planning** si nécessaire
-4. ✅ Peut remplacer workouts sur Intervals.icu (avec confirmation)
+**Ce qu'il fait** :
+1. Tout du workflow standard (feedback + analyse + commit)
+2. Analyse les signaux de fatigue (HRV, RPE, TSB)
+3. Propose des ajustements planning si necessaire
+4. Peut remplacer workouts sur Intervals.icu (avec confirmation)
 
-**Durée**: 5-8 minutes (+ temps décision ajustements)
+**Duree** : 5-8 minutes
 
-**Exemple**:
 ```bash
-# Mercredi soir, semaine S073, après séance
-trains --week-id S073
+trains --week-id S085
 ```
 
-**Scénarios d'ajustement typiques**:
-- HRV baisse de -15% → Propose récupération active au lieu de Sweet-Spot
-- RPE > 9 deux jours de suite → Propose jour de repos additionnel
-- TSB < 0 avec VO2 max prévu → Propose report du workout
-
-**⚠️ Recommandation**: Utiliser 2-3 fois par semaine maximum (ne pas sur-ajuster)
+**Scenarios d'ajustement typiques** :
+- HRV baisse de -15% : Propose recuperation active au lieu de Sweet-Spot
+- RPE > 9 deux jours de suite : Propose jour de repos additionnel
+- TSB < 0 avec VO2 max prevu : Propose report du workout
 
 ---
 
-### 3️⃣ Workflow Rapide (Debug/Multi-Séances)
+### 3. Workflow Rapide
 
-**Alias**: `train-fast`
+**Alias** : `train-fast` | **Commande** : `poetry run workflow-coach --skip-feedback --skip-git`
+**Facade** : `WorkflowCoach` | **Mixins** : `AIAnalysisMixin`, `HistoryMixin` (feedback et git skipes)
 
-**Quand l'utiliser**:
-- Multi-séances rapprochées (2 workouts le même jour)
+**Quand l'utiliser** :
+- Multi-seances rapprochees (2 workouts le meme jour)
 - Rattrapage de plusieurs analyses en une fois
-- Mode debug (test modifications code)
+- Mode debug
 
-**Ce qu'il fait**:
-1. ✅ Génère l'analyse AI uniquement
-2. ⏩ **Skip** la collecte feedback manuel
-3. ⏩ **Skip** le commit git
-
-**Durée**: 1-2 minutes
-
-**Exemple**:
-```bash
-# Samedi: séance matinale + séance après-midi
-train              # Première séance (complet)
-train-fast         # Deuxième séance (rapide)
-
-# Puis en fin de journée, commit groupé:
-cd ~/magma-cycling
-git add .
-git commit -m "Analyses: 2 séances samedi S073-05"
-```
-
-**⚠️ Attention**: Ne pas oublier de commiter manuellement plus tard!
-
----
-
-### 4️⃣ Workflow Réconciliation (Rattrapage Batch)
-
-**Alias**: `trainr --week-id SXXX`
-
-**Quand l'utiliser**:
-- Plusieurs jours sans analyse (retour de voyage, maladie)
-- Séances planifiées mais sautées/annulées
-- Nettoyage de semaine avant analyse hebdomadaire
-
-**Ce qu'il fait**:
-1. ✅ Détecte les séances planifiées non exécutées
-2. ✅ Propose classification pour chaque séance:
-   - `skipped`: Sautée volontairement
-   - `cancelled`: Annulée pour cause valable
-   - `rescheduled`: Reportée à une autre date
-3. ✅ Met à jour le planning sur Intervals.icu
-4. ✅ Crée un commit batch des modifications
-
-**Durée**: 5-10 minutes (selon nombre de séances)
-
-**Exemple**:
-```bash
-# Dimanche soir, semaine S073, avant de lancer wa
-trainr --week-id S073
-```
-
-**Cas d'usage typiques**:
-- 3 jours sans entraînement → Classifier les 3 workouts manqués
-- Semaine avec 2 séances sautées → Nettoyer le planning
-- Avant `wa` (analyse hebdo) → S'assurer que tout est à jour
-
----
-
-## 📊 Tableau Comparatif
-
-| Workflow | Alias | Feedback | Analyse | Git | Planning | Durée | Fréquence |
-|----------|-------|----------|---------|-----|----------|-------|-----------|
-| **Standard** | `train` | ✅ | ✅ | ✅ | ❌ | 3-5min | Quotidien |
-| **Asservissement** | `trains --week-id` | ✅ | ✅ | ✅ | ✅ | 5-8min | 2-3x/semaine |
-| **Rapide** | `train-fast` | ❌ | ✅ | ❌ | ❌ | 1-2min | Occasionnel |
-| **Réconciliation** | `trainr --week-id` | ❌ | ✅ | ✅ | ✅ | 5-10min | 1x/semaine |
-
----
-
-## 🔄 Enchainement Quotidien Recommandé
-
-### Lundi
+**Duree** : 1-2 minutes
 
 ```bash
-# MATIN: Cycle hebdomadaire complet
-wa --week-id S072 --start-date 2025-12-16       # 1. Analyser semaine passée
-wp --week-id S073 --start-date 2025-12-23       # 2. Planifier semaine courante
-wu --week-id S073 --start-date 2025-12-23       # 3. Uploader workouts
-
-# SOIR: Première séance de la semaine
-train
-```
-
-### Mardi
-
-```bash
-# SOIR: Séance standard
-train
-```
-
-### Mercredi
-
-```bash
-# SOIR: Séance avec vérification planning
-trains --week-id S073
-```
-
-**Pourquoi mercredi?** Milieu de semaine, bon moment pour ajuster si fatigue accumulée.
-
-### Jeudi
-
-```bash
-# SOIR: Séance standard
-train
-```
-
-### Vendredi
-
-```bash
-# SOIR: Séance avec vérification planning
-trains --week-id S073
-```
-
-**Pourquoi vendredi?** Ajuster le weekend si nécessaire (volume samedi, repos dimanche).
-
-### Samedi
-
-```bash
-# MATIN: Séance volume weekend (09:00)
-train
-
-# Si 2e séance après-midi:
 train-fast
 ```
 
-### Dimanche
+---
+
+### 4. Workflow Reconciliation
+
+**Alias** : `trainr --week-id SXXX` | **Commande** : `poetry run workflow-coach --reconcile --week-id SXXX`
+**Facade** : `WorkflowCoach` | **Mixins** : `ReconciliationMixin`, `SpecialSessionsMixin`, `GitOpsMixin`
+
+**Quand l'utiliser** :
+- Plusieurs jours sans analyse (retour de voyage, maladie)
+- Seances planifiees mais sautees/annulees
+- Nettoyage de semaine avant analyse hebdomadaire
+
+**Duree** : 5-10 minutes
 
 ```bash
-# SOIR: Séance finale ou repos
-train  # Si séance
-
-# Réconciliation si séances manquées dans la semaine
-trainr --week-id S073  # Optionnel, si nécessaire
+trainr --week-id S085
 ```
 
 ---
 
-## 📅 Cycle Hebdomadaire Complet
+## Tableau Comparatif
 
-Voici le **cycle complet** sur 7 jours:
+| Workflow | Alias | Feedback | Analyse | Git | Planning | Duree | Frequence |
+|----------|-------|----------|---------|-----|----------|-------|-----------|
+| **Standard** | `train` | oui | oui | oui | non | 3-5min | Quotidien |
+| **Asservissement** | `trains --week-id` | oui | oui | oui | oui | 5-8min | 2-3x/semaine |
+| **Rapide** | `train-fast` | non | oui | non | non | 1-2min | Occasionnel |
+| **Reconciliation** | `trainr --week-id` | non | oui | oui | oui | 5-10min | 1x/semaine |
 
+---
+
+## Enchainement Quotidien Recommande
+
+### Lundi
+```bash
+# MATIN : Cycle hebdomadaire complet
+poetry run weekly-analysis --week-id S084     # 1. Analyser semaine passee (wa)
+poetry run weekly-planner S085 --start-date 2026-03-16  # 2. Planifier semaine (wp)
+poetry run upload-workouts --week-id S085     # 3. Uploader workouts (wu)
+
+# SOIR : Premiere seance de la semaine
+train
 ```
-┌─────────────────────────────────────────────────────────┐
-│ LUNDI (Jour J)                                          │
-│ ├─ MATIN: wa S072 → wp S073 → wu S073 (cycle hebdo)   │
-│ └─ SOIR: train (1ère séance semaine)                   │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│ MARDI (J+1)                                             │
-│ └─ SOIR: train                                          │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│ MERCREDI (J+2) ⚡ CHECKPOINT 1                          │
-│ └─ SOIR: trains --week-id S073 (avec asservissement)   │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│ JEUDI (J+3)                                             │
-│ └─ SOIR: train                                          │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│ VENDREDI (J+4) ⚡ CHECKPOINT 2                          │
-│ └─ SOIR: trains --week-id S073 (ajustement weekend)    │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│ SAMEDI (J+5) 🏔️ VOLUME WEEKEND                         │
-│ ├─ MATIN (09:00): train (séance longue)                │
-│ └─ APREM (optionnel): train-fast (si 2e séance)        │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-┌─────────────────────────────────────────────────────────┐
-│ DIMANCHE (J+6) 🧹 CLEAN SLATE                           │
-│ ├─ SOIR: train (si séance) OU repos                    │
-│ └─ SOIR: trainr --week-id S073 (si réconciliation)     │
-└─────────────────────────────────────────────────────────┘
-                          ↓
-                  [Retour LUNDI J+7]
+
+### Mardi / Jeudi
+```bash
+train  # Seance standard
+```
+
+### Mercredi (Checkpoint 1)
+```bash
+trains --week-id S085  # Avec asservissement
+```
+
+### Vendredi (Checkpoint 2)
+```bash
+trains --week-id S085  # Ajustement weekend
+```
+
+### Samedi
+```bash
+train              # Seance longue matin
+train-fast         # 2e seance optionnelle
+```
+
+### Dimanche
+```bash
+train              # Si seance
+trainr --week-id S085  # Reconciliation si necessaire
 ```
 
 ---
 
-## 💡 Règles d'Or
+## Automation LaunchAgent
 
-### 1. Une Séance = Un Workflow
-**Jamais de séance non analysée.** Traite chaque workout le jour même.
+La chaine quotidienne est automatisee via LaunchAgents :
+
+| Heure | Service | Description |
+|-------|---------|-------------|
+| 21:00 | `withings-presync` | Sync donnees sante Withings vers Intervals.icu |
+| 21:30 | `daily-sync` | Synchronisation activites + analyse AI auto + servo |
+| 22:00 | `adherence-check` | Verification adherence planning |
+| 23:00 | `pid-evaluation` | Evaluation PID quotidienne |
+
+Le dimanche a 20:00, `end-of-week --auto` boucle la semaine et genere le planning S+1 automatiquement.
+
+---
+
+## Regles d'Or
+
+### 1. Une Seance = Un Workflow
+Jamais de seance non analysee. Traite chaque workout le jour meme.
 
 ### 2. Mercredi + Vendredi = Asservissement
-Ces 2 checkpoints hebdomadaires permettent d'ajuster le planning si nécessaire.
+Ces 2 checkpoints hebdomadaires permettent d'ajuster le planning si necessaire.
 
 ### 3. Dimanche Soir = Clean Slate
-Avant lundi matin (cycle hebdo), tout doit être propre:
-- Toutes les séances analysées
-- Séances manquées réconciliées
-- Git à jour
+Avant lundi matin, tout doit etre propre : toutes les seances analysees, seances manquees reconciliees, git a jour.
 
-### 4. Multi-Séances = train + train-fast
-Si 2 séances le même jour: feedback complet sur la 1ère, rapide sur la 2e.
+### 4. Multi-Seances = train + train-fast
+Si 2 seances le meme jour : feedback complet sur la 1ere, rapide sur la 2e.
 
-### 5. Commit Quotidien
+### 5. Control Tower = Source de verite
+Toute modification planning passe par PlanningControlTower. Ne jamais editer les JSON directement.
+
+### 6. Commit Quotidien
 Chaque jour = 1 commit minimum. Historique git propre = meilleur suivi.
 
 ---
 
-## 🚨 Cas Particuliers
+## Facades et Mixins
 
-### Séance Annulée (Blessure/Maladie)
+| Facade | Repertoire mixins | Nombre |
+|--------|------------------|--------|
+| `WorkflowCoach` | `workflows/coach/` | 11 mixins |
+| `DailySync` | `workflows/sync/` | 7 mixins |
+| `EndOfWeekWorkflow` | `workflows/eow/` | 5 mixins |
+| `WeeklyPlanner` | `workflows/planner/` | 4 mixins |
+| `WorkoutUploader` | `workflows/uploader/` | 3 mixins |
+| `PromptGenerator` | `workflows/prompt/` | 4 mixins |
 
+---
+
+## Cas Particuliers
+
+### Seance Annulee (Blessure/Maladie)
 ```bash
-# Ne pas laisser le workout planifié "pending"
-trainr --week-id S073
-
-# Sélectionner "cancelled" avec raison
-# → Le planning Intervals.icu sera mis à jour
+trainr --week-id S085
+# Selectionner "cancelled" avec raison
 ```
 
-### Séance Reportée (Imprévu)
-
+### Seance Reportee (Imprevu)
 ```bash
-trainr --week-id S073
-
-# Sélectionner "rescheduled"
-# → Permet de tracker les reports pour analyse hebdo
+trainr --week-id S085
+# Selectionner "rescheduled"
 ```
 
 ### Plusieurs Jours sans Analyse
-
 ```bash
-# Rattraper toutes les séances en batch
-cd ~/magma-cycling
+# 1. Reconcilier les seances manquees
+trainr --week-id S085
 
-# 1. Réconcilier les séances manquées
-trainr --week-id S073
-
-# 2. Analyser les séances exécutées (une par une)
-train --activity-id 123456  # Séance 1
-train --activity-id 123457  # Séance 2
-train --activity-id 123458  # Séance 3
-```
-
-### Mode Debug (Développement)
-
-```bash
-# Tester modifications code sans feedback/git
-train-fast
-
-# Ou avec options explicites
-train --skip-feedback --skip-git
+# 2. Analyser les seances executees (une par une)
+train --activity-id i129821327
+train --activity-id i129821328
 ```
 
 ---
 
-## 🔧 Options Avancées
+## Troubleshooting
 
-### Analyser une Séance Spécifique
-
+### API Intervals.icu non disponible
 ```bash
-# Par défaut, train prend la dernière activité
-train
-
-# Forcer une activité spécifique par ID
-train --activity-id i123456
+# Verifier config
+poetry run python -c "from magma_cycling.api.intervals_client import IntervalsClient; print('OK')"
 ```
 
-### Skip Options
-
+### Git commit echoue
 ```bash
-# Skip feedback uniquement
-train --skip-feedback
-
-# Skip git uniquement
-train --skip-git
-
-# Skip les deux (= train-fast)
-train --skip-feedback --skip-git
-```
-
-### Mode Réconciliation avec Skip
-
-```bash
-# Réconciliation rapide (sans git interactif)
-trainr --week-id S073 --skip-git
-```
-
----
-
-## 📈 Métriques de Suivi
-
-Pour vérifier que ton workflow quotidien est optimal:
-
-### Commits Git
-
-```bash
-# Nombre de commits cette semaine (devrait être ~6-7)
-git log --since="1 week ago" --oneline | wc -l
-```
-
-**Target**: 6-7 commits/semaine (1 par jour de séance + 1 hebdo)
-
-### Historique Workouts
-
-```bash
-# Dernières séances analysées
-tail -20 logs/workouts-history.md
-```
-
-**Vérifier**: Aucune séance > 2 jours sans analyse
-
-### Planning Cohérence
-
-```bash
-# Vérifier planning semaine
-check
-```
-
-**Vérifier**: Pas de "pending" en retard, statuts corrects
-
----
-
-## 🎯 Checklist Quotidienne
-
-Après chaque séance, pose-toi ces questions:
-
-- [ ] La séance est-elle terminée et synchronisée sur Intervals.icu?
-- [ ] Quel workflow utiliser? (train / trains / train-fast)
-- [ ] Ai-je besoin de vérifier le planning? (Mer/Ven → trains)
-- [ ] Y a-t-il une 2e séance prévue aujourd'hui? (train-fast pour la 2e)
-- [ ] Le commit git est-il fait? (vérifier avec `git status`)
-
----
-
-## 📚 Ressources Complémentaires
-
-### Fichiers de Référence
-
-- `COMMANDS.md` - Quick reference des alias
-- `Documentation_Complète_du_Suivi_v1_5.md` - Documentation projet complète
-- `UNIFORMISATION_WEEK_ID.md` - Format arguments standardisés
-
-### Scripts Associés
-
-- `workflow_coach.py` - Script principal (via alias `train`)
-- `upload_workouts.py` - Upload workouts (via alias `wu`)
-- `weekly_planner.py` - Planning hebdo (via alias `wp`)
-- `weekly_analysis.py` - Analyse hebdo (via alias `wa`)
-
-### Logs et Historique
-
-- `logs/workouts-history.md` - Historique toutes séances
-- `logs/weekly_reports/SXXX/` - Rapports hebdomadaires
-
----
-
-## 🆘 Troubleshooting
-
-### "Poetry command not found"
-
-```bash
-# Vérifier Poetry installé
-poetry --version
-
-# Si erreur, réinstaller
-curl -sSL https://install.python-poetry.org | python3 -
-```
-
-### "API Intervals.icu non disponible"
-
-```bash
-# Vérifier config
-cat ~/.intervals_config.json
-
-# Doit contenir:
-# {
-#   "athlete_id": "iXXXXXX",
-#   "api_key": "XXXXX"
-# }
-```
-
-### "Git commit failed"
-
-```bash
-# Vérifier statut
-cd ~/magma-cycling
 git status
-
-# Résoudre conflits si nécessaire
-git add .
-git commit -m "fix: résolution conflit"
-```
-
-### "Prompt trop long pour Claude.ai"
-
-```bash
-# Utiliser --skip-feedback pour réduire
-train --skip-feedback
+git add logs/workouts-history.md
+git commit -m "Analyse: seance"
 ```
 
 ---
 
-## 📞 Support
-
-**Questions ou bugs**:
-- Vérifier `COMMANDS.md` pour quick reference
-- Consulter `--help` sur chaque commande
-- Check git history: `git log --oneline -20`
-
----
-
-**Version**: 1.0
-**Date**: 2025-12-21
-**Dernière mise à jour**: Ajout workflows asservissement et réconciliation
+**Version** : 2.0
+**Date** : Mars 2026

--- a/project-docs/workflows/GRAFCET_WORKFLOW_COMPLET.md
+++ b/project-docs/workflows/GRAFCET_WORKFLOW_COMPLET.md
@@ -1,669 +1,379 @@
-# GRAFCET WORKFLOW COMPLET - Cyclisme Training Logs
+# GRAFCET Workflow Complet - Magma Cycling
 
-**Date**: 2025-12-21
-**Mission**: Cartographie complète du workflow de génération et modification de planning
+**Date** : Mars 2026
+**Version** : 2.0
+**Architecture** : Post-refactoring Phase 3 (facades + mixins)
 
 ---
 
-## 1. GRAFCET PRINCIPAL - Vue d'ensemble
+## 1. Vue d'ensemble systeme
+
+Trois chemins principaux (planning, analyse, servo) convergent vers les facades et leurs mixins.
 
 ```mermaid
 graph TB
-    Start([Utilisateur]) --> Choice{Type d'opération}
+    Start([Utilisateur]) --> Choice{Type d'operation}
 
-    Choice -->|Génération planning| WeeklyPlanner[weekly-planner.py]
-    Choice -->|Analyse séance| WorkflowCoach[workflow-coach.py]
-    Choice -->|Modifications planning| ServoMode[workflow-coach.py --servo-mode]
+    Choice -->|Planning hebdomadaire| WP[WeeklyPlanner]
+    Choice -->|Analyse de seance| WC[WorkflowCoach]
+    Choice -->|Modifications planning| SM[WorkflowCoach --servo-mode]
+    Choice -->|Fin de semaine| EOW[EndOfWeekWorkflow]
+    Choice -->|Synchronisation| DS[DailySync]
+    Choice -->|Upload workouts| UW[WorkoutUploader]
 
-    WeeklyPlanner --> CollectMetrics[Collecte métriques API]
-    CollectMetrics --> LoadBilan[Chargement bilan S-1]
-    LoadBilan --> LoadContext[Chargement fichiers référence]
-    LoadContext --> GeneratePrompt[Génération prompt AI]
-    GeneratePrompt --> Clipboard1[Copie clipboard]
-    Clipboard1 --> Claude1[Claude.ai génère 7 workouts]
-    Claude1 --> ManualUpload[Upload manuel Intervals.icu]
-    ManualUpload --> PlanningJSON[Création week_planning_SXXX.json]
+    subgraph "Facades"
+        WP
+        WC
+        SM
+        EOW
+        DS
+        UW
+    end
 
-    WorkflowCoach --> AnalyzeActivity[Analyse activité]
-    AnalyzeActivity --> GenerateReport[Génération rapport markdown]
-    GenerateReport --> CheckServo{Servo mode actif?}
+    subgraph "Mixins Coach (11)"
+        WC --> GapDetectionMixin
+        WC --> FeedbackMixin
+        WC --> AIAnalysisMixin_C[AIAnalysisMixin]
+        WC --> SessionDisplayMixin
+        WC --> HistoryMixin
+        WC --> GitOpsMixin
+        WC --> ReconciliationMixin
+        WC --> SpecialSessionsMixin
+        WC --> ServoControlMixin
+        WC --> IntervalsAPIMixin
+        WC --> UIHelpersMixin
+    end
 
-    CheckServo -->|Non| GitCommit[Git commit]
-    CheckServo -->|Oui| ServoControl[step_6b_servo_control]
+    subgraph "Mixins Planner (4)"
+        WP --> ContextLoadingMixin_P[ContextLoadingMixin]
+        WP --> PeriodizationMixin
+        WP --> PromptMixin
+        WP --> OutputMixin
+    end
 
-    ServoMode --> ServoControl
-    ServoControl --> LoadRemaining[Chargement sessions futures]
-    LoadRemaining --> FormatCompact[Format compact planning]
-    FormatCompact --> PromptAI[Génération prompt asservissement]
-    PromptAI --> Clipboard2[Copie clipboard]
-    Clipboard2 --> Claude2[Claude.ai analyse + recommandations]
-    Claude2 --> ParseMods[Parsing modifications JSON]
+    subgraph "Mixins EndOfWeek (5)"
+        EOW --> AnalysisMixin
+        EOW --> EvaluationMixin
+        EOW --> AIWorkoutsMixin
+        EOW --> UploadMixin_E[UploadMixin]
+        EOW --> ArchiveMixin
+    end
 
-    ParseMods --> HasMods{Modifications proposées?}
-    HasMods -->|Non| NoChange[Planning maintenu]
-    HasMods -->|Oui| ApplyMods[Application modifications]
+    subgraph "Mixins Sync (7)"
+        DS --> ActivityDetectionMixin
+        DS --> SessionUpdatesMixin
+        DS --> ServoEvaluationMixin
+        DS --> AIAnalysisMixin_S[AIAnalysisMixin]
+        DS --> CTLPeaksMixin
+        DS --> ReportingMixin
+        DS --> ActivityTracker
+    end
 
-    ApplyMods --> LightenLoop{Action = lighten?}
-    LightenLoop -->|Oui| GetTemplate[Récupération template]
-    GetTemplate --> UserConfirm{Confirmation utilisateur}
-    UserConfirm -->|Non| Skip[Modification ignorée]
-    UserConfirm -->|Oui| DeleteOld[Suppression ancien workout API]
-    DeleteOld --> UploadNew[Upload nouveau workout API]
-    UploadNew --> UpdateJSON[Mise à jour planning JSON]
-    UpdateJSON --> NextMod{Autre modification?}
+    subgraph "Mixins Uploader (3)"
+        UW --> ValidationMixin
+        UW --> ParsingMixin
+        UW --> UploadMixin_U[UploadMixin]
+    end
 
-    LightenLoop -->|Non| OtherAction[cancel/reschedule TODO]
-    OtherAction --> NextMod
+    subgraph "Services transverses"
+        CT[PlanningControlTower]
+        PB[PromptBuilder - build_prompt]
+        ES[EventSync - evaluate_sync]
+        IC[IntervalsClient]
+        AP[AIProviderFactory]
+    end
 
-    NextMod -->|Oui| ApplyMods
-    NextMod -->|Non| SavePlanning[Sauvegarde planning JSON]
-
-    NoChange --> GitCommit
-    Skip --> GitCommit
-    SavePlanning --> GitCommit
-    GitCommit --> End([Fin])
+    WC -.-> CT
+    WP -.-> PB
+    EOW -.-> CT
+    UW -.-> ES
+    DS -.-> IC
+    EOW -.-> AP
 ```
 
 ---
 
-## 2. GRAFCET DÉTAILLÉ - Génération Planning Hebdomadaire
+## 2. Pipeline planning hebdomadaire
 
 ```mermaid
 graph TB
-    subgraph "PHASE 1: Collecte Données"
-        Start([poetry run weekly-planner S072 --start-date 2025-12-16])
-        Start --> Init[__init__ lines 47-65]
-        Init --> Run[run lines 484-527]
-        Run --> Step1[collect_current_metrics lines 67-116]
-        Step1 --> API1[GET /api/v1/athlete/iXXXXXX/wellness]
-        API1 --> Metrics[CTL, ATL, TSB, HR, HRV, Weight]
-        Metrics --> Step2[load_previous_week_bilan lines 118-131]
-        Step2 --> ReadBilan[Lecture logs/weekly_reports/S071/bilan_final_S071.md]
-        ReadBilan --> Step3[load_context_files lines 133-171]
-        Step3 --> LoadRef1[references/project_prompt_v2_1_revised.md]
-        Step3 --> LoadRef2[references/cycling_training_concepts.md]
-        Step3 --> LoadRef3[references/Documentation_Complète_du_Suivi_v1_5.md]
-        Step3 --> LoadRef4[references/protocols/*.md si disponible]
+    subgraph "Phase 1 : Chargement contexte"
+        Start([poetry run weekly-planner SXXX --start-date YYYY-MM-DD])
+        Start --> CL[ContextLoadingMixin.load_athlete_context]
+        CL --> CL2[ContextLoadingMixin.load_previous_week_workouts]
+        CL2 --> API1[IntervalsClient : GET /wellness]
+        API1 --> Metrics[CTL, ATL, TSB, HRV, Weight]
     end
 
-    subgraph "PHASE 2: Construction Prompt"
-        LoadRef4 --> Step4[generate_planning_prompt lines 173-473]
-        Step4 --> Section1[Contexte Athlète lines 181-210]
-        Step4 --> Section2[Période à Planifier lines 211-222]
-        Step4 --> Section3[État Actuel metrics + bilan lines 224-256]
-        Step4 --> Section4[Concepts Entraînement lines 258-271]
-        Step4 --> Section5[Guide Intervals.icu lines 226-245]
-        Step4 --> Section6[Mission + Format lines 273-470]
-
-        Section6 --> Constraint1[Format sortie OBLIGATOIRE]
-        Section6 --> Constraint2[Convention nommage SSSS-JJ-TYPE-Nom-V001]
-        Section6 --> Constraint3[Types entraînement ligne 288-298]
-        Section6 --> Constraint4[Règles intensité ligne 307-322]
-        Section6 --> Constraint5[Checklist VO2 Max ligne 344-351]
-        Section6 --> Constraint6[Validation technique ligne 353-366]
-
-        Section6 --> Output[Prompt complet ~15k-20k tokens]
+    subgraph "Phase 2 : Periodisation"
+        Metrics --> PM[PeriodizationMixin.load_periodization_context]
+        PM --> MC[Chargement mesocycle courant]
+        MC --> TP[Objectifs phase + contraintes]
     end
 
-    subgraph "PHASE 3: Interaction Utilisateur"
-        Output --> Step5[copy_to_clipboard lines 475-482]
-        Step5 --> Pbcopy[pbcopy via subprocess]
-        Pbcopy --> Display[Affichage instructions]
-        Display --> UserAction1[Utilisateur ouvre Claude.ai]
-        UserAction1 --> UserAction2[Colle prompt Cmd+V]
-        UserAction2 --> ClaudeGen[Claude génère 7 WORKOUT blocks]
-        ClaudeGen --> UserAction3[Utilisateur copie chaque workout]
-        UserAction3 --> UserAction4[Upload manuel Intervals.icu]
+    subgraph "Phase 3 : Generation prompt"
+        TP --> PR[PromptMixin.generate_planning_prompt]
+        PR --> PB[PromptBuilder.build_prompt mission=weekly_planning]
+        PB --> Prompt[Prompt complet ~15-20k tokens]
     end
 
-    subgraph "PHASE 4: Persistence Planning"
-        UserAction4 --> CreateJSON[Création manuelle week_planning_S072.json]
-        CreateJSON --> JSONStructure{
-            week_id: S072
-            start_date: 2025-12-16
-            end_date: 2025-12-22
-            version: 1
-            planned_sessions: []
-        }
-        JSONStructure --> Session1[Session S072-01-INT-SweetSpot-V001]
-        JSONStructure --> Session7[Session S072-07-REC-ReposObligatoire-V001]
-        Session7 --> SaveJSON[Sauvegarde data/week_planning/week_planning_S072.json]
+    subgraph "Phase 4 : Sortie + Upload"
+        Prompt --> OUT[OutputMixin.copy_to_clipboard]
+        OUT --> AI{AI Provider}
+        AI -->|clipboard| Clipboard[Copie manuelle vers Claude.ai]
+        AI -->|claude_api| DirectAPI[Appel API direct]
+        AI -->|mistral_api| MistralAPI[Appel Mistral]
+
+        Clipboard --> Workouts[7 WORKOUT blocks generes]
+        DirectAPI --> Workouts
+        MistralAPI --> Workouts
+
+        Workouts --> UW2[WorkoutUploader.upload_all]
+        UW2 --> VM[ValidationMixin.validate_workout_notation]
+        VM --> PM2[ParsingMixin.parse_workouts_file]
+        PM2 --> ES2[event_sync.evaluate_sync]
+        ES2 --> UM[UploadMixin.upload_workout]
+        UM --> API2[IntervalsClient : POST /events]
+        API2 --> JSON[Mise a jour week_planning_SXXX.json]
     end
 
-    SaveJSON --> End([Fin génération planning])
+    subgraph "Phase 5 : Statut sessions"
+        JSON --> SS[OutputMixin.update_session_status]
+        SS --> End([Planning operationnel])
+    end
 ```
 
 ---
 
-## 3. GRAFCET DÉTAILLÉ - Servo Mode (Modifications Planning)
+## 3. Boucle servo-mode
 
 ```mermaid
 graph TB
-    subgraph "ENTRÉE Servo Mode"
-        Start([poetry run workflow-coach --servo-mode])
-        Start --> Parse[main lines 2392-2410]
-        Parse --> Constructor[__init__ line 42-64]
-        Constructor --> LoadTemplates[load_workout_templates lines 91-119]
-        LoadTemplates --> Template1[recovery_active_30tss.json]
-        LoadTemplates --> Template6[sweetspot_short_50tss.json]
-        Template6 --> WorkflowRun[run line 2175-2260]
-        WorkflowRun --> Step6b[step_6b_servo_control lines 1855-2024]
+    subgraph "Entree"
+        Start([poetry run workflow-coach --servo-mode --week-id SXXX])
+        Start --> SC[ServoControlMixin]
     end
 
-    subgraph "CHARGEMENT Planning"
-        Step6b --> DetectWeek[Détection week_id lines 1878-1887]
-        DetectWeek --> LoadSessions[load_remaining_sessions lines 1891-1912]
-        LoadSessions --> ReadJSON[Lecture week_planning_S072.json]
-        ReadJSON --> FilterFuture[Filtre sessions date >= today]
-        FilterFuture --> Display[Affichage sessions restantes]
-        Display --> UserPrompt{Demander recommandations AI? line 1917}
+    subgraph "Lecture planning"
+        SC --> CT[PlanningControlTower.read_week]
+        CT --> Filter[Filtre sessions date >= today]
+        Filter --> HasSessions{Sessions futures ?}
+        HasSessions -->|Non| End1([Aucune modification possible])
     end
 
-    subgraph "GÉNÉRATION Prompt Asservissement"
-        UserPrompt -->|Oui| FormatCompact[format_remaining_sessions_compact lines 154-183]
-        FormatCompact --> BuildPrompt[Construction prompt lines 1927-1971]
-
-        BuildPrompt --> Header[# ASSERVISSEMENT PLANNING]
-        BuildPrompt --> Context[Contexte: planning restant]
-        BuildPrompt --> Catalog[Catalogue templates lignes 1932-1946]
-
-        Catalog --> RecGroup[RÉCUPÉRATION: 3 templates]
-        Catalog --> EndGroup[ENDURANCE ALLÉGÉE: 2 templates]
-        Catalog --> IntGroup[INTENSITÉ RÉDUITE: 1 template]
-
-        BuildPrompt --> Criteria[Critères décision lignes 1948-1956]
-        Criteria --> HRV[HRV < -10%]
-        Criteria --> RPE[RPE > 8/10]
-        Criteria --> Decoupling[Découplage > 7.5%]
-        Criteria --> Sleep[Sommeil < 7h]
-
-        BuildPrompt --> JSONFormat[Format JSON lignes 1958-1967]
-        JSONFormat --> PromptReady[Prompt complet]
+    subgraph "Prompt AI"
+        HasSessions -->|Oui| Format[Format compact planning restant]
+        Format --> Build[Construction prompt asservissement]
+        Build --> Catalog[Catalogue templates remplacement]
+        Build --> Criteria[Criteres decision : HRV, RPE, decouplage, sommeil]
+        Build --> JSONSpec[Format JSON attendu]
+        Catalog --> PromptReady[Prompt complet]
+        Criteria --> PromptReady
+        JSONSpec --> PromptReady
     end
 
-    subgraph "INTERACTION Utilisateur"
-        PromptReady --> Clipboard[copy_to_clipboard lines 1975-1979]
-        Clipboard --> Instructions[Affichage instructions lignes 1981-1990]
-        Instructions --> WaitUser[Attente réponse utilisateur ligne 1991]
-        WaitUser --> Pbpaste[pbpaste récupération ligne 2000-2006]
-        Pbpaste --> AIResponse[Réponse AI copiée]
+    subgraph "Interaction AI"
+        PromptReady --> Provider{AI Provider}
+        Provider -->|clipboard| Clipboard[pbcopy + pbpaste]
+        Provider -->|claude_api| API[Appel API direct]
+        Clipboard --> Response[Reponse AI]
+        API --> Response
     end
 
-    subgraph "PARSING Modifications"
-        AIResponse --> ParseMods[parse_ai_modifications lines 185-211]
-        ParseMods --> RegexJSON[Regex extraction JSON lines 197-200]
-        RegexJSON --> JSONParse[json.loads lines 206-208]
-        JSONParse --> CheckEmpty{Liste vide? line 2015}
+    subgraph "Parsing modifications"
+        Response --> Parse[ServoControlMixin.parse_ai_modifications]
+        Parse --> Regex[Extraction JSON via regex]
+        Regex --> HasMods{Modifications proposees ?}
+        HasMods -->|Non| NoChange([Planning maintenu])
     end
 
-    subgraph "APPLICATION Modifications"
-        CheckEmpty -->|Non| ApplyLoop[apply_planning_modifications lines 484-509]
-        ApplyLoop --> ForEachMod{Pour chaque modification}
+    subgraph "Application modifications"
+        HasMods -->|Oui| Loop{Pour chaque modification}
 
-        ForEachMod --> CheckAction{action type? line 499}
-        CheckAction -->|lighten| ApplyLighten[_apply_lighten lines 414-482]
-        CheckAction -->|cancel| TODO1[TODO: Implémenter]
-        CheckAction -->|reschedule| TODO2[TODO: Implémenter]
+        Loop --> Action{Type action}
+        Action -->|lighten| Lighten[ServoControlMixin._apply_lighten]
+        Action -->|cancel| Cancel[Conversion WORKOUT vers NOTE]
+        Action -->|reschedule| Reschedule[Deplacement session]
 
-        ApplyLighten --> ValidateTemplate[Validation template lignes 421-425]
-        ValidateTemplate --> DisplayMod[Affichage modification lignes 429-432]
-        DisplayMod --> UserConfirm{Confirmation utilisateur ligne 435-438}
+        Lighten --> Confirm{Confirmation utilisateur}
+        Cancel --> Confirm
+        Reschedule --> Confirm
 
-        UserConfirm -->|Oui| ExtractDay[_extract_day_number lignes 213-237]
-        ExtractDay --> GenCode[Génération workout_code lignes 440-445]
-        GenCode --> GetOldID[_get_workout_id_intervals lignes 239-273]
-        GetOldID --> DeleteOld[_delete_workout_intervals lignes 275-305]
-        DeleteOld --> UploadNew[_upload_workout_intervals lignes 307-346]
-        UploadNew --> UpdateJSON[_update_planning_json lignes 348-412]
-        UpdateJSON --> NextMod{Autre modification?}
+        Confirm -->|Non| Skip[Modification ignoree]
+        Confirm -->|Oui| Delete[IntervalsClient : DELETE ancien workout]
+        Delete --> Upload[IntervalsClient : POST nouveau workout]
+        Upload --> Update[PlanningControlTower.modify_week]
+        Update --> History[Ajout entree historique + version++]
 
-        UserConfirm -->|Non| SkipMod[Modification ignorée]
-        SkipMod --> NextMod
-
-        NextMod -->|Oui| ForEachMod
-        NextMod -->|Non| Complete[Modifications appliquées]
+        Skip --> Next{Autre modification ?}
+        History --> Next
+        Next -->|Oui| Loop
+        Next -->|Non| Save([Planning sauvegarde])
     end
-
-    CheckEmpty -->|Oui| NoChange[Planning maintenu ligne 2015-2018]
-    Complete --> End([Fin servo mode])
-    NoChange --> End
 ```
 
 ---
 
-## 4. CHAÎNE COMPLÈTE - Prompt → AI → Validation → Upload API
+## 4. Pipeline end-of-week
 
 ```mermaid
-graph LR
-    subgraph "1. PROMPT"
-        P1[Template Catalog]
-        P2[Planning Context]
-        P3[Decision Criteria]
-        P4[JSON Format Spec]
-        P1 --> Prompt[Complete Prompt]
-        P2 --> Prompt
-        P3 --> Prompt
-        P4 --> Prompt
+graph TB
+    subgraph "Etape 1 : Analyse semaine"
+        Start([poetry run end-of-week --auto])
+        Start --> A1[AnalysisMixin._step1_analyze_completed_week]
+        A1 --> LoadReports[Chargement rapports quotidiens]
+        LoadReports --> LoadWellness[Chargement wellness semaine]
+        LoadWellness --> Stats[Calcul statistiques : adherence, TSS, zones]
     end
 
-    subgraph "2. AI"
-        Prompt --> Claude[Claude.ai]
-        Claude --> Analysis[Natural Language Analysis]
-        Claude --> JSON[JSON Block]
-        JSON --> ModArray["modifications: []"]
+    subgraph "Etape 2 : Evaluation PID"
+        Stats --> E1[EvaluationMixin._step1b_pid_evaluation]
+        E1 --> PID[Calcul ecart TSS cible vs realise]
+        PID --> FTP[Correction FTP si necessaire]
+        FTP --> Reco[Recommandations charge S+1]
     end
 
-    subgraph "3. PARSE"
-        ModArray --> Regex[Regex Extraction]
-        Regex --> Deserialize[json.loads]
-        Deserialize --> ModList[List of Dicts]
+    subgraph "Etape 3 : Generation planning AI"
+        Reco --> AI1[AIWorkoutsMixin._step2_generate_planning_prompt]
+        AI1 --> PB[PromptBuilder.build_prompt mission=weekly_planning]
+        PB --> AI2[AIWorkoutsMixin._step3_get_ai_workouts]
+        AI2 --> Provider{AI Provider}
+        Provider -->|claude_api| Claude[Claude API]
+        Provider -->|mistral_api| Mistral[Mistral API]
+        Provider -->|clipboard| Manual[Copie manuelle]
+        Claude --> Workouts[7 workouts generes]
+        Mistral --> Workouts
+        Manual --> Workouts
     end
 
-    subgraph "4. VALIDATE"
-        ModList --> CheckTemplate{Template exists?}
-        CheckTemplate -->|No| Error[Erreur template]
-        CheckTemplate -->|Yes| LoadTemplate[Load Template JSON]
-        LoadTemplate --> CheckFields{Required fields?}
-        CheckFields --> ValidateType{type in VALID_TYPES?}
-        ValidateType --> UserConfirm{User confirmation?}
+    subgraph "Etape 4-5 : Validation et upload"
+        Workouts --> V1[UploadMixin._step4_validate_workouts]
+        V1 --> Valid{Validation OK ?}
+        Valid -->|Non| Retry[Retry avec autre provider]
+        Valid -->|Oui| U1[UploadMixin._step5_upload_to_intervals]
+        U1 --> Sync[event_sync.evaluate_sync par session]
+        Sync --> API[IntervalsClient : POST /events]
+        API --> JSON[UploadMixin._step6_save_planning_json]
     end
 
-    subgraph "5. TRANSFORM"
-        UserConfirm -->|Yes| ExtractDay[Extract day_num]
-        ExtractDay --> FormatCode[Format workout_code]
-        FormatCode --> BuildEvent[Build event dict]
-        BuildEvent --> EventStruct{
-            category: WORKOUT
-            name: code
-            workout_doc: intervals_icu_format
-            start_date_local: dateT06:00:00
-        }
+    subgraph "Etape 6 : Archive et commit"
+        JSON --> AR[ArchiveMixin._step6_archive_and_commit]
+        AR --> Archive[Archive rapports S-1]
+        Archive --> Git[Git commit + push data repo]
+        Git --> Summary[ArchiveMixin._print_success_summary]
+        Summary --> End([Semaine bouclée])
+    end
+```
+
+---
+
+## 5. Pipeline daily-sync
+
+Chaine automatisee quotidienne via LaunchAgents.
+
+```mermaid
+graph TB
+    subgraph "21:00 Withings pre-sync"
+        T1([LaunchAgent 21:00])
+        T1 --> WP[withings_presync.sync_withings_to_intervals]
+        WP --> Sleep[Sync sommeil hier + aujourd'hui]
+        WP --> Weight[Sync poids hier + aujourd'hui]
+        Sleep --> Intervals1[IntervalsClient : PUT /wellness]
+        Weight --> Intervals1
     end
 
-    subgraph "6. UPLOAD API"
-        EventStruct --> DeleteOld[DELETE old workout]
-        DeleteOld --> CreateNew[POST /api/v1/athlete/ID/events]
-        CreateNew --> APIResponse{Success?}
-        APIResponse -->|Yes| UpdateJSON[Update planning JSON]
-        APIResponse -->|No| Rollback[Error no rollback]
+    subgraph "21:30 Daily Sync"
+        Intervals1 -.-> T2([LaunchAgent 21:30])
+        T2 --> DS[DailySync.run]
+        DS --> AD[ActivityDetectionMixin._detect_duplicate_activities]
+        AD --> SU[SessionUpdatesMixin.check_planning_changes]
+        SU --> AI[AIAnalysisMixin : analyse automatique]
+        AI --> Email[Envoi rapport email]
+        AI --> SE[ServoEvaluationMixin.extract_metrics_from_activity]
+        SE --> AutoServo{Servo auto active ?}
+        AutoServo -->|Oui| Servo[Declenchement servo-mode]
+        AutoServo -->|Non| Report[ReportingMixin : generation rapport quotidien]
     end
 
-    UpdateJSON --> History[Add history entry]
-    History --> IncrementVersion[Increment version]
-    IncrementVersion --> SaveFile[Save JSON file]
+    subgraph "22:00 Adherence check"
+        Report -.-> T3([LaunchAgent 22:00])
+        T3 --> Check[Verification adherence planning]
+    end
+
+    subgraph "23:00 PID Evaluation"
+        Check -.-> T4([LaunchAgent 23:00])
+        T4 --> PID[pid_daily_evaluation]
+        PID --> CTL[CTLPeaksMixin.analyze_ctl_peaks]
+        CTL --> End([Fin chaine quotidienne])
+    end
 ```
 
 ---
 
-## 5. FICHIERS IMPLIQUÉS - Index Complet
+## 6. Services transverses
 
-### 5.1 Scripts Principaux
+```mermaid
+graph TB
+    subgraph "Control Tower"
+        CT[PlanningControlTower]
+        CT --> Read[read_week : lecture seule]
+        CT --> Modify[modify_week : context manager]
+        Modify --> Backup[Backup automatique]
+        Modify --> Audit[Audit JSONL : WHO/WHY/WHEN/WHAT]
+        Modify --> Permission[Verification permissions]
+    end
 
-| Fichier | Lignes | Responsabilité | Points Clés |
-|---------|--------|----------------|-------------|
-| **magma_cycling/weekly_planner.py** | 592 | Génération planning hebdomadaire | Lines 173-473: generate_planning_prompt()<br>Lines 226-245: Règles format Intervals.icu<br>Lines 288-298: VALID_TYPES<br>Lines 484-527: run() |
-| **magma_cycling/workflow_coach.py** | 2370 | Orchestration analyse + servo mode | Lines 1855-2024: step_6b_servo_control()<br>Lines 414-482: _apply_lighten()<br>Lines 307-346: _upload_workout_intervals()<br>Lines 185-211: parse_ai_modifications() |
-| **magma_cycling/prepare_analysis.py** | 1200+ | API Intervals.icu | Lines 108-146: create_event()<br>Lines 148-171: get_events()<br>Lines 173-195: get_activities() |
-| **magma_cycling/rest_and_cancellations.py** | 589 | Validation planning | Line 41: VALID_STATUSES<br>Line 42: VALID_TYPES<br>Lines 49-86: load_week_planning()<br>Lines 88-132: validate_week_planning() |
+    subgraph "Prompt Builder"
+        PBuild[prompt_builder.build_prompt]
+        PBuild --> Mission{Mission}
+        Mission -->|daily_feedback| DailyPrompt[Prompt analyse seance]
+        Mission -->|weekly_planning| WeeklyPrompt[Prompt planning hebdo]
+        PBuild --> Profile[format_athlete_profile]
+        PBuild --> Metrics[load_current_metrics : FTP, CTL, ATL]
+        PBuild --> System[base_system.txt + mission file]
+    end
 
-### 5.2 Données et Templates
+    subgraph "Event Sync"
+        ESSync[event_sync]
+        ESSync --> Eval[evaluate_sync : decision sync]
+        ESSync --> Hash[calculate_description_hash]
+        ESSync --> Time[compute_start_time]
+        Eval --> Decision{SyncDecision}
+        Decision --> Create[CREATE : nouveau workout]
+        Decision --> Update[UPDATE : workout modifie]
+        Decision --> Skip[SKIP : deja a jour]
+    end
 
-| Fichier | Format | Usage |
-|---------|--------|-------|
-| **data/workout_templates/*.json** | JSON | 6 templates de remplacement servo mode |
-| **data/week_planning/week_planning_SXXX.json** | JSON | Planning hebdomadaire avec statuts |
-| **references/project_prompt_v2_1_revised.md** | Markdown | Contexte athlète (FTP, objectifs) |
-| **references/cycling_training_concepts.md** | Markdown | Zones Z1-Z7, TSS/IF/NP |
-| **logs/workout-templates.md** | Markdown | Exemples formats validés |
-| **logs/weekly_reports/SXXX/bilan_final_SXXX.md** | Markdown | Bilan semaine précédente |
+    subgraph "AI Providers"
+        APF[AIProviderFactory]
+        APF --> Claude[claude_api]
+        APF --> Mistral[mistral_api]
+        APF --> OpenAI[openai_api]
+        APF --> Ollama[ollama]
+        APF --> Clip[clipboard]
+    end
 
-### 5.3 Configuration
-
-| Fichier | Usage |
-|---------|-------|
-| **~/.intervals_config.json** | Credentials API (athlete_id, api_key) |
-| **pyproject.toml** | CLI commands registration (lines 51-57) |
-| **.workflow_state.json** | État workflow (dernière activité analysée) |
-
----
-
-## 6. POINTS CRITIQUES - Injection Corrections
-
-### 6.1 BUG CRITIQUE: "workout_doc" vs "description"
-
-**Localisation**: `workflow_coach.py` ligne 336
-
-**Code Actuel**:
-```python
-event = {
-    "category": "WORKOUT",
-    "start_date_local": f"{date}T06:00:00",
-    "name": code,
-    "description": code,
-    "workout_doc": structure  # ⚠️ PROBLÈME ICI
-}
-```
-
-**Documentation API** (`prepare_analysis.py` ligne 116):
-```python
-Args:
-    event_data: Dictionnaire contenant :
-        - category: "WORKOUT"
-        - name: Nom du workout
-        - description: Contenu au format Intervals.icu  # ⬅️ Devrait être ici
-        - start_date_local: Date au format YYYY-MM-DD
-```
-
-**Correction P0 #6**: Changer `workout_doc` en `description`
-```python
-event = {
-    "category": "WORKOUT",
-    "start_date_local": f"{date}T06:00:00",
-    "name": code,
-    "description": structure,  # ✅ CORRECTION
-}
-```
-
-**Impact**: Upload workouts échoue ou format mal interprété par Intervals.icu
-
----
-
-### 6.2 BUG FORMAT: Blocs Répétés "Test capacité 3x"
-
-**Symptôme**: Génération de "Test capacité 3x" au lieu de "3x" seul
-
-**Format Attendu** (weekly_planner.py ligne 239):
-```
-Main set 3x
-- 10m 90% 92rpm
-- 4m 62% 85rpm
-```
-
-**Format Incorrect Produit**:
-```
-Test capacité 3x
-- 10m 90% 92rpm
-- 4m 62% 85rpm
-```
-
-**Analyse Root Cause**:
-- Templates JSON contiennent format correct (vérification faite)
-- Prompt `weekly_planner.py` ligne 226-245 documente correctement
-- Problème probable: Claude.ai génère label + "3x" ensemble
-
-**Point d'Injection P0 #7**: Ajouter validation post-génération
-
-**Localisation**: Après `generate_planning_prompt()`, avant copie clipboard
-
-**Nouveau code à ajouter** (ligne 474 dans `weekly_planner.py`):
-```python
-def validate_intervals_format(self, prompt: str) -> str:
-    """
-    Valider et corriger format blocs répétés
-
-    Corrige: "Test capacité 3x" → "3x"
-    Corrige: "Main set Test 3x" → "Main set 3x"
-    """
-    import re
-
-    # Pattern: Trouve lignes avec texte + "3x" ou "2x" etc
-    pattern = r'^(.*?)\s+(\d+x)\s*$'
-
-    lines = prompt.split('\n')
-    corrected = []
-
-    for line in lines:
-        match = re.match(pattern, line)
-        if match:
-            prefix = match.group(1).strip()
-            repetition = match.group(2)
-
-            # Si prefix contient "Main set", "Warmup", "Cooldown" → OK
-            # Sinon, ne garder que le répétition marker
-            valid_prefixes = ['Main set', 'Warmup', 'Cooldown', 'Block']
-
-            if any(vp in prefix for vp in valid_prefixes):
-                corrected.append(f"{prefix} {repetition}")
-            else:
-                # Supprimer label parasite
-                corrected.append(repetition)
-        else:
-            corrected.append(line)
-
-    return '\n'.join(corrected)
-```
-
-**Intégration** (ligne 469):
-```python
-prompt = self.generate_planning_prompt()
-prompt = self.validate_intervals_format(prompt)  # ⬅️ NOUVELLE LIGNE
-self.copy_to_clipboard(prompt)
+    subgraph "Intervals.icu Client"
+        IC[IntervalsClient]
+        IC --> GetAth[get_athlete]
+        IC --> GetAct[get_activities]
+        IC --> GetWell[get_wellness]
+        IC --> GetEvt[get_events]
+        IC --> CreateEvt[create_event]
+        IC --> UpdateWell[update_wellness]
+    end
 ```
 
 ---
 
-### 6.3 Validation VALID_TYPES
+## Conventions
 
-**Localisation**: `rest_and_cancellations.py` ligne 42
-
-**Valeur Actuelle** (corrigée Phase 2):
-```python
-VALID_TYPES = ['END', 'INT', 'FTP', 'SPR', 'CLM', 'REC', 'FOR', 'CAD', 'TEC', 'MIX', 'PDC', 'TST']
-```
-
-**Point d'injection validation**: `validate_week_planning()` ligne 88-132
-
-**Code de validation** (lignes 110-116):
-```python
-for session in week_planning['planned_sessions']:
-    # Validation type
-    if session['type'] not in VALID_TYPES:
-        errors.append(
-            f"Session {session['session_id']} : type '{session['type']}' invalide. "
-            f"Types valides : {', '.join(VALID_TYPES)}"
-        )
-```
-
-**Status**: ✅ Déjà implémenté et corrigé
+- **Nommage noeuds** : `MixinName.method()` (pas de numeros de ligne)
+- **Subgraphs** : par phase fonctionnelle
+- **Liens pointilles** : dependances inter-services (non bloquantes)
+- **Liens pleins** : flux de donnees principal
 
 ---
 
-### 6.4 Validation Format Intervals.icu dans Templates
-
-**Point d'injection**: `load_workout_templates()` ligne 91-119
-
-**Validation à ajouter** (après ligne 107):
-```python
-def validate_template_format(self, template: dict) -> bool:
-    """
-    Valider format Intervals.icu dans template
-
-    Vérifie:
-    - Pas de markdown (**, ###, etc)
-    - Sections valides (Warmup, Main set, Cooldown)
-    - Format répétitions "Nx" seul
-    """
-    format_str = template.get('intervals_icu_format', '')
-
-    # Check 1: Pas de markdown
-    if '**' in format_str or '###' in format_str:
-        print(f"⚠️  Template {template['id']}: contient markdown")
-        return False
-
-    # Check 2: Répétitions format correct
-    import re
-    lines = format_str.split('\n')
-    for line in lines:
-        # Détecter "texte 3x" (incorrect)
-        if re.search(r'[a-zA-Z]\s+\d+x\s*$', line):
-            # Vérifier si c'est "Main set 3x" (OK) ou "Test 3x" (NOK)
-            if not any(prefix in line for prefix in ['Main set', 'Block']):
-                print(f"⚠️  Template {template['id']}: format répétition incorrect: {line}")
-                return False
-
-    return True
-```
-
-**Intégration** (ligne 109):
-```python
-with open(template_path, 'r', encoding='utf-8') as f:
-    template = json.load(f)
-
-    # NOUVELLE VALIDATION
-    if not self.validate_template_format(template):
-        print(f"❌ Template {template_path.name} : format invalide")
-        continue
-
-    self.workout_templates[template['id']] = template
-```
-
----
-
-## 7. RÉSUMÉ - Points d'Injection P0 #6 et #7
-
-### P0 #6: Correction champ API "workout_doc" → "description"
-
-| Composant | Fichier | Ligne | Action |
-|-----------|---------|-------|--------|
-| Upload workout | workflow_coach.py | 336 | Renommer `"workout_doc"` en `"description"` |
-| Documentation API | prepare_analysis.py | 116 | Vérifier cohérence docs |
-
-**Priorité**: P0 - CRITIQUE
-**Effort**: 2 minutes
-**Test**: Upload workout via servo mode
-
----
-
-### P0 #7: Validation format blocs répétés
-
-| Composant | Fichier | Ligne | Action |
-|-----------|---------|-------|--------|
-| Post-generation validation | weekly_planner.py | 474 | Ajouter `validate_intervals_format()` |
-| Template loading validation | workflow_coach.py | 109 | Ajouter `validate_template_format()` |
-| Prompt clarification | weekly_planner.py | 239-245 | Renforcer instruction "3x SEUL" |
-
-**Priorité**: P0 - CRITIQUE
-**Effort**: 30 minutes
-**Test**: Générer planning + vérifier format répétitions
-
----
-
-## 8. FLUX DONNÉES - Schéma Complet
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│ GÉNÉRATION PLANNING (weekly-planner.py)                         │
-├──────────────────────────────────────────────────────────────────┤
-│ Inputs:                                                           │
-│   • Metrics API (CTL, ATL, TSB, HRV)                             │
-│   • Bilan S-1 (logs/weekly_reports/S071/bilan_final_S071.md)    │
-│   • Références (project_prompt, concepts, protocols)             │
-│                                                                   │
-│ Processing:                                                       │
-│   • Prompt construction (~15-20k tokens)                         │
-│   • Format Intervals.icu specification                           │
-│   • Naming convention SSSS-JJ-TYPE-Name-V001                    │
-│                                                                   │
-│ Outputs:                                                          │
-│   • Prompt copié clipboard                                       │
-│   • User paste to Claude.ai                                      │
-│   • Claude generates 7 WORKOUT blocks                            │
-│   • User uploads to Intervals.icu manually                       │
-│   • Creation week_planning_SXXX.json                             │
-└──────────────────────────────────────────────────────────────────┘
-                              ↓
-┌──────────────────────────────────────────────────────────────────┐
-│ ANALYSE SÉANCE (workflow-coach.py)                              │
-├──────────────────────────────────────────────────────────────────┤
-│ Inputs:                                                           │
-│   • Activity data from Intervals.icu API                         │
-│   • Week planning JSON                                           │
-│   • Activity streams (power, HR, cadence)                        │
-│                                                                   │
-│ Processing:                                                       │
-│   • Analysis metrics (NP, IF, VI, TSS)                           │
-│   • Cardiac decoupling calculation                               │
-│   • Report generation (markdown)                                 │
-│                                                                   │
-│ Outputs:                                                          │
-│   • Analysis markdown report                                     │
-│   • Git commit                                                   │
-│   • Workflow state update                                        │
-└──────────────────────────────────────────────────────────────────┘
-                              ↓ (if --servo-mode)
-┌──────────────────────────────────────────────────────────────────┐
-│ MODIFICATIONS PLANNING (servo mode)                             │
-├──────────────────────────────────────────────────────────────────┤
-│ Inputs:                                                           │
-│   • Remaining sessions from week_planning_SXXX.json              │
-│   • Workout templates catalog (6 templates)                      │
-│   • Activity analysis (fatigue signals)                          │
-│                                                                   │
-│ Processing:                                                       │
-│   • AI prompt with planning context                              │
-│   • Parse AI modifications (JSON extraction)                     │
-│   • User confirmation per modification                           │
-│   • Delete old workout from API                                  │
-│   • Upload new workout to API                                    │
-│   • Update planning JSON with history                            │
-│                                                                   │
-│ Outputs:                                                          │
-│   • Modified week_planning_SXXX.json (version++)                 │
-│   • Updated workouts on Intervals.icu                            │
-│   • History entries in JSON                                      │
-└──────────────────────────────────────────────────────────────────┘
-```
-
----
-
-## 9. COMMANDES CLI - Référence Rapide
-
-```bash
-# Génération planning hebdomadaire
-poetry run weekly-planner S072 --start-date 2025-12-16
-
-# Analyse séance simple
-poetry run workflow-coach
-
-# Analyse séance avec servo mode
-poetry run workflow-coach --servo-mode --week-id S072
-
-# Réconciliation batch
-poetry run workflow-coach --reconcile --week-id S072
-
-# Analyse activité spécifique
-poetry run workflow-coach --activity-id i107779437
-
-# Mode skip (tests)
-poetry run workflow-coach --skip-feedback --skip-git
-```
-
----
-
-## 10. PROCHAINES ÉTAPES - Corrections P0 #6 et #7
-
-### Étape 1: Correction champ API (P0 #6)
-```bash
-# 1. Modifier workflow_coach.py ligne 336
-# 2. Tester upload workout
-poetry run workflow-coach --servo-mode --week-id S072
-```
-
-### Étape 2: Validation format répétitions (P0 #7)
-```bash
-# 1. Ajouter validate_intervals_format() dans weekly_planner.py
-# 2. Ajouter validate_template_format() dans workflow_coach.py
-# 3. Tester génération planning
-poetry run weekly-planner S073 --start-date 2025-12-23
-```
-
-### Étape 3: Tests Validation
-```bash
-# Créer tests/test_intervals_format.py
-poetry run pytest tests/test_intervals_format.py -v
-```
-
----
-
-**Status**: 📋 GRAFCET COMPLET
-**Prêt pour**: Implémentation corrections P0 #6 et #7
+**Date** : Mars 2026
+**Version** : 2.0

--- a/project-docs/workflows/README.md
+++ b/project-docs/workflows/README.md
@@ -1,24 +1,116 @@
-# Workflows Documentation
+# Workflows - Hub d'Onboarding
 
-Documentation des workflows quotidiens et hebdomadaires du projet.
+**Version** : 2.0
+**Date** : Mars 2026
 
-## Fichiers
+---
 
-### DAILY_WORKFLOW.md
-Documentation complète du workflow quotidien avec 4 modes:
-- `train` - Workflow standard
-- `trains` - Avec asservissement planning
-- `train-fast` - Mode rapide
-- `trainr` - Réconciliation batch
+## Quick Start - Sequence hebdomadaire
 
-### GRAFCET_WORKFLOW_COMPLET.md
-Diagrammes Grafcet complets montrant:
-- Flux génération planning
-- Flux servo-mode
-- Points critiques P0
+```bash
+# Lundi matin : cycle hebdomadaire
+wa --week-id S084                              # Analyse semaine passee
+wp --week-id S085 --start-date 2026-03-16      # Planning semaine courante
+wu --week-id S085                              # Upload workouts Intervals.icu
 
-### UML_ACTIVITY_DIAGRAMS.md
-Diagrammes d'activité UML détaillés:
-- Génération & Upload Workout
-- Servo-Mode Modifications
-- Annotations fichier:ligne pour chaque étape
+# Quotidien : apres chaque seance
+train                                          # Analyse standard
+trains --week-id S085                          # Avec asservissement (Mer/Ven)
+
+# Dimanche soir
+trainr --week-id S085                          # Reconciliation si necessaire
+```
+
+---
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "6 Facades"
+        WC[WorkflowCoach<br/>workflow_coach.py]
+        DS[DailySync<br/>daily_sync.py]
+        WP[WeeklyPlanner<br/>weekly_planner.py]
+        UW[WorkoutUploader<br/>upload_workouts.py]
+        PG[PromptGenerator<br/>prepare_analysis.py]
+        EOW[EndOfWeekWorkflow<br/>workflows/end_of_week.py]
+    end
+
+    subgraph "Repertoires mixins"
+        WC --- CM[workflows/coach/ - 11 mixins]
+        DS --- SM[workflows/sync/ - 7 mixins]
+        WP --- PM[workflows/planner/ - 4 mixins]
+        UW --- UM[workflows/uploader/ - 3 mixins]
+        PG --- PRM[workflows/prompt/ - 4 mixins]
+        EOW --- EM[workflows/eow/ - 5 mixins]
+    end
+
+    subgraph "Services transverses"
+        CT[PlanningControlTower]
+        PBuild[PromptBuilder]
+        ES[EventSync]
+        IC[IntervalsClient]
+        APF[AIProviderFactory]
+    end
+```
+
+---
+
+## Documentation
+
+| Document | Audience | Quand le lire |
+|----------|----------|---------------|
+| [DAILY_WORKFLOW.md](DAILY_WORKFLOW.md) | Utilisateur | Routine quotidienne : quel workflow utiliser apres chaque seance |
+| [WORKFLOW_COMPLET.md](WORKFLOW_COMPLET.md) | Developpeur | Reference technique : architecture WorkflowCoach, 11 mixins, providers AI |
+| [GRAFCET_WORKFLOW_COMPLET.md](GRAFCET_WORKFLOW_COMPLET.md) | Developpeur | 6 diagrammes Mermaid : vues systeme, pipelines, services transverses |
+| [UML_ACTIVITY_DIAGRAMS.md](UML_ACTIVITY_DIAGRAMS.md) | Developpeur | 4 diagrammes de detail : flux analyse, upload, servo, end-of-week |
+| [../MCP_INTEGRATION.md](../MCP_INTEGRATION.md) | Developpeur | Integration MCP : 48 tools exposes a Claude Desktop |
+
+---
+
+## Commandes CLI principales
+
+| Alias | Commande | Description |
+|-------|----------|-------------|
+| `train` | `poetry run workflow-coach` | Analyse standard post-seance |
+| `trains` | `poetry run workflow-coach --servo-mode` | Analyse + asservissement planning |
+| `train-fast` | `poetry run workflow-coach --skip-feedback --skip-git` | Analyse rapide sans feedback |
+| `trainr` | `poetry run workflow-coach --reconcile` | Reconciliation seances manquees |
+| `wa` | `poetry run weekly-analysis` | Analyse hebdomadaire |
+| `wp` | `poetry run weekly-planner` | Generation planning hebdomadaire |
+| `wu` | `poetry run upload-workouts` | Upload workouts vers Intervals.icu |
+| `check` | `poetry run planned-checker` | Verification planning semaine |
+| `ds` | `poetry run daily-sync` | Synchronisation quotidienne |
+| `eow` | `poetry run end-of-week` | Workflow fin de semaine |
+
+---
+
+## Automation LaunchAgents
+
+### Chaine quotidienne
+| Heure | Service | Description |
+|-------|---------|-------------|
+| 21:00 | `withings-presync` | Sync sante Withings vers Intervals.icu |
+| 21:30 | `daily-sync` | Sync activites + analyse AI + servo auto |
+| 22:00 | `adherence-check` | Verification adherence planning |
+| 23:00 | `pid-evaluation` | Evaluation PID quotidienne |
+
+### Dimanche
+| Heure | Service | Description |
+|-------|---------|-------------|
+| 20:00 | `end-of-week` | Boucle semaine + planning S+1 automatique |
+
+---
+
+## Liens utiles
+
+- [AUTOMATION.md](../AUTOMATION.md) : Configuration LaunchAgents
+- [COMMANDS.md](../COMMANDS.md) : Reference complete des commandes CLI
+- [ARCHITECTURE.md](../ARCHITECTURE.md) : Architecture technique du projet
+- [MCP_INTEGRATION.md](../MCP_INTEGRATION.md) : Integration MCP (48 tools)
+- [CONTROL_TOWER.md](../CONTROL_TOWER.md) : Systeme de controle planning
+
+---
+
+**Version** : 2.0
+**Date** : Mars 2026

--- a/project-docs/workflows/UML_ACTIVITY_DIAGRAMS.md
+++ b/project-docs/workflows/UML_ACTIVITY_DIAGRAMS.md
@@ -1,590 +1,294 @@
-# DIAGRAMMES UML ACTIVITÉ - Corrections P0 Focus
+# Diagrammes d'activite - Magma Cycling
 
-**Date**: 2025-12-21
-**Scope**: Workflow génération/upload workouts + servo mode
-**Annotations**: fichier:ligne pour chaque point critique
+**Date** : Mars 2026
+**Version** : 2.0
+**Architecture** : Post-refactoring Phase 3 (facades + mixins)
 
 ---
 
-## Diagramme 1 : Génération & Upload Workout
+## 1. Flux analyse de seance (WorkflowCoach)
 
-### Vue d'ensemble
-Ce diagramme montre le flux complet de génération d'un workout hebdomadaire, avec focus sur les 3 points d'injection des corrections P0 (#6, #7, #8).
+Pipeline complet depuis la detection d'activites jusqu'au commit git.
 
 ```mermaid
 graph TB
-    Start([Utilisateur lance weekly-planner S072])
+    Start([poetry run workflow-coach])
 
-    subgraph "PHASE 1: Collection Données"
-        Start --> Init[__init__ weekly_planner.py:47-65<br/>Initialisation WeeklyPlanner]
-        Init --> Run[run weekly_planner.py:484-527<br/>Orchestration workflow]
-        Run --> CollectMetrics[collect_current_metrics<br/>weekly_planner.py:67-116<br/>API GET /wellness]
-        CollectMetrics --> Metrics{Métriques OK?}
-        Metrics -->|Non| ErrorMetrics[Erreur: Credentials invalides]
-        Metrics -->|Oui| DataMetrics[CTL, ATL, TSB, HRV, HR]
-
-        DataMetrics --> LoadBilan[load_previous_week_bilan<br/>weekly_planner.py:118-131<br/>Lecture S071 bilan]
-        LoadBilan --> BilanExists{Bilan S-1 existe?}
-        BilanExists -->|Non| NoBilan[Bilan vide]
-        BilanExists -->|Oui| BilanData[Contenu bilan S-1]
-
-        BilanData --> LoadContext[load_context_files<br/>weekly_planner.py:133-171]
-        NoBilan --> LoadContext
-        LoadContext --> ContextFiles[project_prompt_v2_1<br/>cycling_concepts<br/>protocols]
+    subgraph "Detection"
+        Start --> Gap[GapDetectionMixin.step_1b_detect_all_gaps]
+        Gap --> DetectAct[_detect_unanalyzed_activities]
+        DetectAct --> DetectSkip[_detect_skipped_sessions]
+        DetectSkip --> DetectRest[_detect_rest_and_cancelled_sessions]
+        DetectRest --> Menu[_prompt_user_choice]
+        Menu --> Choice{Nombre activites}
+        Choice -->|0| NoActivity([Aucune activite a analyser])
+        Choice -->|1| Single[Analyse directe]
+        Choice -->|2+| Batch[Menu : derniere / choisir / batch]
     end
 
-    subgraph "PHASE 2: Génération Prompt"
-        ContextFiles --> GenPrompt[generate_planning_prompt<br/>weekly_planner.py:173-473]
-
-        GenPrompt --> Section1[Contexte Athlète<br/>lines 181-210]
-        GenPrompt --> Section2[Période Planning<br/>lines 211-222]
-        GenPrompt --> Section3[État Actuel<br/>lines 224-256]
-
-        Section3 --> Section4[Guide Intervals.icu<br/>lines 226-265]
-
-        Section4 --> ValidTypes["⚠️ P0 #8: VALID_TYPES<br/>weekly_planner.py:285<br/>END, INT, FTP, SPR, CLM,<br/>REC, FOR, CAD, TEC, MIX, PDC, TST"]
-        ValidTypes:::p0fix
-
-        ValidTypes --> RepFormat["⚠️ P0 #7: RÈGLE CRITIQUE<br/>weekly_planner.py:232-251<br/>Format blocs répétés:<br/>✅ Main set 3x<br/>❌ - 3x 10m 90%"]
-        RepFormat:::p0fix
-
-        RepFormat --> Section5[Mission + Contraintes<br/>lines 269-470]
-        Section5 --> PromptReady[Prompt complet<br/>~15-20k tokens]
+    subgraph "Feedback"
+        Single --> FB[FeedbackMixin.step_2_collect_feedback]
+        Batch --> FB
+        FB --> Validate[_validate_feedback_collection]
+        Validate --> Prepare[_prepare_feedback_context]
+        Prepare --> Execute[_execute_feedback_collection]
+        Execute --> FBResult{Feedback collecte ?}
+        FBResult -->|Non, skip| Analysis
+        FBResult -->|Oui| FBData[RPE, sensations, sommeil]
+        FBData --> Analysis
     end
 
-    subgraph "PHASE 3: Interaction AI"
-        PromptReady --> Clipboard[copy_to_clipboard<br/>weekly_planner.py:475-482<br/>pbcopy MacOS]
-        Clipboard --> UserPaste[Utilisateur colle<br/>dans Claude.ai]
-        UserPaste --> ClaudeGen[Claude génère<br/>7 WORKOUT blocks]
-
-        ClaudeGen --> Workout1["=== WORKOUT S072-01-INT... ===<br/>Warmup<br/>- 10m ramp 50-75%<br/>Main set 3x<br/>- 10m 90%<br/>- 4m 62%<br/>Cooldown<br/>- 10m ramp 75-50%<br/>=== FIN WORKOUT ==="]
-
-        Workout1 --> UserCopy[Utilisateur copie workouts]
+    subgraph "Analyse AI"
+        Analysis[AIAnalysisMixin.step_3_prepare_analysis]
+        Analysis --> DetectWeek[_detect_week_id]
+        DetectWeek --> CheckPlan[_check_planning_available]
+        CheckPlan --> BuildPrompt[PromptBuilder.build_prompt mission=daily_feedback]
+        BuildPrompt --> Provider{AI Provider}
+        Provider -->|clipboard| Clipboard[Copie presse-papier]
+        Provider -->|claude_api| APICall[Appel API direct]
+        Provider -->|mistral_api| MistralCall[Appel Mistral]
+        Clipboard --> Display
+        APICall --> Display
+        MistralCall --> Display
     end
 
-    subgraph "PHASE 4: Validation Format (Optionnel)"
-        UserCopy --> ValidateDecision{Valider format?}
-        ValidateDecision -->|Non| ManualUpload
-        ValidateDecision -->|Oui| ValidateFormat["intervals_format_validator.py<br/>validate_workout"]
-
-        ValidateFormat --> CheckMarkdown{Contient<br/>markdown?}
-        CheckMarkdown -->|Oui| ErrorMD[Erreur: Markdown détecté<br/>**, ###, etc.]
-        CheckMarkdown -->|Non| CheckRepFormat
-
-        CheckRepFormat["⚠️ P0 #7 Validation<br/>_check_repetition_format<br/>validator.py:75-111"]:::p0fix
-        CheckRepFormat --> RepInInterval{Répétition dans<br/>intervalle?}
-        RepInInterval -->|Oui| ErrorRep1["Erreur: '- 3x 10m 90%'<br/>Format incorrect"]
-        RepInInterval -->|Non| RepAlone
-
-        RepAlone{Répétition<br/>seule?}
-        RepAlone -->|Oui| ErrorRep2["Erreur: '3x' seul<br/>Doit être sur ligne section"]
-        RepAlone -->|Non| NonStandard
-
-        NonStandard{Section non<br/>standard?}
-        NonStandard -->|Oui| Warn1["⚠️ Warning:<br/>'Test capacité 3x'<br/>Suggérer 'Main set 3x'"]
-        NonStandard -->|Non| FormatOK
-
-        Warn1 --> AutoFix[fix_repetition_format<br/>validator.py:118-155<br/>Correction auto]
-        AutoFix --> FormatOK
-
-        FormatOK[Format valide]
-        ErrorRep1 --> ManualFix[Correction manuelle]
-        ErrorRep2 --> ManualFix
-        ErrorMD --> ManualFix
-        ManualFix --> ValidateFormat
+    subgraph "Affichage et validation"
+        Display[SessionDisplayMixin.step_4_paste_prompt]
+        Display --> Show[step_4b_display_analysis]
+        Show --> Validate2[step_5_validate_analysis]
+        Validate2 --> Valid{Analyse valide ?}
+        Valid -->|Non| Retry([Corriger et relancer])
+        Valid -->|Oui| Extract[_extract_metrics_from_analysis]
+        Extract --> PostAPI[_post_analysis_to_intervals]
     end
 
-    subgraph "PHASE 5: Upload Manuel Intervals.icu"
-        FormatOK --> ManualUpload[Upload manuel<br/>Intervals.icu Web UI]
-        ManualUpload --> CreateJSON[Création manuelle<br/>week_planning_S072.json]
-        CreateJSON --> JSONStructure{
-            week_id: S072
-            version: 1
-            planned_sessions: []
-        }
+    subgraph "Insertion historique"
+        PostAPI --> Insert[HistoryMixin.step_6_insert_analysis]
+        Insert --> Preview[_preview_markdowns]
+        Preview --> DetectType[_detect_session_type_from_markdown]
+        DetectType --> InsertHistory[_insert_to_history]
+        InsertHistory --> Export[_export_markdowns]
     end
 
-    subgraph "PHASE 6: Upload Automatique (Servo Mode)"
-        UserCopy --> ServoUpload{Servo mode<br/>actif?}
-        ServoUpload -->|Non| ManualUpload
-        ServoUpload -->|Oui| UploadWorkout[_upload_workout_intervals<br/>workflow_coach.py:307-346]
-
-        UploadWorkout --> LoadCreds[load_credentials<br/>lines 320-325]
-        LoadCreds --> CredsOK{Credentials OK?}
-        CredsOK -->|Non| ErrorCreds[Erreur: API key manquante]
-        CredsOK -->|Oui| InitAPI[IntervalsAPI<br/>lines 327-328]
-
-        InitAPI --> BuildEvent["⚠️ P0 #6: Prepare event<br/>workflow_coach.py:331-336<br/>CORRECTION APPLIQUÉE"]:::p0fix
-
-        BuildEvent --> EventStruct{
-            category: WORKOUT
-            start_date_local: dateT06:00:00
-            name: workout_code
-            description: structure ✅
-        }
-
-        EventStruct --> APICall[api.create_event<br/>line 339<br/>POST /athlete/ID/events]
-        APICall --> APIResult{Upload OK?}
-        APIResult -->|Non| ErrorAPI[Erreur upload<br/>line 345<br/>Print erreur]
-        APIResult -->|Oui| Success[return True<br/>line 342]
+    subgraph "Git"
+        Export --> Git[GitOpsMixin.step_7_git_commit]
+        Git --> Commit[_optional_git_commit]
+        Commit --> End([Analyse terminee])
     end
 
-    Success --> End([Fin workflow])
-    CreateJSON --> End
-    ErrorMetrics --> End
-    ErrorCreds --> End
-    ErrorAPI --> End
-
-    classDef p0fix fill:#ff6b6b,stroke:#c92a2a,stroke-width:3px,color:#fff
-    classDef success fill:#51cf66,stroke:#2f9e44,stroke-width:2px
-    classDef error fill:#ffd43b,stroke:#f59f00,stroke-width:2px
+    subgraph "Erreurs"
+        Analysis -->|API indisponible| ErrAPI([Erreur : verifier credentials])
+        Insert -->|Doublon detecte| ErrDup([Erreur : analyse deja inseree])
+    end
 ```
-
-### Points Critiques - Diagramme 1
-
-#### 🔴 P0 #8: VALID_TYPES (weekly_planner.py:285)
-**Injection**: Dans la génération du prompt AI
-```python
-# Line 285
-- **TYPE** : END, INT, FTP, SPR, CLM, REC, FOR, CAD, TEC, MIX, PDC, TST
-```
-
-**Impact**: Claude.ai reçoit la liste complète des types valides, évite génération de types inconnus.
 
 ---
 
-#### 🔴 P0 #7: Format Blocs Répétés (weekly_planner.py:232-251)
-**Injection 1**: Documentation prompt AI (ligne 232)
-```python
-**RÈGLE CRITIQUE - Blocs répétés** :
-Le marqueur (3x) doit être sur la ligne du titre, PAS dans intervalles.
+## 2. Flux upload workouts (WorkoutUploader)
 
-✅ CORRECT:
-Main set 3x
-- 10m 90%
-
-❌ INCORRECT:
-- 3x 10m 90%
-Test capacité 3x
-```
-
-**Injection 2**: Validation post-génération (optionnel)
-```python
-# intervals_format_validator.py:75-111
-def _check_repetition_format(self, lines):
-    # Détecte "- 3x 10m 90%" → ERREUR
-    # Détecte "3x" seul → ERREUR
-    # Détecte "Test capacité 3x" → WARNING + auto-fix
-```
-
-**Impact**:
-- Réduit erreurs AI via prompt explicite
-- Permet validation avant upload manuel
-- Auto-correction des formats corrigibles
-
----
-
-#### 🔴 P0 #6: Champ API Description (workflow_coach.py:336)
-**Injection**: Construction event data
-```python
-# AVANT (incorrect):
-event = {
-    "workout_doc": structure  # ❌ Champ inexistant
-}
-
-# APRÈS (corrigé):
-event = {
-    "description": structure  # ✅ Champ API valide
-}
-```
-
-**Impact**: Upload workouts réussit, Intervals.icu parse correctement le format.
-
----
-
-## Diagramme 2 : Servo-Mode Modifications Planning
-
-### Vue d'ensemble
-Ce diagramme montre le flux servo-mode avec validation format et gestion erreurs upload.
+Pipeline depuis le parsing du fichier workouts jusqu'a l'upload API.
 
 ```mermaid
 graph TB
-    Start([workflow-coach --servo-mode --week-id S072])
+    Start([poetry run upload-workouts --week-id SXXX])
 
-    subgraph "PHASE 1: Initialisation"
-        Start --> ParseArgs[main<br/>workflow_coach.py:2392-2410<br/>argparse]
-        ParseArgs --> Constructor[__init__<br/>lines 42-64<br/>servo_mode=True]
-        Constructor --> LoadTemplates["load_workout_templates<br/>lines 91-119<br/>Chargement 6 templates JSON"]
-
-        LoadTemplates --> Template1[recovery_active_30tss<br/>45min Z1-Z2 30 TSS]
-        LoadTemplates --> Template6[sweetspot_short_50tss<br/>2x10min 88% 50 TSS]
-
-        Template6 --> ValidateTemplates["⚠️ Validation templates<br/>validate_template_format<br/>Vérifier format Intervals.icu"]:::validation
-
-        ValidateTemplates --> TplMarkdown{Template contient<br/>markdown?}
-        TplMarkdown -->|Oui| ErrorTpl[Erreur: Template invalide]
-        TplMarkdown -->|Non| TplRepFormat
-
-        TplRepFormat{Format répétitions<br/>correct?}
-        TplRepFormat -->|Non| ErrorTpl
-        TplRepFormat -->|Oui| TplOK[6 templates valides]
-
-        TplOK --> RunWorkflow[run<br/>lines 2175-2260]
-        RunWorkflow --> Step6b[step_6b_servo_control<br/>lines 1855-2024]
+    subgraph "Parsing"
+        Start --> Source{Source des workouts}
+        Source -->|Fichier| ParseFile[ParsingMixin.parse_workouts_file]
+        Source -->|Clipboard| ParseClip[ParsingMixin.parse_clipboard]
+        ParseFile --> Workouts[Liste de workouts parses]
+        ParseClip --> Workouts
     end
 
-    subgraph "PHASE 2: Chargement Planning"
-        Step6b --> DetectWeek[Détection week_id<br/>lines 1878-1887<br/>Input utilisateur si absent]
-        DetectWeek --> LoadJSON[load_remaining_sessions<br/>lines 121-152<br/>Lecture week_planning_S072.json]
-
-        LoadJSON --> JSONExists{Planning JSON<br/>existe?}
-        JSONExists -->|Non| ErrorJSON[Erreur: Fichier absent]
-        JSONExists -->|Oui| FilterFuture[Filtre sessions<br/>date >= today]
-
-        FilterFuture --> HasRemaining{Sessions<br/>futures?}
-        HasRemaining -->|Non| NoModif[Aucune session à modifier<br/>Fin servo mode]
-        HasRemaining -->|Oui| DisplaySessions[Affichage sessions<br/>lines 1907-1912<br/>Format compact]
-
-        DisplaySessions --> UserConfirm{Demander<br/>recommendations AI?<br/>line 1917}
-        UserConfirm -->|Non| NoModif
+    subgraph "Validation"
+        Workouts --> Loop{Pour chaque workout}
+        Loop --> Validate[ValidationMixin.validate_workout_notation]
+        Validate --> ValidResult{Format valide ?}
+        ValidResult -->|Non| ErrFormat([Erreur : format invalide - skip])
+        ValidResult -->|Oui| Naming[Verification convention SSSS-JJ-TYPE-Nom-V001]
     end
 
-    subgraph "PHASE 3: Génération Prompt Asservissement"
-        UserConfirm -->|Oui| FormatContext[format_remaining_sessions_compact<br/>lines 154-183<br/>~150 tokens]
-
-        FormatContext --> BuildPrompt[Construction prompt<br/>lines 1927-1971]
-        BuildPrompt --> Header[# ASSERVISSEMENT PLANNING<br/>Contexte: planning restant]
-        BuildPrompt --> Catalog["Catalogue templates<br/>lines 1932-1946<br/>RÉCUPÉRATION: 3 templates<br/>ENDURANCE: 2 templates<br/>INTENSITÉ: 1 template"]
-
-        BuildPrompt --> Criteria[Critères décision<br/>lines 1948-1956<br/>HRV < -10%<br/>RPE > 8/10<br/>Découplage > 7.5%]
-
-        BuildPrompt --> JSONFormat["Format JSON attendu<br/>lines 1958-1967<br/>{modifications: [{<br/>  action: 'lighten',<br/>  target_date: 'YYYY-MM-DD',<br/>  template_id: 'recovery_...',<br/>  reason: '...'<br/>}]}"]
-
-        JSONFormat --> PromptReady[Prompt complet<br/>~2000 tokens]
-        PromptReady --> Clipboard[pbcopy<br/>lines 1975-1979]
-        Clipboard --> Instructions[Affichage instructions<br/>lines 1981-1990]
+    subgraph "Decision de synchronisation"
+        Naming --> Sync[event_sync.evaluate_sync]
+        Sync --> Hash[calculate_description_hash]
+        Hash --> Time[compute_start_time]
+        Time --> Decision{SyncDecision}
+        Decision -->|SKIP| AlreadySync([Deja synchronise - skip])
+        Decision -->|CREATE| Create[Nouveau workout]
+        Decision -->|UPDATE| Update[Workout modifie]
     end
 
-    subgraph "PHASE 4: Interaction AI & Parsing"
-        Instructions --> UserPaste[Utilisateur colle<br/>dans Claude.ai]
-        UserPaste --> ClaudeAnalyze[Claude analyse fatigue<br/>+ planning restant]
-        ClaudeAnalyze --> ClaudeDecision{Modifications<br/>nécessaires?}
-
-        ClaudeDecision -->|Non| NoModJSON["Réponse:<br/>'Aucune modification nécessaire'<br/>Pas de bloc JSON"]
-        ClaudeDecision -->|Oui| GenModJSON["Réponse avec JSON:<br/>```json<br/>{modifications: [...]}<br/>```"]
-
-        GenModJSON --> UserCopyResp[Utilisateur copie réponse<br/>pbpaste lines 2000-2006]
-        NoModJSON --> UserCopyResp
-
-        UserCopyResp --> ParseMods["⚠️ parse_ai_modifications<br/>lines 185-211<br/>Extraction regex JSON"]:::validation
-
-        ParseMods --> RegexJSON[Pattern:<br/>```json...```<br/>lines 197-200]
-        RegexJSON --> JSONFound{JSON block<br/>trouvé?}
-
-        JSONFound -->|Non| EmptyMods[return []<br/>line 204]
-        JSONFound -->|Oui| Deserialize[json.loads<br/>lines 206-208]
-
-        Deserialize --> DeserOK{Parsing OK?}
-        DeserOK -->|Non| ErrorParse[JSONDecodeError<br/>line 209-211<br/>return []]
-        DeserOK -->|Oui| ModList[Liste modifications]
-
-        EmptyMods --> CheckEmpty
-        ErrorParse --> CheckEmpty
-        ModList --> CheckEmpty{Liste vide?<br/>line 2015}
+    subgraph "Upload API"
+        Create --> Upload[UploadMixin.upload_workout]
+        Update --> Upload
+        Upload --> Match[_find_matching_event]
+        Match --> HasExisting{Event existant ?}
+        HasExisting -->|Oui, UPDATE| Delete[IntervalsClient : DELETE ancien]
+        HasExisting -->|Non, CREATE| Post[IntervalsClient : POST /events]
+        Delete --> Post
+        Post --> Result{Upload OK ?}
+        Result -->|Non| ErrUpload([Erreur API - log et continue])
+        Result -->|Oui| Success[Workout uploade]
     end
 
-    subgraph "PHASE 5: Application Modifications"
-        CheckEmpty -->|Oui| NoChange[Planning maintenu<br/>lines 2015-2018]
-        CheckEmpty -->|Non| ApplyLoop[apply_planning_modifications<br/>lines 484-509]
+    subgraph "Finalisation"
+        Success --> Next{Autre workout ?}
+        ErrFormat --> Next
+        AlreadySync --> Next
+        ErrUpload --> Next
+        Next -->|Oui| Loop
+        Next -->|Non| Summary[upload_all : resume final]
+        Summary --> End([Upload termine])
+    end
+```
 
-        ApplyLoop --> ForEach{Pour chaque<br/>modification}
-        ForEach --> ActionType{Action type?<br/>line 499}
+---
 
-        ActionType -->|lighten| ApplyLighten[_apply_lighten<br/>lines 414-482]
-        ActionType -->|cancel| TodoCancel[TODO: Implémenter]
-        ActionType -->|reschedule| TodoReschedule[TODO: Implémenter]
+## 3. Boucle servo-control
 
-        ApplyLighten --> ValidateTpl["⚠️ Validation template<br/>lines 421-425<br/>template_id existe?"]:::validation
-        ValidateTpl -->|Non| ErrorTpl2[Erreur: Template inconnu<br/>Skip modification]
-        ValidateTpl -->|Oui| DisplayMod[Affichage modification<br/>lines 429-432]
+Control Tower comme gardien des modifications planning.
 
-        DisplayMod --> UserConfirm2{Confirmation<br/>utilisateur<br/>lines 435-438}
-        UserConfirm2 -->|Non| SkipMod[Modification ignorée<br/>line 439]
-        UserConfirm2 -->|Oui| ExtractDay
+```mermaid
+graph TB
+    Start([Declenchement servo])
 
-        ExtractDay[_extract_day_number<br/>lines 213-237<br/>Calcul jour 1-7]
-        ExtractDay --> GenCode[Génération workout_code<br/>lines 440-445<br/>Pattern: {week_id}-{day:02d}-{TYPE}-{Name}-V001]
+    subgraph "Lecture protegee"
+        Start --> Read[PlanningControlTower.read_week]
+        Read --> Audit1[Audit log : READ operation]
+        Audit1 --> Planning[Donnees planning en lecture seule]
+        Planning --> Filter[Filtre sessions futures]
+        Filter --> HasSessions{Sessions modifiables ?}
+        HasSessions -->|Non| End1([Rien a modifier])
     end
 
-    subgraph "PHASE 6: Upload API avec Rollback Potentiel"
-        GenCode --> SaveSnapshot["⚠️ Point rollback<br/>État actuel planning"]:::validation
-
-        SaveSnapshot --> GetOldID[_get_workout_id_intervals<br/>lines 239-273<br/>GET /events date=target_date]
-        GetOldID --> OldExists{Workout existant<br/>trouvé?}
-
-        OldExists -->|Oui| DeleteOld[_delete_workout_intervals<br/>lines 275-305<br/>DELETE /events/{id}]
-        OldExists -->|Non| NoDelete[Aucun workout à supprimer]
-
-        DeleteOld --> DelResult{Suppression OK?}
-        DelResult -->|Non| ErrorDel[Erreur suppression<br/>line 304-305<br/>⚠️ Continue quand même]
-        DelResult -->|Oui| DeleteSuccess[🗑️ Ancien workout supprimé<br/>line 453]
-
-        NoDelete --> UploadNew
-        DeleteSuccess --> UploadNew
-        ErrorDel --> UploadNew
-
-        UploadNew["⚠️ P0 #6: _upload_workout_intervals<br/>lines 307-346<br/>POST /events"]:::p0fix
-
-        UploadNew --> BuildEvent2["Prepare event<br/>lines 331-336<br/>{<br/>  category: 'WORKOUT',<br/>  name: code,<br/>  description: structure ✅<br/>}"]
-
-        BuildEvent2 --> APICall2[api.create_event<br/>line 339]
-        APICall2 --> UploadResult{Upload OK?<br/>line 342}
-
-        UploadResult -->|Non| ErrorUpload["❌ Erreur upload<br/>line 345<br/>⚠️ PAS DE ROLLBACK<br/>Ancien workout supprimé<br/>Nouveau pas créé"]:::error
-        UploadResult -->|Oui| UploadSuccess[✅ Nouveau workout créé<br/>line 460]
-
-        UploadSuccess --> UpdateJSON[_update_planning_json<br/>lines 348-412]
-        UpdateJSON --> LoadPlanning[Lecture planning JSON<br/>lines 367-375]
-        LoadPlanning --> FindSession[Recherche session<br/>lines 380-387]
-        FindSession --> UpdateSession[Modification session<br/>lines 388-403<br/>status='modified'<br/>history.append]
-        UpdateSession --> IncrVersion[Incrément version<br/>line 406]
-        IncrVersion --> SaveJSON[Sauvegarde JSON<br/>line 408-410]
-
-        SaveJSON --> Complete[✅ Modification appliquée<br/>line 481]
+    subgraph "Generation recommandations"
+        HasSessions -->|Oui| Format[Format compact sessions]
+        Format --> Prompt[Construction prompt asservissement]
+        Prompt --> AI{AI Provider}
+        AI --> Response[Reponse AI avec JSON]
+        Response --> Parse[ServoControlMixin.parse_ai_modifications]
+        Parse --> Mods{Modifications ?}
+        Mods -->|Non| End2([Planning maintenu])
     end
 
-    subgraph "PHASE 7: Boucle Modifications"
-        Complete --> NextMod{Autre<br/>modification?}
-        ErrorTpl2 --> NextMod
-        SkipMod --> NextMod
-        TodoCancel --> NextMod
-        TodoReschedule --> NextMod
+    subgraph "Application avec Control Tower"
+        Mods -->|Oui| ForEach{Pour chaque modification}
 
-        NextMod -->|Oui| ForEach
-        NextMod -->|Non| AllComplete[Toutes modifications traitées]
+        ForEach --> Action{Type action}
+        Action -->|lighten| Lighten[_apply_lighten]
+        Action -->|cancel| Cancel[Conversion WORKOUT vers NOTE avec tag ANNULEE]
+        Action -->|reschedule| Reschedule[Deplacement session a nouvelle date]
+
+        Lighten --> Confirm{Confirmation}
+        Cancel --> Confirm
+        Reschedule --> Confirm
+
+        Confirm -->|Non| Skip[Modification ignoree]
+        Confirm -->|Oui| CTModify[PlanningControlTower.modify_week]
     end
 
-    AllComplete --> End([Fin servo mode])
-    NoChange --> End
-    NoModif --> End
-    ErrorJSON --> End
-    ErrorTpl --> End
-    ErrorUpload --> End
+    subgraph "Modifications atomiques"
+        CTModify --> Backup[Backup automatique planning]
+        Backup --> Permission[Verification pas de modification concurrente]
+        Permission --> Apply[Application modification JSON]
+        Apply --> Version[Increment version]
+        Version --> AuditLog[Audit JSONL : MODIFY operation]
+        AuditLog --> APISync[IntervalsClient : sync Intervals.icu]
+        APISync --> Save[Sauvegarde planning]
+    end
 
-    classDef p0fix fill:#ff6b6b,stroke:#c92a2a,stroke-width:3px,color:#fff
-    classDef validation fill:#4c6ef5,stroke:#364fc7,stroke-width:3px,color:#fff
-    classDef error fill:#ffd43b,stroke:#f59f00,stroke-width:2px
-    classDef success fill:#51cf66,stroke:#2f9e44,stroke-width:2px
+    Save --> Next{Autre modification ?}
+    Skip --> Next
+    Next -->|Oui| ForEach
+    Next -->|Non| End3([Modifications appliquees])
 ```
 
-### Points Critiques - Diagramme 2
+---
 
-#### 🔵 Validation Templates (Initialisation)
-**Injection**: Après chargement templates, avant utilisation
-```python
-# workflow_coach.py:109 (à ajouter)
-def validate_template_format(self, template: dict) -> bool:
-    """Valider format Intervals.icu dans template"""
-    from magma_cycling.intervals_format_validator import IntervalsFormatValidator
-    validator = IntervalsFormatValidator()
+## 4. Pipeline end-of-week autonome
 
-    format_str = template.get('intervals_icu_format', '')
-    is_valid, errors, warnings = validator.validate_workout(format_str)
+Workflow autonome dimanche soir avec decisions et fallbacks.
 
-    if not is_valid:
-        print(f"❌ Template {template['id']}: {errors}")
-        return False
-    return True
+```mermaid
+graph TB
+    Start([poetry run end-of-week --auto --provider claude_api])
+
+    subgraph "Analyse semaine completee"
+        Start --> CheckReports{Rapports quotidiens existent ?}
+        CheckReports -->|Non| GenReports[Generation rapports manquants]
+        CheckReports -->|Oui| LoadReports[AnalysisMixin._step1_analyze_completed_week]
+        GenReports --> LoadReports
+        LoadReports --> LoadWellness[Chargement wellness semaine]
+        LoadWellness --> Stats[Calcul adherence, TSS cumule, zones]
+    end
+
+    subgraph "Evaluation PID"
+        Stats --> PID[EvaluationMixin._step1b_pid_evaluation]
+        PID --> Ecart{Ecart TSS > seuil ?}
+        Ecart -->|Oui| Correction[Correction charge recommandee S+1]
+        Ecart -->|Non| Nominal[Charge nominale S+1]
+        Correction --> Planning
+        Nominal --> Planning
+    end
+
+    subgraph "Generation planning S+1"
+        Planning[AIWorkoutsMixin._step2_generate_planning_prompt]
+        Planning --> BuildPrompt[PromptBuilder.build_prompt mission=weekly_planning]
+        BuildPrompt --> GetAI[AIWorkoutsMixin._step3_get_ai_workouts]
+        GetAI --> Provider{Provider principal}
+        Provider -->|claude_api| Claude[Appel Claude API]
+        Provider -->|mistral_api| Mistral[Appel Mistral API]
+        Claude --> ValidAI{Reponse valide ?}
+        Mistral --> ValidAI
+        ValidAI -->|Non| Fallback{Fallback provider ?}
+        Fallback -->|Oui| Provider
+        Fallback -->|Non| ErrAI([Erreur : aucun provider disponible])
+        ValidAI -->|Oui| Workouts[7 workouts generes]
+    end
+
+    subgraph "Validation et upload"
+        Workouts --> Validate[UploadMixin._step4_validate_workouts]
+        Validate --> ValidFmt{Format OK ?}
+        ValidFmt -->|Non| RetryAI[Retry generation AI]
+        RetryAI --> GetAI
+        ValidFmt -->|Oui| Upload[UploadMixin._step5_upload_to_intervals]
+        Upload --> PerSession{Pour chaque session}
+        PerSession --> EvalSync[event_sync.evaluate_sync]
+        EvalSync --> SyncDecision{Decision}
+        SyncDecision -->|CREATE| Create[IntervalsClient : POST]
+        SyncDecision -->|UPDATE| Update[IntervalsClient : PUT]
+        SyncDecision -->|SKIP| SkipSync[Deja a jour]
+        Create --> UploadResult{OK ?}
+        Update --> UploadResult
+        UploadResult -->|Non| RetryUpload[Retry avec throttle]
+        UploadResult -->|Oui| NextSession{Session suivante ?}
+        SkipSync --> NextSession
+        RetryUpload --> NextSession
+        NextSession -->|Oui| PerSession
+        NextSession -->|Non| SaveJSON[_step6_save_planning_json]
+    end
+
+    subgraph "Archive et commit"
+        SaveJSON --> Archive[ArchiveMixin._step6_archive_and_commit]
+        Archive --> ArchiveFiles[Archive rapports dans weekly_reports/]
+        ArchiveFiles --> GitCommit[Git commit data repo]
+        GitCommit --> GitPush[Git push data repo]
+        GitPush --> Summary[_print_success_summary]
+        Summary --> End([Semaine S+1 planifiee])
+    end
 ```
 
-**Impact**: Templates invalides rejetés au démarrage, pas d'upload de formats incorrects.
+---
+
+## Conventions
+
+- **Nommage noeuds** : `MixinName.method()` ou `module.function()`
+- **Subgraphs** : par phase fonctionnelle
+- **Decisions** : losanges avec conditions explicites
+- **Erreurs** : noeuds stadium (arrondi) avec prefix "Erreur"
+- **Pas de numeros de ligne** : references par module et methode uniquement
 
 ---
 
-#### 🔵 Parsing Réponse AI (Extraction JSON)
-**Injection**: `parse_ai_modifications()` lines 185-211
-```python
-# Pattern regex
-json_match = re.search(
-    r'```json\s*\n(\{.*?"modifications".*?\})\s*\n```',
-    ai_response,
-    re.DOTALL
-)
-
-if not json_match:
-    return []  # Aucune modification
-
-data = json.loads(json_match.group(1))
-return data.get('modifications', [])
-```
-
-**Structure attendue**:
-```json
-{
-  "modifications": [
-    {
-      "action": "lighten",
-      "target_date": "2025-12-18",
-      "current_workout": "S072-03-END-Endurance-V001",
-      "template_id": "recovery_active_30tss",
-      "reason": "HRV -15%, prioriser récupération"
-    }
-  ]
-}
-```
-
-**Impact**:
-- Parsing robuste avec regex
-- Gère absence de JSON (no modifications)
-- Gère erreurs JSON (JSONDecodeError)
-
----
-
-#### 🔵 Validation Template ID
-**Injection**: `_apply_lighten()` lines 421-425
-```python
-template_id = mod['template_id']
-if template_id not in self.workout_templates:
-    print(f"❌ Template inconnu: {template_id}")
-    return  # Skip modification
-```
-
-**Impact**: Évite crash si AI propose template inexistant.
-
----
-
-#### 🔴 P0 #6: Upload API avec Champ Correct
-**Injection**: `_upload_workout_intervals()` line 336
-```python
-event = {
-    "category": "WORKOUT",
-    "start_date_local": f"{date}T06:00:00",
-    "name": code,
-    "description": structure  # ✅ CORRIGÉ (était "workout_doc")
-}
-
-result = api.create_event(event)
-```
-
-**Impact**: Upload réussit avec format Intervals.icu correctement transmis.
-
----
-
-#### ⚠️ Point de Rollback Manquant (P1 Fix Future)
-**Problème**: Si upload nouveau workout échoue, ancien workout déjà supprimé.
-
-**État actuel** (lines 447-464):
-```python
-# 1. Supprimer ancien
-if self._delete_workout_intervals(old_workout_id):
-    print("🗑️ Ancien workout supprimé")
-
-# 2. Upload nouveau
-if self._upload_workout_intervals(...):
-    print("⬆️ Nouveau workout uploadé")
-else:
-    print("❌ Erreur upload")
-    # ⚠️ PAS DE ROLLBACK - ancien workout perdu!
-```
-
-**Solution recommandée** (P1):
-```python
-# Sauvegarder ancien workout avant suppression
-snapshot = self._get_workout_data(old_workout_id)
-
-try:
-    # Supprimer ancien
-    self._delete_workout_intervals(old_workout_id)
-
-    # Upload nouveau
-    if not self._upload_workout_intervals(...):
-        # Rollback: restaurer ancien
-        self._upload_workout_intervals(
-            date=snapshot['date'],
-            code=snapshot['name'],
-            structure=snapshot['description']
-        )
-        raise Exception("Upload failed, rollback effectué")
-except:
-    # Rollback automatique en cas d'erreur
-```
-
-**Impact**: Évite perte de workout en cas d'échec upload.
-
----
-
-## Légende Diagrammes
-
-### Couleurs
-- 🔴 **Rouge** (`p0fix`): Points d'injection corrections P0 (#6, #7, #8)
-- 🔵 **Bleu** (`validation`): Points de validation format/données
-- 🟡 **Jaune** (`error`): Chemins d'erreur
-- 🟢 **Vert** (`success`): Succès/complétion
-
-### Annotations
-- `fichier.py:ligne`: Référence exacte code source
-- `lines X-Y`: Plage de lignes pour méthodes
-- `⚠️`: Point critique nécessitant attention
-- `✅`: Correction appliquée
-- `❌`: Erreur détectée
-
----
-
-## Validation Points - Checklist
-
-### Diagramme 1 (Génération & Upload)
-- [ ] P0 #8: VALID_TYPES complets dans prompt (line 285)
-- [ ] P0 #7: Format répétitions documenté (lines 232-251)
-- [ ] P0 #7: Validation optionnelle avant upload
-- [ ] P0 #6: Champ `description` utilisé (line 336)
-- [ ] Gestion erreurs credentials API
-- [ ] Gestion erreurs upload API
-
-### Diagramme 2 (Servo Mode)
-- [ ] Templates validés au chargement
-- [ ] Format Intervals.icu vérifié templates
-- [ ] Parsing JSON robuste (regex + try/catch)
-- [ ] Validation template_id avant application
-- [ ] P0 #6: Champ `description` utilisé upload
-- [ ] Confirmation utilisateur avant modifications
-- [ ] Historique JSON avec timestamp
-- [ ] Versioning JSON incrémenté
-- [ ] ⚠️ Rollback upload manquant (P1 future)
-
----
-
-## Utilisation Diagrammes
-
-### Développement
-- Référence pour debugging avec numéros de ligne exacts
-- Identification rapide points d'injection corrections
-- Traçabilité décisions architecture
-
-### Tests
-- Validation complète de tous les chemins
-- Coverage des cas d'erreur
-- Vérification points critiques P0
-
-### Documentation
-- Onboarding nouveaux développeurs
-- Revue de code structurée
-- Maintenance et évolution système
-
----
-
-## Fichiers Référencés
-
-| Fichier | Lignes Clés | Responsabilité |
-|---------|-------------|----------------|
-| **weekly_planner.py** | 173-473, 226-265, 285, 475-482 | Génération prompt AI, règles format |
-| **workflow_coach.py** | 42-64, 91-119, 185-211, 307-346, 414-482, 1855-2024 | Servo mode, upload API, parsing |
-| **intervals_format_validator.py** | 75-111, 118-155 | Validation format, auto-correction |
-| **prepare_analysis.py** | 108-146 | API Intervals.icu (create_event) |
-| **rest_and_cancellations.py** | 41-42 | VALID_STATUSES, VALID_TYPES |
-
----
-
-**Date Création**: 2025-12-21
-**Mis à Jour**: Après Phase 3 P0 Fixes
-**Version**: 1.0
-****
+**Date** : Mars 2026
+**Version** : 2.0

--- a/project-docs/workflows/WORKFLOW_COMPLET.md
+++ b/project-docs/workflows/WORKFLOW_COMPLET.md
@@ -1,509 +1,237 @@
-# 🎯 Guide Workflow Coach - Analyse de Séance
+# Guide Workflow Coach - Analyse de Seance
 
-Le **Workflow Coach** est un orchestrateur interactif qui guide l'utilisateur à travers toutes les étapes d'analyse d'une séance cyclisme avec Claude.ai.
+**Version** : 2.0
+**Date** : Mars 2026
+**Architecture** : Facade `WorkflowCoach` + 11 mixins
 
-## 🚀 Démarrage Rapide
+---
+
+## Demarrage Rapide
 
 ```bash
 # Lancement standard (guidage complet)
-python3 scripts/workflow_coach.py
+poetry run workflow-coach
 
 # Mode rapide (sans feedback ni git)
-python3 scripts/workflow_coach.py --skip-feedback --skip-git
+poetry run workflow-coach --skip-feedback --skip-git
 
-# Analyser une séance spécifique
-python3 scripts/workflow_coach.py --activity-id i123456
-```
+# Analyser une seance specifique
+poetry run workflow-coach --activity-id i123456
 
-## 🔍 Détection Multi-Séances (NOUVEAU)
+# Mode asservissement
+poetry run workflow-coach --servo-mode --week-id S085
 
-Le workflow intègre désormais la **détection automatique des séances non analysées** !
+# Mode reconciliation
+poetry run workflow-coach --reconcile --week-id S085
 
-### Fonctionnement
-
-Lorsque tu lances le workflow sans spécifier `--activity-id`, le système :
-
-1. **Charge l'état** : Lit `.workflow_state.json` pour savoir quelle est la dernière séance analysée
-2. **Récupère les activités récentes** : Appelle l'API Intervals.icu pour les 7-30 derniers jours
-3. **Détecte les gaps** : Identifie les séances non encore analysées
-4. **Affiche un menu interactif** selon le nombre détecté :
-   - **0 séance** : Message "Aucune activité non analysée !"
-   - **1 séance** : Propose d'analyser directement ou d'annuler
-   - **2+ séances** : Menu complet avec 4 options
-
-### Menu Interactif (2+ séances)
-
-```
-📊 3 ACTIVITÉS NON ANALYSÉES DÉTECTÉES
-
-1. [2025-11-21] Zwift - Morning Endurance (partie 1)
-   ID: i107779438 | Durée: 45min | TSS: 42
-
-2. [2025-11-21] Zwift - Morning Endurance (partie 2)
-   ID: i107779439 | Durée: 43min | TSS: 40
-
-3. [2025-11-20] Sweet Spot 2x15min
-   ID: i107779437 | Durée: 75min | TSS: 68
-
-OPTIONS :
-  1 - Analyser la DERNIÈRE séance uniquement
-  2 - Choisir UNE séance spécifique
-  3 - Analyser TOUTES en mode batch
-  0 - Annuler
-```
-
-### Cas d'Usage
-
-#### Déconnexion Zwift
-Tu as fait une séance Zwift qui s'est déconnectée → 2 activités distinctes dans Intervals.icu
-
-**Solution** : Option 3 (mode batch) pour analyser les deux en une seule session
-
-#### Weekend Multi-Séances
-Tu analyses le lundi, tu as fait 3 séances samedi-dimanche
-
-**Solution** : Option 3 (mode batch) ou Option 2 (choisir les plus importantes)
-
-#### Rattrapage
-Tu n'as pas analysé depuis 1 semaine → 5 séances en attente
-
-**Solution** : Option 3 (mode batch) pour tout traiter d'un coup
-
-### Mode Batch
-
-Quand tu sélectionnes l'option 3, le système :
-
-1. **Boucle sur chaque séance** (ex: "📊 SÉANCE 2/3")
-2. **Génère le prompt** pour chaque activité
-3. **Copie dans le presse-papier**
-4. **Attend ton signal** après avoir copié la réponse de Claude
-5. **Propose l'insertion automatique** via `insert_analysis.py`
-6. **Marque comme analysée** dans le state
-7. **Passe à la suivante**
-
-**Avantage** : Tu restes dans Claude.ai, pas besoin de relancer le workflow entre chaque séance !
-
-### Option --list
-
-Liste les séances non analysées sans lancer l'analyse :
-
-```bash
-python3 scripts/prepare_analysis.py --list
-
-📋 3 activité(s) non analysée(s) :
-
-1. [2025-11-21] Zwift - Morning Endurance (partie 1)
-   ID: i107779438 | Durée: 45min | TSS: 42
-
-2. [2025-11-21] Zwift - Morning Endurance (partie 2)
-   ID: i107779439 | Durée: 43min | TSS: 40
-
-3. [2025-11-20] Sweet Spot 2x15min
-   ID: i107779437 | Durée: 75min | TSS: 68
+# Mode automatique (non interactif)
+poetry run workflow-coach --auto
 ```
 
 ---
 
-## 📋 Vue d'Ensemble du Workflow
+## Architecture
 
-Le script orchestre 7 étapes séquentielles (+ étape 1b si gaps détectés) :
+La facade `WorkflowCoach` delegue a 11 mixins specialises dans `workflows/coach/` :
 
-### 1️⃣ Bienvenue et Présentation
-Affiche le plan du workflow et explique que :
-- Le prompt généré contient **automatiquement** tout le contexte nécessaire
-- **Aucun upload de fichier requis** (contexte inclus dans le prompt)
-- Tous les éléments sont chargés depuis le projet local
-
-⏱️ **Temps** : 10 secondes
-
-### 1️⃣b Détection Multi-Séances (Automatique si gaps)
-Si 2+ séances non analysées sont détectées :
-- Affiche la liste des séances en attente
-- Informe que le menu interactif sera proposé à l'étape suivante
-- Options : analyser une seule, choisir, ou mode batch
-
-⏱️ **Temps** : 5 secondes
-
-💡 **Skip** : Automatique si `--activity-id` fourni ou si 0-1 séance détectée
-
-### 2️⃣ Collecte Feedback Athlète (Optionnel)
-Lance `collect_athlete_feedback.py` pour capturer le ressenti subjectif.
-
-⏱️ **Temps** : 30 secondes (quick) ou 2-3 min (full)
-
-💡 **Avantage** : Claude croise métriques objectives + ressenti subjectif
-
-### 3️⃣ Préparation Prompt
-Lance `prepare_analysis.py` pour :
-- Récupérer la séance depuis Intervals.icu
-- Charger le contexte athlète depuis `references/project_prompt_v2_1_revised.md`
-- Charger l'historique depuis `logs/workouts-history.md`
-- Intégrer les concepts depuis `references/cycling_training_concepts.md`
-- Récupérer le workout planifié (si disponible)
-- Intégrer le feedback athlète (si collecté)
-- Générer le prompt complet optimisé
-- Copier dans le presse-papier
-
-⏱️ **Temps** : 10 secondes
-
-### 4️⃣ Envoi à Claude.ai
-Instructions pour :
-- Ouvrir Claude.ai (nouveau chat ou conversation existante)
-- Coller le prompt complet
-- Attendre la réponse (~30-60s)
-- Copier UNIQUEMENT le bloc markdown généré
-
-⏱️ **Temps** : 1-2 minutes
-
-### 5️⃣ Validation Analyse
-Checklist de validation avant insertion :
-- ✓ Format markdown correct
-- ✓ Toutes les sections présentes
-- ✓ Contenu cohérent et factuel
-
-⚠️ **Point d'arrêt** : Si invalide, possibilité de corriger et relancer
-
-### 6️⃣ Insertion dans les Logs
-Lance `insert_analysis.py` pour :
-- Valider le format markdown
-- Détecter les doublons
-- Insérer au bon endroit dans `workouts-history.md`
-- Afficher le diff
-
-⏱️ **Temps** : 5 secondes
-
-### 7️⃣ Commit Git (Optionnel)
-Propose de commiter avec un message auto-généré :
-```
-Analyse: [Nom Séance]
-
-🤖 Generated with Claude Code
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-```
-
-Propose aussi le `git push` vers remote.
-
-⏱️ **Temps** : 10 secondes
+| Mixin | Responsabilite | Methodes principales |
+|-------|---------------|---------------------|
+| **GapDetectionMixin** | Detection seances non analysees | `step_1b_detect_all_gaps()`, `_detect_unanalyzed_activities()` |
+| **FeedbackMixin** | Collecte ressenti athlete | `step_2_collect_feedback()`, `_validate_feedback_collection()` |
+| **AIAnalysisMixin** | Preparation et envoi analyse AI | `step_3_prepare_analysis()`, `_detect_week_id()` |
+| **SessionDisplayMixin** | Affichage prompt et analyse | `step_4_paste_prompt()`, `step_5_validate_analysis()` |
+| **HistoryMixin** | Insertion dans workouts-history | `step_6_insert_analysis()`, `_insert_to_history()` |
+| **GitOpsMixin** | Commit git automatique | `step_7_git_commit()`, `_optional_git_commit()` |
+| **ServoControlMixin** | Asservissement planning | `_apply_lighten()`, `_update_planning_json()` |
+| **IntervalsAPIMixin** | Communication API Intervals.icu | `load_credentials()`, `load_workout_templates()` |
+| **ReconciliationMixin** | Reconciliation planifie vs realise | `reconcile_week()`, `_display_reconciliation_report()` |
+| **SpecialSessionsMixin** | Repos, annulations, sauts | `_handle_rest_cancellations()`, `_handle_skipped_sessions()` |
+| **UIHelpersMixin** | Utilitaires affichage terminal | Helpers d'affichage interactif |
 
 ---
 
-## ⏱️ Temps Total
+## Pipeline en 7 etapes
 
-- **Minimum** : ~3 minutes (sans feedback, séance simple)
-- **Standard** : ~4 minutes (avec feedback quick)
-- **Complet** : ~5-6 minutes (avec feedback full + commit)
+### Etape 1 : Detection multi-seances
+**Mixin** : `GapDetectionMixin`
 
-💡 **Gain de temps** : Aucun upload manuel de fichiers requis !
+Le systeme detecte automatiquement les activites non analysees :
+- Charge l'etat depuis `.workflow_state.json`
+- Interroge l'API Intervals.icu (7-30 derniers jours)
+- Identifie les gaps (seances non analysees)
+- Menu interactif : derniere / choisir / batch
+
+### Etape 2 : Collecte feedback (optionnel)
+**Mixin** : `FeedbackMixin`
+
+Capture le ressenti subjectif de l'athlete : RPE, sensations, HRRc.
+Skip avec `--skip-feedback`. Les donnees wellness Intervals.icu (Feel, sommeil, CTL/ATL/TSB) sont toujours incluses dans le prompt.
+
+### Etape 3 : Preparation analyse AI
+**Mixin** : `AIAnalysisMixin`
+
+- Detecte le week_id correspondant a l'activite
+- Verifie la disponibilite du planning
+- Construit le prompt via `PromptBuilder.build_prompt(mission="daily_feedback")`
+- Envoie au provider AI selectionne
+
+### Etape 4 : Affichage et envoi
+**Mixin** : `SessionDisplayMixin`
+
+Selon le provider :
+- **clipboard** : copie dans le presse-papier, attend le retour utilisateur
+- **claude_api / mistral_api / openai_api** : appel API direct, affichage resultat
+- **ollama** : appel local
+
+### Etape 5 : Validation analyse
+**Mixin** : `SessionDisplayMixin`
+
+Checklist de validation : format markdown, sections presentes, coherence contenu.
+
+### Etape 6 : Insertion dans les logs
+**Mixin** : `HistoryMixin`
+
+- Detecte le type de session depuis le markdown
+- Verifie les doublons (detection paranoiaque)
+- Insere dans `workouts-history.md`
+
+### Etape 7 : Commit git
+**Mixin** : `GitOpsMixin`
+
+Commit automatique avec message genere. Skip avec `--skip-git`.
 
 ---
 
-## 🎮 Modes d'Utilisation
+## AI Provider System
 
-### Mode Standard (Recommandé)
-```bash
-python3 scripts/workflow_coach.py
-```
-- Guidage complet interactif
-- Feedback athlète proposé
-- Git commit proposé
-- Adapté pour première utilisation
+Le systeme utilise `AIProviderFactory` pour abstraire le fournisseur AI :
 
-### Mode Rapide
-```bash
-python3 scripts/workflow_coach.py --skip-feedback --skip-git
-```
-- Skip feedback et commit
-- Analyse basée uniquement sur métriques
-- Pas de commit automatique
-- Adapté pour analyses multiples rapides
+| Provider | Usage | Configuration |
+|----------|-------|---------------|
+| **claude_api** | Analyses automatiques (daily-sync, end-of-week) | `ANTHROPIC_API_KEY` |
+| **mistral_api** | Alternative/fallback | `MISTRAL_API_KEY` |
+| **openai_api** | Alternative | `OPENAI_API_KEY` |
+| **ollama** | Modele local | Ollama installe localement |
+| **clipboard** | Mode interactif (workflow-coach) | Aucune config requise |
 
-### Mode Séance Spécifique
-```bash
-python3 scripts/workflow_coach.py --activity-id i123456
-```
-- Analyser une séance passée
-- Utile pour rattraper des analyses manquées
-- Même workflow complet
-
-### Mode Projet Claude Code
-```bash
-# Depuis Claude Code
-python3 scripts/workflow_coach.py
-```
-- Adapte les instructions pour contexte projet
-- Skip l'upload de fichiers (déjà dans le projet)
-- Simplifie les instructions de copier-coller
+Le provider est selectionne via `--provider` en CLI ou configure par defaut selon le workflow :
+- `workflow-coach` : clipboard (interactif)
+- `daily-sync --ai-analysis` : claude_api
+- `end-of-week --auto` : claude_api avec fallback mistral_api
 
 ---
 
-## 📊 Flux de Données
+## Services transverses
+
+### Control Tower (`planning/control_tower.py`)
+
+Gardien centralise de tous les fichiers planning :
+- **Lecture** : `PlanningControlTower.read_week()` — acces en lecture seule
+- **Modification** : `PlanningControlTower.modify_week()` — context manager avec backup automatique
+- **Audit** : chaque operation loggee en JSONL (timestamp, operation, tool, reason)
+- **Atomicite** : une seule modification a la fois, rollback si erreur
+
+### Prompt Builder (`prompts/prompt_builder.py`)
+
+Construction standardisee des prompts AI :
+- `build_prompt(mission="daily_feedback"|"weekly_planning")` : assemble systeme + mission + contexte
+- `format_athlete_profile()` : profil athlete depuis `config/athlete_context.yaml`
+- `load_current_metrics()` : FTP, CTL, ATL, ramp_rate depuis env + API
+
+### Event Sync (`utils/event_sync.py`)
+
+Logique de synchronisation partagee entre `WorkoutUploader` et MCP :
+- `evaluate_sync()` : decide CREATE / UPDATE / SKIP
+- `calculate_description_hash()` : detection de changements
+- `compute_start_time()` : calcul heure de debut
+
+---
+
+## Flux de donnees
 
 ```
 Intervals.icu API
-    ↓
-prepare_analysis.py
-    ↓
-[Clipboard: Prompt]
-    ↓
-Claude.ai
-    ↓
-[Clipboard: Analyse markdown]
-    ↓
-insert_analysis.py
-    ↓
-workouts-history.md
-    ↓
-git commit (optionnel)
+       |
+       v
+PromptGenerator (prepare_analysis.py)
+       |
+       v
+PromptBuilder.build_prompt(mission="daily_feedback")
+       |
+       v
+AIProvider (claude_api / mistral_api / clipboard)
+       |
+       v
+HistoryMixin._insert_to_history()
+       |
+       v
+workouts-history.md (data repo)
+       |
+       v
+GitOpsMixin.step_7_git_commit()
 ```
 
 ---
 
-## 🛠️ Options de Ligne de Commande
+## Modes d'utilisation
 
-| Option | Description | Usage |
-|--------|-------------|-------|
-| `--skip-feedback` | Ne pas collecter le feedback athlète | Mode rapide |
-| `--skip-git` | Ne pas proposer le commit git | Commit manuel plus tard |
-| `--activity-id ID` | Analyser une séance spécifique | Rattrapage séances passées |
-
-### Exemples Combinés
-
+### Mode Standard
 ```bash
-# Séance spécifique, sans feedback, avec commit
-python3 scripts/workflow_coach.py --activity-id i123456 --skip-feedback
-
-# Analyse rapide de la dernière séance
-python3 scripts/workflow_coach.py --skip-feedback --skip-git
-
-# Workflow complet avec tout
-python3 scripts/workflow_coach.py
+poetry run workflow-coach
 ```
+Guidage complet interactif avec feedback, analyse AI, insertion, commit.
+
+### Mode Rapide
+```bash
+poetry run workflow-coach --skip-feedback --skip-git
+```
+Analyse uniquement, sans feedback ni commit.
+
+### Mode Asservissement
+```bash
+poetry run workflow-coach --servo-mode --week-id S085
+```
+Analyse + ajustement automatique du planning futur selon signaux de fatigue.
+
+### Mode Reconciliation
+```bash
+poetry run workflow-coach --reconcile --week-id S085
+```
+Detection des seances planifiees non executees, classification batch.
+
+### Mode Automatique
+```bash
+poetry run workflow-coach --auto
+```
+Non interactif, utilise pour automation LaunchAgent.
 
 ---
 
-## ⚠️ Gestion des Erreurs
+## Options de ligne de commande
 
-### Erreur API Intervals.icu
-**Symptôme** : `❌ Erreur lors de la préparation du prompt`
-
-**Solutions** :
-```bash
-# Vérifier la config
-cat ~/.intervals_config.json
-
-# Tester manuellement
-python3 scripts/prepare_analysis.py
-```
-
-### Format Markdown Invalide
-**Symptôme** : `❌ Erreur lors de l'insertion de l'analyse`
-
-**Solutions** :
-- Vérifier que seul le bloc markdown est copié (pas de texte avant/après)
-- Recopier la réponse de Claude
-- Valider le format avec `scripts/insert_analysis.py --dry-run`
-
-### Interruption (Ctrl+C)
-Le workflow gère proprement l'interruption à tout moment.
-
-**Actions** :
-- Relancer le script pour reprendre
-- Les étapes déjà complétées (feedback) sont conservées
-- Aucun fichier corrompu
+| Option | Description |
+|--------|-------------|
+| `--skip-feedback` | Ne pas collecter le feedback athlete |
+| `--skip-git` | Ne pas proposer le commit git |
+| `--activity-id ID` | Analyser une seance specifique (ID Intervals.icu, ex: `i129821327`) |
+| `--week-id SXXX` | Specifier la semaine cible |
+| `--servo-mode` | Activer l'asservissement planning |
+| `--reconcile` | Mode reconciliation batch |
+| `--auto` | Mode non interactif |
+| `--provider NAME` | Forcer un AI provider |
 
 ---
 
-## 🧪 Scénarios de Test
+## Gestion des erreurs
 
-### Test 1 : Workflow Complet
-```bash
-python3 scripts/workflow_coach.py
-# Vérifier guidage complet (7 étapes)
-# Tester avec feedback athlète
-# Vérifier commit git
-```
-
-### Test 2 : Mode Rapide
-```bash
-python3 scripts/workflow_coach.py --skip-feedback --skip-git
-# Vérifier workflow minimal (~3 min)
-```
-
-### Test 3 : Validation Refusée
-```bash
-python3 scripts/workflow_coach.py
-# À l'étape 5 (validation), répondre 'n'
-# Vérifier sortie propre
-```
+| Erreur | Cause | Solution |
+|--------|-------|----------|
+| Erreur API Intervals.icu | Credentials invalides | Verifier `~/.intervals_config.json` |
+| Format markdown invalide | Copie incorrecte | Recopier uniquement le bloc markdown |
+| Doublon detecte | Analyse deja inseree | Utiliser `scripts/debug/clean_duplicates.py` |
+| Interruption Ctrl+C | Arret utilisateur | Relancer, etapes deja completees conservees |
 
 ---
 
-## 🎯 Cas d'Usage
-
-### Analyse Post-Séance Immédiate
-**Contexte** : Viens de terminer une séance
-
-```bash
-# Avec feedback (recommandé)
-python3 scripts/workflow_coach.py
-
-# Sans feedback (rapide)
-python3 scripts/workflow_coach.py --skip-feedback
-```
-
-### Rattrapage Analyses Manquées
-**Contexte** : Plusieurs séances à analyser rétroactivement
-
-```bash
-# Séance 1
-python3 scripts/workflow_coach.py --activity-id i123456 --skip-feedback
-
-# Séance 2
-python3 scripts/workflow_coach.py --activity-id i123457 --skip-feedback
-
-# Commit groupé
-git add logs/workouts-history.md
-git commit -m "Analyses: Rattrapage semaine 067"
-```
-
-### Analyse Comparative Workout Planifié
-**Contexte** : Séance avec workout planifié dans Intervals.icu
-
-```bash
-python3 scripts/workflow_coach.py
-# Le script détecte automatiquement le workout planifié
-# Claude compare planifié vs réalisé
-```
-
----
-
-## 📚 Scripts Associés
-
-Le workflow coach orchestre ces scripts :
-
-| Script | Rôle | Documentation |
-|--------|------|---------------|
-| `collect_athlete_feedback.py` | Collecte ressenti | [WORKFLOW_WITH_FEEDBACK.md](WORKFLOW_WITH_FEEDBACK.md) |
-| `prepare_analysis.py` | Génère prompt | [README_ANALYSIS.md](README_ANALYSIS.md) |
-| `insert_analysis.py` | Insère analyse | [README_ANALYSIS.md](README_ANALYSIS.md) |
-
----
-
-## 💡 Bonnes Pratiques
-
-### ✅ À Faire
-
-- **Collecter le feedback systématiquement** pour analyses plus riches
-- **Valider l'analyse avant insertion** pour garantir qualité
-- **Commiter régulièrement** pour historique versionné
-- **Relire l'analyse** après insertion pour s'approprier les recommandations
-
-### ❌ À Éviter
-
-- Ne pas copier le texte explicatif de Claude (seulement markdown)
-- Ne pas skipper la validation (étape 6) par précipitation
-- Ne pas analyser plusieurs séances simultanément (risque confusion clipboard)
-- Ne pas modifier manuellement le markdown copié avant insertion
-
----
-
-## 🔧 Personnalisation
-
-### Changer le Message de Commit
-Éditer `workflow_coach.py` ligne ~450 :
-
-```python
-commit_msg = f"Analyse: {short_name}\n\nVotre message personnalisé"
-```
-
-### Ajouter des Validations Custom
-Ajouter dans `step_6_validate_analysis()` :
-
-```python
-# Vérification custom
-if "votre_critère" not in clipboard:
-    print("⚠️  Critère manquant")
-```
-
-### Modifier les Fichiers Contexte Chargés
-Le contexte est chargé automatiquement depuis 3 fichiers locaux :
-
-```python
-# Dans prepare_analysis.py
-generator.load_athlete_context()  # project_prompt_v2_1_revised.md
-generator.load_recent_workouts()  # workouts-history.md
-# + cycling_training_concepts.md (intégré dans le prompt)
-```
-
-Pour modifier le contexte, éditer directement ces fichiers markdown.
-
----
-
-## 📖 Ressources Complémentaires
-
-- **Démarrage rapide** : [QUICKSTART.md](QUICKSTART.md)
-- **Documentation technique** : [README_ANALYSIS.md](README_ANALYSIS.md)
-- **Feedback athlète** : [WORKFLOW_WITH_FEEDBACK.md](WORKFLOW_WITH_FEEDBACK.md)
-- **Bilans hebdo** : [WEEKLY_REPORT_WORKFLOW.md](WEEKLY_REPORT_WORKFLOW.md)
-- **Format analyse** : [EXAMPLE_ANALYSIS_FORMAT.md](EXAMPLE_ANALYSIS_FORMAT.md)
-
----
-
-## 🐛 Dépannage
-
-### Le script ne trouve pas `workouts-history.md`
-```bash
-# Vérifier le répertoire courant
-pwd
-
-# Naviguer vers la racine du projet
-cd /Users/stephanejouve/magma-cycling
-
-# Relancer
-python3 scripts/workflow_coach.py
-```
-
-### Le presse-papier est vide après `prepare_analysis.py`
-```bash
-# Tester manuellement
-python3 scripts/prepare_analysis.py
-pbpaste | head
-
-# Si vide, problème config Intervals.icu
-cat ~/.intervals_config.json
-```
-
-### Git commit échoue
-```bash
-# Vérifier git status
-git status
-
-# Vérifier config git
-git config user.name
-git config user.email
-
-# Commiter manuellement si nécessaire
-git add logs/workouts-history.md
-git commit -m "Analyse: Séance"
-```
-
----
-
-## 🎉 Avantages du Workflow Coach
-
-✅ **Guidage complet** : Plus besoin de se souvenir des commandes
-
-✅ **Validation intégrée** : Détection erreurs avant insertion
-
-✅ **Gain de temps** : Orchestration automatique des 3 scripts
-
-✅ **Flexibilité** : Options pour adapter à chaque cas d'usage
-
-✅ **Robustesse** : Gestion erreurs et interruptions
-
-✅ **Contexte adaptatif** : Détecte et s'adapte à l'environnement Claude
-
----
-
-**Prêt ?** → `python3 scripts/workflow_coach.py` 🚴
+**Version** : 2.0
+**Date** : Mars 2026

--- a/test-data/activities_tracking.json
+++ b/test-data/activities_tracking.json
@@ -2,8 +2,8 @@
   "2026-02-21": {
     "activities": [
       {
-        "id": "i126850020",
-        "activity_id": "i126850020",
+        "id": "iXXXXXXXXX",
+        "activity_id": "iXXXXXXXXX",
         "paired_event_id": null,
         "name": "S081-06-END-EnduranceLongue-V001",
         "type": "VirtualRide",


### PR DESCRIPTION
## Summary

- Rewrite 5 workflow docs (`project-docs/workflows/`) to reflect facade+mixins architecture (Phase 3)
- Replace all monolithic script references with `poetry run` commands and `Module:Class.method()` conventions
- Remove all P0/P7/P8 TODO items (all resolved), line number references, and obsolete code samples
- Add 10 Mermaid diagrams (6 GRAFCET + 4 UML) covering system overview, pipelines, and services
- Update `MCP_INTEGRATION.md`: 6 tools → 48 tools with full categorized table by handler
- Create onboarding hub `README.md` with quick-start, architecture diagram, and CLI reference
- Anonymize real activity ID in test data for public repo preparation

## Test plan

- [x] `poetry run pre-commit run --all-files` → 15/15 passed
- [x] Zero `python3 scripts/` references in workflow docs
- [x] Zero `fichier.py:ligne` references in workflow docs
- [x] Zero P0/P7/P8 TODO items
- [x] MCP tools count = 48 everywhere
- [x] Secrets audit: 0 secrets in committed code
- [ ] CI checks pass (6 required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)