### PR TITLE
feat(maintenance): GitHub API utilities (CI monitor + secrets)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2839,6 +2839,48 @@ docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
+name = "pynacl"
+version = "1.6.2"
+description = "Python binding to the Networking and Cryptography (NaCl) library"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88"},
+    {file = "pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14"},
+    {file = "pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444"},
+    {file = "pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b"},
+    {file = "pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145"},
+    {file = "pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590"},
+    {file = "pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2"},
+    {file = "pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130"},
+    {file = "pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6"},
+    {file = "pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e"},
+    {file = "pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577"},
+    {file = "pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa"},
+    {file = "pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0"},
+    {file = "pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c"},
+    {file = "pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\" and python_version >= \"3.9\""}
+
+[package.extras]
+docs = ["sphinx (<7)", "sphinx_rtd_theme"]
+tests = ["hypothesis (>=3.27.0)", "pytest (>=7.4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 description = "pyparsing - Classes and methods to define and execute parsing grammars"
@@ -3897,4 +3939,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "3b6582bd018f74af6186f7fbeaebad7a44276e8e23253a54738a231da32ad02b"
+content-hash = "d083703fc5d71fbb1c5781d12506aa3f51210c0d8d75778edff08f13303b5e16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ beautifulsoup4 = "^4.12.0"
 numpy = "^2.4.2"
 mcp = "^1.26.0"
 mcp-http-transport = "^0.1.0"
+pynacl = "^1.6.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.0"

--- a/scripts/maintenance/github_utils.py
+++ b/scripts/maintenance/github_utils.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""GitHub API utilities for CI monitoring and secrets management.
+
+Provides two CLI sub-commands:
+  wait-ci <pr_number>   — poll PR check runs until completion
+  set-secret <name>     — upload an encrypted GitHub Actions secret
+
+Requires: requests, pynacl (for set-secret only).
+Token read from macOS keychain (github_token_cyclisme).
+"""
+
+import argparse
+import base64
+import subprocess
+import sys
+import time
+
+import requests
+
+OWNER = "stephanejouve"
+REPO = "magma-cycling"
+API_BASE = f"https://api.github.com/repos/{OWNER}/{REPO}"
+IGNORED_CHECKS = {"codecov/patch"}
+POLL_INTERVAL = 15
+
+
+def _get_token():
+    """Retrieve GitHub token from macOS keychain."""
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", "github_token_cyclisme", "-w"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        print("Error: cannot read github_token_cyclisme from keychain")
+        sys.exit(1)
+
+
+def _headers(token):
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _keychain_value(service):
+    """Read a value from macOS keychain by service name."""
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", service, "-w"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        print(f"Error: cannot read '{service}' from keychain")
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# wait-ci
+# ---------------------------------------------------------------------------
+
+
+def wait_ci(pr_number):
+    """Poll check runs for a PR until all complete."""
+    token = _get_token()
+    hdrs = _headers(token)
+
+    # Get HEAD SHA
+    resp = requests.get(f"{API_BASE}/pulls/{pr_number}", headers=hdrs, timeout=15)
+    resp.raise_for_status()
+    sha = resp.json()["head"]["sha"]
+    print(f"PR #{pr_number} — HEAD {sha[:8]}")
+
+    while True:
+        resp = requests.get(f"{API_BASE}/commits/{sha}/check-runs", headers=hdrs, timeout=15)
+        resp.raise_for_status()
+        runs = resp.json().get("check_runs", [])
+
+        pending = []
+        failed = []
+        passed = []
+        for r in runs:
+            name = r["name"]
+            if name in IGNORED_CHECKS:
+                continue
+            status = r["status"]
+            conclusion = r.get("conclusion")
+            if status != "completed":
+                pending.append(name)
+            elif conclusion == "success":
+                passed.append(name)
+            else:
+                failed.append((name, conclusion))
+
+        # Display current state
+        print(
+            f"\n[{time.strftime('%H:%M:%S')}] — {len(passed)} passed, "
+            f"{len(pending)} pending, {len(failed)} failed"
+        )
+        for name in pending:
+            print(f"  ⏳ {name}")
+        for name, conclusion in failed:
+            print(f"  ❌ {name} ({conclusion})")
+        for name in passed:
+            print(f"  ✅ {name}")
+
+        if not pending:
+            if failed:
+                print(f"\nCI failed ({len(failed)} check(s))")
+                sys.exit(1)
+            print(f"\nAll {len(passed)} checks passed")
+            return
+
+        time.sleep(POLL_INTERVAL)
+
+
+# ---------------------------------------------------------------------------
+# set-secret
+# ---------------------------------------------------------------------------
+
+
+def set_secret(secret_name, value):
+    """Upload an encrypted secret to GitHub Actions."""
+    from nacl.public import PublicKey, SealedBox
+
+    token = _get_token()
+    hdrs = _headers(token)
+
+    # Get repo public key
+    resp = requests.get(f"{API_BASE}/actions/secrets/public-key", headers=hdrs, timeout=15)
+    resp.raise_for_status()
+    key_data = resp.json()
+    pub_key = PublicKey(base64.b64decode(key_data["key"]))
+    key_id = key_data["key_id"]
+
+    # Encrypt
+    sealed = SealedBox(pub_key)
+    encrypted = sealed.encrypt(value.encode())
+    encrypted_b64 = base64.b64encode(encrypted).decode()
+
+    # Upload
+    resp = requests.put(
+        f"{API_BASE}/actions/secrets/{secret_name}",
+        headers=hdrs,
+        json={"encrypted_value": encrypted_b64, "key_id": key_id},
+        timeout=15,
+    )
+    resp.raise_for_status()
+    print(f"Secret '{secret_name}' uploaded (HTTP {resp.status_code})")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    """Entry point."""
+    parser = argparse.ArgumentParser(description="GitHub API utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # wait-ci
+    wci = sub.add_parser("wait-ci", help="Poll PR check runs until completion")
+    wci.add_argument("pr_number", type=int, help="PR number")
+
+    # set-secret
+    ss = sub.add_parser("set-secret", help="Upload a GitHub Actions secret")
+    ss.add_argument("secret_name", help="Secret name (e.g. CODECOV_TOKEN)")
+    ss.add_argument("--value", help="Secret value (plain text)")
+    ss.add_argument("--from-keychain", help="Read value from macOS keychain service")
+
+    args = parser.parse_args()
+
+    if args.command == "wait-ci":
+        wait_ci(args.pr_number)
+    elif args.command == "set-secret":
+        if args.from_keychain:
+            value = _keychain_value(args.from_keychain)
+        elif args.value:
+            value = args.value
+        else:
+            print("Error: provide --value or --from-keychain")
+            sys.exit(1)
+        set_secret(args.secret_name, value)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `scripts/maintenance/github_utils.py` with two CLI sub-commands:
  - `wait-ci <pr>`: polls check runs until all complete (ignores codecov/patch)
  - `set-secret <name> --from-keychain <service>`: uploads encrypted GitHub Actions secrets via PyNaCl
- Add `pynacl ^1.6.2` dependency

## Test plan

- [x] `wait-ci 139` returns all 15 checks passed
- [x] Pre-commit hooks pass
- [x] 2557 tests pass, 0 failures
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)