### PR TITLE
test: Phase 3A-3C — MCP handlers, servo_control, reconciliation

### DIFF
--- a/tests/_mcp/handlers/test_intervals_events.py
+++ b/tests/_mcp/handlers/test_intervals_events.py
@@ -1,0 +1,375 @@
+"""Tests for _mcp/handlers/intervals_events.py — event management handlers."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.intervals_events import (
+    handle_create_remote_note,
+    handle_delete_remote_session,
+    handle_list_remote_events,
+    handle_update_remote_session,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_client():
+    """Mock IntervalsClient returned by create_intervals_client."""
+    client = MagicMock()
+    client.delete_event.return_value = True
+    client.get_events.return_value = []
+    client.update_event.return_value = {"id": 42, "name": "updated"}
+    client.create_event.return_value = {"id": 99}
+    return client
+
+
+@pytest.fixture
+def mock_planning_dir(tmp_path):
+    """Create a temporary planning dir with one week file."""
+    planning_dir = tmp_path / "week_planning"
+    planning_dir.mkdir()
+
+    plan_data = {
+        "week_id": "S999",
+        "start_date": "2026-03-02",
+        "end_date": "2026-03-08",
+        "created_at": "2026-03-01T20:00:00Z",
+        "last_updated": "2026-03-01T20:00:00Z",
+        "version": 1,
+        "athlete_id": "iXXXXXX",
+        "tss_target": 350,
+        "planned_sessions": [
+            {
+                "session_id": "S999-01",
+                "date": "2026-03-02",
+                "name": "Endurance",
+                "type": "END",
+                "version": "V001",
+                "tss_planned": 50,
+                "duration_min": 60,
+                "description": "Endurance Z2",
+                "status": "uploaded",
+                "intervals_id": 42,
+                "description_hash": None,
+            },
+            {
+                "session_id": "S999-02",
+                "date": "2026-03-03",
+                "name": "Interval",
+                "type": "INT",
+                "version": "V001",
+                "tss_planned": 70,
+                "duration_min": 65,
+                "description": "Sweet Spot 3x10",
+                "status": "completed",
+                "intervals_id": 55,
+                "description_hash": None,
+            },
+        ],
+    }
+
+    plan_file = planning_dir / "week_planning_S999.json"
+    plan_file.write_text(json.dumps(plan_data))
+    return planning_dir
+
+
+@pytest.fixture
+def patch_tower(mock_planning_dir):
+    """Redirect planning_tower to use tmp_path (no mock — real singleton)."""
+    from magma_cycling.planning.control_tower import planning_tower
+
+    original_dir = planning_tower.planning_dir
+    original_backup_dir = planning_tower.backup_system.planning_dir
+    planning_tower.planning_dir = mock_planning_dir
+    planning_tower.backup_system.planning_dir = mock_planning_dir
+
+    yield mock_planning_dir
+
+    planning_tower.planning_dir = original_dir
+    planning_tower.backup_system.planning_dir = original_backup_dir
+
+
+# ---------------------------------------------------------------------------
+# handle_delete_remote_session
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDeleteRemoteSession:
+    """Tests for handle_delete_remote_session."""
+
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self):
+        """Returns error when confirm is not set."""
+        result = await handle_delete_remote_session({"event_id": 42})
+        data = json.loads(result[0].text)
+        assert "error" in data
+        assert "confirm" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_requires_confirmation_false(self):
+        """Returns error when confirm=False."""
+        result = await handle_delete_remote_session({"event_id": 42, "confirm": False})
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_successful_delete_no_local_match(self, mock_factory, mock_client):
+        """Deletes event from API when no local planning match found."""
+        mock_factory.return_value = mock_client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+
+            result = await handle_delete_remote_session({"event_id": 42, "confirm": True})
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["event_id"] == 42
+        mock_client.delete_event.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_delete_failure_returns_error(self, mock_factory, mock_client):
+        """Returns error when API delete fails."""
+        mock_client.delete_event.return_value = False
+        mock_factory.return_value = mock_client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+
+            result = await handle_delete_remote_session({"event_id": 42, "confirm": True})
+
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_blocks_delete_of_completed_session(self, mock_factory, patch_tower):
+        """Cannot delete a completed session (protection)."""
+        mock_factory.return_value = MagicMock()
+
+        result = await handle_delete_remote_session({"event_id": 55, "confirm": True})
+
+        data = json.loads(result[0].text)
+        assert "error" in data
+        assert "completed" in data["error"].lower() or "COMPLETED" in data.get("message", "")
+
+
+# ---------------------------------------------------------------------------
+# handle_list_remote_events
+# ---------------------------------------------------------------------------
+
+
+class TestHandleListRemoteEvents:
+    """Tests for handle_list_remote_events."""
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_list_events_empty(self, mock_factory, mock_client):
+        """Returns empty list when no events."""
+        mock_factory.return_value = mock_client
+
+        result = await handle_list_remote_events(
+            {"start_date": "2026-03-01", "end_date": "2026-03-07"}
+        )
+        data = json.loads(result[0].text)
+        assert data["total_events"] == 0
+        assert data["events"] == []
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_list_events_with_results(self, mock_factory):
+        """Returns formatted events."""
+        client = MagicMock()
+        client.get_events.return_value = [
+            {
+                "id": 1,
+                "category": "WORKOUT",
+                "name": "Endurance Z2",
+                "description": "Easy ride",
+                "start_date_local": "2026-03-02T08:00:00",
+                "type": "Ride",
+            }
+        ]
+        mock_factory.return_value = client
+
+        result = await handle_list_remote_events(
+            {"start_date": "2026-03-01", "end_date": "2026-03-07"}
+        )
+        data = json.loads(result[0].text)
+        assert data["total_events"] == 1
+        assert data["events"][0]["name"] == "Endurance Z2"
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_list_events_with_category_filter(self, mock_factory):
+        """Filters events by category."""
+        client = MagicMock()
+        client.get_events.return_value = [
+            {"id": 1, "category": "WORKOUT", "name": "W1"},
+            {"id": 2, "category": "NOTE", "name": "N1"},
+        ]
+        mock_factory.return_value = client
+
+        result = await handle_list_remote_events(
+            {"start_date": "2026-03-01", "end_date": "2026-03-07", "category": "NOTE"}
+        )
+        data = json.loads(result[0].text)
+        assert data["total_events"] == 1
+        assert data["filtered_by"] == "NOTE"
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_list_events_api_error(self, mock_factory):
+        """Returns error on API failure."""
+        mock_factory.side_effect = Exception("API down")
+
+        result = await handle_list_remote_events(
+            {"start_date": "2026-03-01", "end_date": "2026-03-07"}
+        )
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# handle_update_remote_session
+# ---------------------------------------------------------------------------
+
+
+class TestHandleUpdateRemoteSession:
+    """Tests for handle_update_remote_session."""
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_update_success_no_local_match(self, mock_factory):
+        """Updates event on API when no local planning match."""
+        client = MagicMock()
+        client.update_event.return_value = {"id": 42, "name": "Updated"}
+        mock_factory.return_value = client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+
+            result = await handle_update_remote_session(
+                {"event_id": 42, "updates": {"name": "New Name"}}
+            )
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert "name" in data["updated_fields"]
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_update_failure(self, mock_factory):
+        """Returns error when API update fails."""
+        client = MagicMock()
+        client.update_event.return_value = None
+        mock_factory.return_value = client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+
+            result = await handle_update_remote_session({"event_id": 42, "updates": {"name": "X"}})
+
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_blocks_update_of_completed_session(self, mock_factory, patch_tower):
+        """Cannot update a completed session."""
+        mock_factory.return_value = MagicMock()
+
+        result = await handle_update_remote_session({"event_id": 55, "updates": {"name": "X"}})
+        data = json.loads(result[0].text)
+        assert "error" in data
+        assert "completed" in data["error"].lower() or "COMPLETED" in data.get("message", "")
+
+
+# ---------------------------------------------------------------------------
+# handle_create_remote_note
+# ---------------------------------------------------------------------------
+
+
+class TestHandleCreateRemoteNote:
+    """Tests for handle_create_remote_note."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_prefix(self):
+        """Rejects note names without allowed prefix."""
+        result = await handle_create_remote_note(
+            {"date": "2026-03-02", "name": "Bad Name", "description": "test"}
+        )
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert "allowed_prefixes" in data
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_create_note_success(self, mock_factory, mock_client):
+        """Creates note on API successfully."""
+        mock_factory.return_value = mock_client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+
+            result = await handle_create_remote_note(
+                {
+                    "date": "2026-03-02",
+                    "name": "[ANNULÉE] S999-01 Endurance",
+                    "description": "Fatigue",
+                }
+            )
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert data["event_id"] == 99
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_create_note_api_failure(self, mock_factory):
+        """Returns error when API create fails."""
+        client = MagicMock()
+        client.create_event.return_value = {}  # no 'id' key
+        mock_factory.return_value = client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+
+            result = await handle_create_remote_note(
+                {
+                    "date": "2026-03-02",
+                    "name": "[SAUTÉE] S999-01 Endurance",
+                    "description": "Oubli",
+                }
+            )
+
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_create_note_with_local_planning_update(self, mock_factory, patch_tower):
+        """Creates note and updates local planning when session_id found."""
+        client = MagicMock()
+        client.create_event.return_value = {"id": 99}
+        mock_factory.return_value = client
+
+        result = await handle_create_remote_note(
+            {
+                "date": "2026-03-02",
+                "name": "[ANNULÉE] S999-01 Endurance",
+                "description": "Fatigue accumulée",
+            }
+        )
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        # Verify local planning was updated
+        assert "local planning" in data["message"].lower()

--- a/tests/workflows/test_reconciliation_mixin.py
+++ b/tests/workflows/test_reconciliation_mixin.py
@@ -1,0 +1,188 @@
+"""Tests for ReconciliationMixin — _display_reconciliation_report and reconcile_week."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.workflows.coach.reconciliation import ReconciliationMixin
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def reconciliation_result():
+    """Sample reconciliation result dict."""
+    return {
+        "matched": [
+            {
+                "session": {"session_id": "S999-01", "date": "2026-03-02"},
+                "activity": {"id": "a1"},
+            },
+        ],
+        "rest_days": [
+            {"session_id": "S999-03", "date": "2026-03-04"},
+        ],
+        "cancelled": [
+            {
+                "session_id": "S999-05",
+                "date": "2026-03-06",
+                "cancellation_reason": "Blessure genou droit",
+            },
+        ],
+        "skipped": [],
+        "unplanned": [],
+    }
+
+
+@pytest.fixture
+def mixin_with_planning():
+    """ReconciliationMixin with planning attribute set."""
+    mixin = ReconciliationMixin()
+    mixin.planning = {
+        "planned_sessions": [
+            {"session_id": "S999-01"},
+            {"session_id": "S999-02"},
+            {"session_id": "S999-03"},
+            {"session_id": "S999-04"},
+            {"session_id": "S999-05"},
+        ],
+    }
+    return mixin
+
+
+# ---------------------------------------------------------------------------
+# _display_reconciliation_report
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayReconciliationReport:
+    """Tests for _display_reconciliation_report output."""
+
+    def test_displays_session_counts(self, mixin_with_planning, reconciliation_result, capsys):
+        """Prints counts for matched, rest_days, cancelled."""
+        mixin_with_planning._display_reconciliation_report(reconciliation_result)
+
+        out = capsys.readouterr().out
+        assert "Sessions planifiées" in out
+        assert "Sessions exécutées" in out
+        assert "Repos planifiés" in out
+        assert "Séances annulées" in out
+
+    def test_displays_matched_sessions(self, mixin_with_planning, reconciliation_result, capsys):
+        """Lists matched sessions by session_id."""
+        mixin_with_planning._display_reconciliation_report(reconciliation_result)
+
+        out = capsys.readouterr().out
+        assert "S999-01" in out
+        assert "2026-03-02" in out
+
+    def test_displays_cancelled_with_reason(
+        self, mixin_with_planning, reconciliation_result, capsys
+    ):
+        """Lists cancelled sessions with truncated reason."""
+        mixin_with_planning._display_reconciliation_report(reconciliation_result)
+
+        out = capsys.readouterr().out
+        assert "S999-05" in out
+        assert "Blessure" in out
+
+    def test_displays_unplanned_activities(self, mixin_with_planning, capsys):
+        """Shows unplanned activities when present."""
+        result = {
+            "matched": [],
+            "rest_days": [],
+            "cancelled": [],
+            "unplanned": [
+                {"name": "Morning Run", "start_date_local": "2026-03-05T07:00:00"},
+            ],
+        }
+
+        mixin_with_planning._display_reconciliation_report(result)
+
+        out = capsys.readouterr().out
+        assert "non planifiées" in out
+        assert "Morning Run" in out
+
+    def test_no_unplanned_section_when_empty(
+        self, mixin_with_planning, reconciliation_result, capsys
+    ):
+        """No unplanned section when list is empty."""
+        mixin_with_planning._display_reconciliation_report(reconciliation_result)
+
+        out = capsys.readouterr().out
+        assert "non planifiées" not in out
+
+
+# ---------------------------------------------------------------------------
+# reconcile_week
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileWeek:
+    """Tests for reconcile_week workflow."""
+
+    def test_returns_early_on_api_error(self, capsys):
+        """Returns early when _get_api raises ValueError."""
+        mixin = ReconciliationMixin()
+        mixin.clear_screen = MagicMock()
+        mixin.print_header = MagicMock()
+        mixin._get_api = MagicMock(side_effect=ValueError("No credentials"))
+
+        mixin.reconcile_week("S999")
+
+        out = capsys.readouterr().out
+        assert "Credentials" in out
+
+    @patch("magma_cycling.workflows.coach.reconciliation.load_week_planning")
+    def test_returns_early_on_missing_planning(self, mock_load, capsys):
+        """Returns early when planning file not found."""
+        mock_load.side_effect = FileNotFoundError("not found")
+
+        mixin = ReconciliationMixin()
+        mixin.clear_screen = MagicMock()
+        mixin.print_header = MagicMock()
+        mixin._get_api = MagicMock(return_value=MagicMock())
+
+        with patch("magma_cycling.workflows.coach.reconciliation.get_data_config") as mock_config:
+            mock_config.return_value = MagicMock(week_planning_dir="/tmp/fake")
+            mixin.reconcile_week("S999")
+
+        out = capsys.readouterr().out
+        assert "non trouvé" in out
+
+    @patch("magma_cycling.workflows.coach.reconciliation.reconcile_planned_vs_actual")
+    @patch("magma_cycling.workflows.coach.reconciliation.load_week_planning")
+    @patch("magma_cycling.workflows.coach.reconciliation.get_data_config")
+    def test_displays_summary_no_skipped(self, mock_config, mock_load, mock_reconcile, capsys):
+        """Shows summary when no skipped sessions (no interactive prompts)."""
+        mock_config.return_value = MagicMock(week_planning_dir="/tmp/fake")
+
+        planning = MagicMock()
+        planning.start_date = "2026-03-02"
+        planning.end_date = "2026-03-08"
+        planning.planned_sessions = []
+        mock_load.return_value = planning
+
+        api = MagicMock()
+        api.get_activities.return_value = []
+
+        mock_reconcile.return_value = {
+            "matched": [],
+            "skipped": [],
+            "cancelled": [],
+            "rest_days": [{"session_id": "S999-03", "date": "2026-03-04", "name": "Repos"}],
+        }
+
+        mixin = ReconciliationMixin()
+        mixin.clear_screen = MagicMock()
+        mixin.print_header = MagicMock()
+        mixin._get_api = MagicMock(return_value=api)
+
+        mixin.reconcile_week("S999")
+
+        out = capsys.readouterr().out
+        assert "RÉCONCILIATION" in out
+        assert "Repos planifiés" in out
+        assert "TERMINÉE" in out

--- a/tests/workflows/test_servo_control_extended.py
+++ b/tests/workflows/test_servo_control_extended.py
@@ -1,0 +1,349 @@
+"""Extended tests for servo_control — _update_planning_json, _apply_lighten, routing."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from magma_cycling.planning.models import WeeklyPlan
+from magma_cycling.workflows.coach.servo_control import ServoControlMixin
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def planning_data():
+    """Sample planning data with multiple sessions."""
+    return {
+        "week_id": "S999",
+        "start_date": "2026-03-02",
+        "end_date": "2026-03-08",
+        "created_at": "2026-02-01T20:00:00Z",
+        "last_updated": "2026-02-01T20:00:00Z",
+        "version": 1,
+        "athlete_id": "iXXXXXX",
+        "tss_target": 350,
+        "planned_sessions": [
+            {
+                "session_id": "S999-01",
+                "date": "2026-03-02",
+                "name": "Endurance",
+                "type": "END",
+                "version": "V001",
+                "tss_planned": 50,
+                "duration_min": 60,
+                "description": "Endurance Z2",
+                "status": "planned",
+                "intervals_id": None,
+                "description_hash": None,
+            },
+            {
+                "session_id": "S999-02",
+                "date": "2026-03-04",
+                "name": "SweetSpot",
+                "type": "INT",
+                "version": "V001",
+                "tss_planned": 70,
+                "duration_min": 65,
+                "description": "Sweet Spot 3x10",
+                "status": "planned",
+                "intervals_id": 12345,
+                "description_hash": None,
+            },
+            {
+                "session_id": "S999-03",
+                "date": "2026-03-06",
+                "name": "Endurance Long",
+                "type": "END",
+                "version": "V001",
+                "tss_planned": 80,
+                "duration_min": 90,
+                "description": "Endurance longue Z2",
+                "status": "planned",
+                "intervals_id": None,
+                "description_hash": None,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_control_tower(tmp_path, planning_data):
+    """Mock Control Tower to use tmp_path for planning."""
+    from magma_cycling.planning.control_tower import planning_tower
+
+    original_planning_dir = planning_tower.planning_dir
+    original_backup_dir = planning_tower.backup_system.planning_dir
+    planning_tower.planning_dir = tmp_path
+    planning_tower.backup_system.planning_dir = tmp_path
+
+    planning_file = tmp_path / "week_planning_S999.json"
+    with open(planning_file, "w", encoding="utf-8") as f:
+        json.dump(planning_data, f, indent=2)
+
+    yield tmp_path
+
+    planning_tower.planning_dir = original_planning_dir
+    planning_tower.backup_system.planning_dir = original_backup_dir
+
+
+# ---------------------------------------------------------------------------
+# _update_planning_json
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePlanningJson:
+    """Tests for _update_planning_json."""
+
+    def test_updates_session_fields(self, mock_control_tower):
+        """Updates session type, tss, description via Control Tower."""
+        mixin = ServoControlMixin()
+        new_workout = {
+            "code": "S999-01-REC-Recovery-V001",
+            "session_id": "S999-01",
+            "name": "Recovery",
+            "type": "REC",
+            "tss": 25,
+            "description": "Recovery spin 40min Z1",
+        }
+
+        result = mixin._update_planning_json(
+            week_id="S999",
+            date="2026-03-02",
+            new_workout=new_workout,
+            old_workout="S999-01-END-Endurance-V001",
+            reason="Fatigue accumulée",
+        )
+
+        assert result is True
+
+        # Verify planning file updated
+        plan = WeeklyPlan.from_json(mock_control_tower / "week_planning_S999.json")
+        session = plan.planned_sessions[0]
+        assert session.session_type == "REC"
+        assert session.tss_planned == 25
+        assert session.status == "modified"
+
+    def test_returns_false_for_missing_date(self, mock_control_tower):
+        """Returns False when no session matches the target date."""
+        mixin = ServoControlMixin()
+        new_workout = {
+            "code": "S999-99-REC-V001",
+            "type": "REC",
+            "tss": 20,
+            "description": "Test",
+        }
+
+        result = mixin._update_planning_json(
+            week_id="S999",
+            date="2099-01-01",
+            new_workout=new_workout,
+            old_workout="OLD",
+            reason="test",
+        )
+
+        assert result is False
+
+    def test_returns_false_for_missing_week(self, mock_control_tower):
+        """Returns False when week planning file doesn't exist."""
+        mixin = ServoControlMixin()
+        new_workout = {"code": "X", "type": "REC", "tss": 20, "description": "Test"}
+
+        result = mixin._update_planning_json(
+            week_id="S000",
+            date="2026-03-02",
+            new_workout=new_workout,
+            old_workout="OLD",
+            reason="test",
+        )
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _apply_lighten
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLighten:
+    """Tests for _apply_lighten."""
+
+    def test_auto_mode_stores_recommendation(self, mock_control_tower):
+        """In auto_mode, stores recommendation without applying."""
+        mixin = ServoControlMixin()
+        mixin.auto_mode = True
+        mixin.workout_templates = {
+            "recovery_active_30tss": {
+                "name": "Recovery Active 30 TSS",
+                "type": "REC",
+                "tss": 30,
+                "duration_minutes": 45,
+                "description": "45min Z1-Z2 easy spin",
+                "workout_code_pattern": "S{week_id}-{day_num}-REC-V001",
+                "intervals_icu_format": "[WARMUP 10:00 Z1]",
+            },
+        }
+
+        mod = {
+            "action": "lighten",
+            "target_date": "2026-03-04",
+            "current_workout": "S999-02-INT-SweetSpot-V001",
+            "template_id": "recovery_active_30tss",
+            "reason": "Découplage 11.2%",
+        }
+
+        mixin._apply_lighten(mod, "S999")
+
+        assert hasattr(mixin, "_servo_recommendations")
+        assert len(mixin._servo_recommendations) == 1
+        rec = mixin._servo_recommendations[0]
+        assert rec["template"] == "Recovery Active 30 TSS"
+        assert rec["tss"] == 30
+        assert rec["status"] == "pending_manual_application"
+
+    def test_unknown_template_prints_error(self, mock_control_tower, capsys):
+        """Prints error for unknown template_id."""
+        mixin = ServoControlMixin()
+        mixin.auto_mode = True
+        mixin.workout_templates = {}
+
+        mod = {
+            "action": "lighten",
+            "target_date": "2026-03-04",
+            "current_workout": "S999-02-INT",
+            "template_id": "nonexistent_template",
+            "reason": "test",
+        }
+
+        mixin._apply_lighten(mod, "S999")
+
+        captured = capsys.readouterr()
+        assert "Template inconnu" in captured.out
+
+    @patch("sys.stdin")
+    def test_non_tty_stores_recommendation(self, mock_stdin, mock_control_tower):
+        """Non-tty mode stores recommendation without interactive prompt."""
+        mock_stdin.isatty.return_value = False
+
+        mixin = ServoControlMixin()
+        mixin.auto_mode = False
+        mixin.workout_templates = {
+            "recovery_short_20tss": {
+                "name": "Recovery Short 20 TSS",
+                "type": "REC",
+                "tss": 20,
+                "duration_minutes": 30,
+                "description": "30min Z1",
+                "workout_code_pattern": "S{week_id}-{day_num}-REC-V001",
+                "intervals_icu_format": "[STEADY 30:00 Z1]",
+            },
+        }
+
+        mod = {
+            "action": "lighten",
+            "target_date": "2026-03-04",
+            "current_workout": "CODE",
+            "template_id": "recovery_short_20tss",
+            "reason": "Sommeil < 5h",
+        }
+
+        mixin._apply_lighten(mod, "S999")
+
+        assert hasattr(mixin, "_servo_recommendations")
+        assert len(mixin._servo_recommendations) == 1
+
+
+# ---------------------------------------------------------------------------
+# apply_planning_modifications — routing
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPlanningModificationsRouting:
+    """Tests for apply_planning_modifications dispatch logic."""
+
+    def test_empty_modifications_no_op(self, capsys):
+        """Empty list prints 'maintained' message."""
+        mixin = ServoControlMixin()
+        mixin.apply_planning_modifications([], "S999")
+
+        captured = capsys.readouterr()
+        assert "maintenu" in captured.out
+
+    @patch.object(ServoControlMixin, "_apply_lighten")
+    def test_lighten_action_routed(self, mock_lighten):
+        """Lighten action dispatches to _apply_lighten."""
+        mixin = ServoControlMixin()
+        mods = [
+            {
+                "action": "lighten",
+                "target_date": "2026-03-04",
+                "current_workout": "CODE",
+                "template_id": "recovery_active_30tss",
+                "reason": "Fatigue",
+            },
+        ]
+
+        mixin.apply_planning_modifications(mods, "S999")
+        mock_lighten.assert_called_once_with(mods[0], "S999")
+
+    def test_reschedule_prints_warning(self, capsys):
+        """Reschedule prints not-implemented warning."""
+        mixin = ServoControlMixin()
+        mods = [
+            {
+                "action": "reschedule",
+                "target_date": "2026-03-04",
+                "current_workout": "CODE",
+                "reason": "test",
+            },
+        ]
+
+        mixin.apply_planning_modifications(mods, "S999")
+
+        captured = capsys.readouterr()
+        assert "reschedule" in captured.out
+
+    def test_unknown_action_prints_warning(self, capsys):
+        """Unknown action prints warning."""
+        mixin = ServoControlMixin()
+        mods = [
+            {
+                "action": "teleport",
+                "target_date": "2026-03-04",
+                "current_workout": "CODE",
+                "reason": "test",
+            },
+        ]
+
+        mixin.apply_planning_modifications(mods, "S999")
+
+        captured = capsys.readouterr()
+        assert "inconnue" in captured.out
+
+    @patch.object(ServoControlMixin, "_apply_lighten")
+    @patch.object(ServoControlMixin, "_apply_rest_day")
+    def test_multiple_modifications_dispatched(self, mock_rest, mock_lighten):
+        """Multiple modifications each dispatch to correct handler."""
+        mixin = ServoControlMixin()
+        mods = [
+            {
+                "action": "lighten",
+                "target_date": "2026-03-04",
+                "current_workout": "A",
+                "template_id": "t1",
+                "reason": "r1",
+            },
+            {
+                "action": "rest_day",
+                "target_date": "2026-03-06",
+                "current_workout": "B",
+                "reason": "r2",
+            },
+        ]
+
+        mixin.apply_planning_modifications(mods, "S999")
+
+        mock_lighten.assert_called_once_with(mods[0], "S999")
+        mock_rest.assert_called_once_with(mods[1], "S999")


### PR DESCRIPTION
## Summary

PR F of the coverage improvement plan — Phase 3A-3C (mock API tests).

- **16 tests** for `_mcp/handlers/intervals_events.py` (delete, list, update, create-note)
- **11 tests** for `workflows/coach/servo_control.py` (_update_planning_json, _apply_lighten, routing)
- **8 tests** for `workflows/coach/reconciliation.py` (display report, reconcile_week paths)

Total: **35 new tests**, 2396 suite-wide passing.

## Test plan

- [x] `poetry run pytest tests/ -x -q` → 2396 passed
- [x] Pre-commit all passed
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)