### PR TITLE
chore: configure coverage exclusions and expand CI test scope

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,15 +103,9 @@ jobs:
         DATA_REPO_PATH: ${{ github.workspace }}/test-data
         CI: "true"
       run: |
-        # Run unit tests only (exclude integration tests and tests requiring external data)
-        poetry run pytest \
-          tests/config/ \
-          tests/intelligence/ \
-          tests/planning/ \
-          tests/reports/ \
-          tests/test_ai_providers/ \
-          tests/utils/ \
-          tests/workflows/test_insert_analysis.py \
+        # Run all unit tests (exclude integration tests only)
+        poetry run pytest tests/ \
+          --ignore=tests/integration \
           -v --cov=magma_cycling --cov-report=xml --cov-report=term --junitxml=junit.xml
       continue-on-error: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,35 @@ target-version = "py311"
 select = ["E", "W", "F", "I", "C", "B", "UP"]
 ignore = ["E501", "B008", "C901"]
 
+[tool.coverage.run]
+source = ["magma_cycling"]
+omit = [
+    "magma_cycling/fix_weekly_reports_casing.py",
+    "magma_cycling/normalize_weekly_reports_casing.py",
+    "magma_cycling/organize_weekly_report.py",
+    "magma_cycling/debug_detection.py",
+    "magma_cycling/diagnose-matching.py",
+    "magma_cycling/check_activity_sources.py",
+    "magma_cycling/dashboard.py",
+    "magma_cycling/session_monitor.py",
+    "magma_cycling/collect_athlete_feedback.py",
+    "magma_cycling/scripts/populate_zwift_cache.py",
+    "magma_cycling/scripts/search_zwift_workouts.py",
+    "magma_cycling/scripts/seed_zwift_workouts.py",
+    "magma_cycling/scripts/backfill_history.py",
+    "magma_cycling/scripts/initialize_pid_controller.py",
+    "magma_cycling/scripts/setup_withings.py",
+    "magma_cycling/scripts/withings_presync.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["-v"]


### PR DESCRIPTION
## Summary

- Add `[tool.coverage.run]` omitting one-shot scripts, debug tools, interactive CLIs, and thin CLI wrappers
- Add `[tool.coverage.report]` excluding `TYPE_CHECKING`, `__main__` guards, `NotImplementedError`
- Expand CI test scope from 7 explicit directories to `tests/ --ignore=tests/integration`

Local coverage: **57% → 71%** (zero tests written)

## Test plan

- [x] `poetry run pytest tests/ --cov=magma_cycling --cov-report=term -q` → 71%
- [x] Pre-commit all passed
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)