### PR TITLE
feat(mcp): pre-session-check tool + blood pressure integration

### DIFF
--- a/magma_cycling/_mcp/handlers/rest.py
+++ b/magma_cycling/_mcp/handlers/rest.py
@@ -1,0 +1,179 @@
+"""Rest and recovery handlers — pre-session safety gate."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import TYPE_CHECKING
+
+from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
+
+__all__ = ["handle_pre_session_check"]
+
+logger = logging.getLogger(__name__)
+
+
+def _find_week_id_for_date(target: date) -> str | None:
+    """Find the week_id whose date range contains *target*."""
+    import json
+
+    from magma_cycling.config import get_data_config
+
+    config = get_data_config()
+    for path in sorted(config.week_planning_dir.glob("week_planning_S*.json")):
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        start = data.get("start_date")
+        end = data.get("end_date")
+        if start and end:
+            sd = date.fromisoformat(start)
+            ed = date.fromisoformat(end)
+            if sd <= target <= ed:
+                return data.get("week_id")
+    return None
+
+
+def _find_session_for_date(week_id: str, target: date) -> dict | None:
+    """Return the first planned session matching *target* in the planning."""
+    from magma_cycling.planning.control_tower import planning_tower
+
+    try:
+        plan = planning_tower.read_week(week_id)
+    except FileNotFoundError:
+        return None
+
+    for session in plan.planned_sessions:
+        if session.session_date == target:
+            return {
+                "session_id": session.session_id,
+                "name": session.name,
+                "tss_planned": session.tss_planned,
+                "session_type": session.session_type,
+                "duration_min": session.duration_min,
+                "status": session.status,
+            }
+    return None
+
+
+async def handle_pre_session_check(args: dict) -> list[TextContent]:
+    """Pre-session safety gate: Withings sync + veto protocol."""
+    with suppress_stdout_stderr():
+        from magma_cycling.config import AthleteProfile, create_intervals_client
+        from magma_cycling.health import create_health_provider
+        from magma_cycling.workflows.rest.veto_check import check_pre_session_veto
+
+        # 1. Parse date
+        date_str = args.get("date")
+        target = date.fromisoformat(date_str) if date_str else date.today()
+        date_str = target.isoformat()
+
+        # 2. Withings sync (best-effort — fallback to cached data)
+        wellness_source = "fresh"
+        try:
+            from magma_cycling._mcp.handlers.withings import (
+                sync_withings_to_intervals,
+            )
+
+            sync_withings_to_intervals(
+                start_date=target,
+                end_date=target,
+                data_types=["sleep"],
+            )
+        except Exception as exc:
+            logger.warning("Withings sync failed, using cached data: %s", exc)
+            wellness_source = "cached"
+
+        # 3. Wellness from Intervals.icu
+        client = create_intervals_client()
+        wellness_list = client.get_wellness(oldest=date_str, newest=date_str)
+        wellness_raw = wellness_list[0] if wellness_list else {}
+
+        sleep_hours = wellness_raw.get("sleepTime")
+        if sleep_hours and isinstance(sleep_hours, (int, float)) and sleep_hours > 24:
+            # sleepTime is in seconds from Intervals.icu
+            sleep_hours = round(sleep_hours / 3600, 2)
+
+        wellness = {
+            "ctl": wellness_raw.get("ctl", 0),
+            "atl": wellness_raw.get("atl", 0),
+            "tsb": wellness_raw.get("ctl", 0) - wellness_raw.get("atl", 0),
+            "sleep_hours": sleep_hours,
+            "systolic": wellness_raw.get("systolic"),
+            "diastolic": wellness_raw.get("diastolic"),
+        }
+
+        # 4. Readiness from HealthProvider (best-effort, before veto)
+        readiness_data = None
+        try:
+            provider = create_health_provider()
+            readiness = provider.get_readiness(target)
+            if readiness:
+                readiness_data = readiness.model_dump(mode="json")
+                # Enrich wellness with Withings sleep if Intervals.icu has none
+                if wellness["sleep_hours"] is None and readiness.sleep_hours:
+                    wellness["sleep_hours"] = readiness.sleep_hours
+        except Exception:
+            pass
+
+        # 5. Planned session from planning
+        week_id = args.get("week_id") or _find_week_id_for_date(target)
+        session_info = None
+        if week_id:
+            session_info = _find_session_for_date(week_id, target)
+
+        # 6. Athlete profile
+        profile = AthleteProfile.from_env()
+
+        # 7. Veto check
+        intensity = None
+        if session_info and session_info.get("session_type") in (
+            "INT",
+            "VO2",
+            "FRC",
+            "TMP",
+            "MAP",
+        ):
+            intensity = 90.0  # high-intensity proxy
+
+        veto_result = check_pre_session_veto(
+            wellness_data=wellness,
+            athlete_profile=profile.model_dump(),
+            session_intensity=intensity,
+        )
+
+        # 8. Build verdict
+        if veto_result["veto"]:
+            verdict = "VETO"
+        elif veto_result["risk_level"] in ("high", "medium"):
+            verdict = "CAUTION"
+        else:
+            verdict = "GO"
+
+        result = {
+            "date": date_str,
+            "verdict": verdict,
+            "risk_level": veto_result["risk_level"],
+            "veto": veto_result["veto"],
+            "factors": veto_result["factors"],
+            "recommendation": veto_result["recommendation"],
+            "wellness": wellness,
+            "wellness_source": wellness_source,
+        }
+
+        if session_info:
+            result["session"] = session_info
+        else:
+            result["session"] = None
+            result["session_note"] = (
+                "No planned session found for this date"
+                if week_id
+                else "Could not auto-detect week_id — provide week_id parameter"
+            )
+
+        if readiness_data:
+            result["readiness"] = readiness_data
+
+    return mcp_response(result)

--- a/magma_cycling/_mcp/schemas/rest.py
+++ b/magma_cycling/_mcp/schemas/rest.py
@@ -1,0 +1,32 @@
+"""Rest and recovery tool schemas."""
+
+from mcp.types import Tool
+
+
+def get_tools() -> list[Tool]:
+    """Return rest and recovery tool schemas."""
+    return [
+        Tool(
+            name="pre-session-check",
+            description=(
+                "Pre-session safety check: evaluates sleep, fatigue (TSB), "
+                "and overtraining risk before a planned session. "
+                "Forces a Withings sync then runs the veto protocol."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "description": "Date to check (YYYY-MM-DD, default: today)",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    },
+                    "week_id": {
+                        "type": "string",
+                        "description": "Week ID (default: auto-detect from date)",
+                        "pattern": "^S\\d{3}$",
+                    },
+                },
+            },
+        ),
+    ]

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -64,10 +64,6 @@ from magma_cycling._mcp.handlers.intervals import (  # noqa: F401
     handle_sync_week_to_intervals,
     handle_update_remote_session,
 )
-
-# ---------------------------------------------------------------------------
-# Re-exports — backward compat: all 43 handlers importable from mcp_server
-# ---------------------------------------------------------------------------
 from magma_cycling._mcp.handlers.planning import (  # noqa: F401
     handle_create_session,
     handle_daily_sync,
@@ -80,6 +76,13 @@ from magma_cycling._mcp.handlers.planning import (  # noqa: F401
     handle_rename_session,
     handle_update_session,
     handle_weekly_planner,
+)
+
+# ---------------------------------------------------------------------------
+# Re-exports — backward compat: all 43 handlers importable from mcp_server
+# ---------------------------------------------------------------------------
+from magma_cycling._mcp.handlers.rest import (  # noqa: F401
+    handle_pre_session_check,
 )
 from magma_cycling._mcp.handlers.sessions import (  # noqa: F401
     handle_attach_workout,
@@ -108,6 +111,7 @@ from magma_cycling._mcp.schemas import athlete as _s_athlete
 from magma_cycling._mcp.schemas import catalog as _s_catalog
 from magma_cycling._mcp.schemas import intervals as _s_intervals
 from magma_cycling._mcp.schemas import planning as _s_planning
+from magma_cycling._mcp.schemas import rest as _s_rest
 from magma_cycling._mcp.schemas import sessions as _s_sessions
 from magma_cycling._mcp.schemas import withings as _s_withings
 from magma_cycling._mcp.schemas import workouts as _s_workouts
@@ -139,6 +143,7 @@ async def list_tools() -> list[Tool]:
         *_s_admin.get_tools(),
         *_s_catalog.get_tools(),
         *_s_withings.get_tools(),
+        *_s_rest.get_tools(),
     ]
 
 
@@ -203,6 +208,8 @@ TOOL_HANDLERS = {
     "withings-sync-to-intervals": handle_withings_sync_to_intervals,
     "withings-analyze-trends": handle_withings_analyze_trends,
     "withings-enrich-session": handle_withings_enrich_session,
+    # Rest / Recovery (1)
+    "pre-session-check": handle_pre_session_check,
 }
 
 

--- a/magma_cycling/prompts/prompt_builder.py
+++ b/magma_cycling/prompts/prompt_builder.py
@@ -49,6 +49,10 @@ def load_current_metrics() -> dict:
             metrics["ctl"] = day.get("ctl")
             metrics["atl"] = day.get("atl")
             metrics["ramp_rate"] = day.get("rampRate")
+            if day.get("systolic"):
+                metrics["systolic"] = day["systolic"]
+            if day.get("diastolic"):
+                metrics["diastolic"] = day["diastolic"]
     except Exception:
         logger.debug("Could not load Intervals.icu metrics, skipping CTL/ATL")
 
@@ -287,6 +291,26 @@ def format_athlete_profile(context: dict, metrics: dict) -> str:
         consec = metrics.get("consecutive_training_days")
         if consec and consec >= 2:
             lines.append(f"  - Jours consecutifs: {consec}")
+
+    # Blood pressure (cardiovascular recovery marker)
+    sys_bp = metrics.get("systolic")
+    dia_bp = metrics.get("diastolic")
+    if sys_bp or dia_bp:
+        bp_str = f"{sys_bp or '?'}/{dia_bp or '?'} mmHg"
+        if sys_bp and sys_bp >= 140:
+            bp_label = "ELEVEE - surveillance"
+        elif sys_bp and sys_bp >= 130:
+            bp_label = "limite haute"
+        else:
+            bp_label = "normale"
+        lines.append(f"  - Tension: {bp_str} ({bp_label})")
+        if sys_bp and sys_bp >= 140 and metrics.get("tsb") is not None:
+            tsb_val = metrics["tsb"]
+            if tsb_val < -10:
+                lines.append(
+                    "  - ATTENTION: tension elevee + fatigue (TSB < -10)"
+                    " → risque cardiovasculaire accru"
+                )
 
     # Constraints
     constraints = context.get("constraints", [])

--- a/magma_cycling/workflows/rest/veto_check.py
+++ b/magma_cycling/workflows/rest/veto_check.py
@@ -26,6 +26,8 @@ def check_pre_session_veto(
             - atl: Acute Training Load (fatigue)
             - tsb: Training Stress Balance (form)
             - sleep_hours: Hours of sleep (optional)
+            - systolic: Systolic blood pressure in mmHg (optional)
+            - diastolic: Diastolic blood pressure in mmHg (optional)
         athlete_profile: Athlete characteristics:
             - age: Athlete age
             - category: 'junior', 'senior', or 'master'
@@ -98,6 +100,33 @@ def check_pre_session_veto(
     risk_result = detect_overtraining_risk(
         ctl=ctl, atl=atl, tsb=tsb, sleep_hours=sleep_hours, profile=athlete_profile
     )
+
+    # Blood pressure checks (optional — skip if data absent)
+    systolic = wellness_data.get("systolic")
+    diastolic = wellness_data.get("diastolic")
+
+    if systolic is not None and isinstance(systolic, (int, float)):
+        if systolic > 150:
+            risk_result["factors"].append(f"Systolic BP critical ({systolic} mmHg > 150)")
+            risk_result["risk_level"] = "critical"
+            risk_result["veto"] = True
+        elif systolic >= 140:
+            risk_result["factors"].append(f"Systolic BP elevated ({systolic} mmHg >= 140)")
+            if risk_result["risk_level"] == "low":
+                risk_result["risk_level"] = "high"
+
+    if diastolic is not None and isinstance(diastolic, (int, float)):
+        if diastolic > 95:
+            risk_result["factors"].append(f"Diastolic BP elevated ({diastolic} mmHg > 95)")
+            if risk_result["risk_level"] in ("low", "medium"):
+                risk_result["risk_level"] = "high"
+
+    # Update recommendation if BP triggered escalation
+    if risk_result["veto"] and not risk_result.get("_recommendation_set"):
+        if systolic is not None and systolic > 150:
+            risk_result["recommendation"] = (
+                "VETO: Tension arterielle critique. " "Repos complet, consulter si persistant."
+            )
 
     # Build result with additional context
     result = {


### PR DESCRIPTION
## Summary
- New MCP tool `pre-session-check` (#49) — pre-session safety gate combining Withings sync, wellness, planning lookup, and veto protocol in one call
- Blood pressure thresholds in `veto_check`: systolic >150 → VETO, 140-150 → CAUTION, diastolic >95 → CAUTION
- BP data exposed in `pre-session-check` handler wellness block (systolic/diastolic)
- BP context added to AI coach prompts with combined fatigue+hypertension alert

## Files changed
- `magma_cycling/_mcp/handlers/rest.py` (new)
- `magma_cycling/_mcp/schemas/rest.py` (new)
- `magma_cycling/mcp_server.py` (registration)
- `magma_cycling/workflows/rest/veto_check.py` (BP thresholds)
- `magma_cycling/prompts/prompt_builder.py` (BP in metrics + prompts)

## Test plan
- [x] 2557 existing tests pass (zero regression)
- [x] Pre-commit all green
- [x] 5 BP threshold cases validated manually
- [x] Tool count 48 → 49 confirmed
- [ ] Live test via MCP reload + `pre-session-check` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)