### PR TITLE
test(coverage): phases 2B, 2C, 3F — 62 new tests

### DIFF
--- a/tests/test_shift_sessions_extended.py
+++ b/tests/test_shift_sessions_extended.py
@@ -1,0 +1,272 @@
+"""Extended tests for shift_sessions — sync, edge cases, error handling.
+
+Extends test_shift_sessions.py with:
+- sync_session_changes with mock IntervalsClient
+- Boundary overflow (shift beyond week)
+- Shift backward
+- Shift from session_id
+- Insert rest day on existing session (error)
+- Remove non-existent session
+- Shift requires from_session_id or from_day
+- Session not found errors
+"""
+
+import json
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from magma_cycling.planning.models import WeeklyPlan
+from magma_cycling.shift_sessions import SessionShifter
+
+
+@pytest.fixture
+def planning_data():
+    """Base planning data for tests."""
+    return {
+        "week_id": "S999",
+        "start_date": "2026-03-02",
+        "end_date": "2026-03-08",
+        "created_at": "2026-02-01T20:00:00Z",
+        "last_updated": "2026-02-01T20:00:00Z",
+        "version": 1,
+        "athlete_id": "iXXXXXX",
+        "tss_target": 350,
+        "planned_sessions": [
+            {
+                "session_id": "S999-01",
+                "date": "2026-03-02",
+                "name": "Endurance",
+                "type": "END",
+                "version": "V001",
+                "tss_planned": 50,
+                "duration_min": 60,
+                "description": "Easy ride",
+                "status": "completed",
+                "intervals_id": 11111,
+                "description_hash": None,
+            },
+            {
+                "session_id": "S999-02",
+                "date": "2026-03-03",
+                "name": "Intervals",
+                "type": "INT",
+                "version": "V001",
+                "tss_planned": 70,
+                "duration_min": 65,
+                "description": "VO2max",
+                "status": "planned",
+                "intervals_id": 22222,
+                "description_hash": None,
+            },
+            {
+                "session_id": "S999-04",
+                "date": "2026-03-05",
+                "name": "Sweet Spot",
+                "type": "FTP",
+                "version": "V001",
+                "tss_planned": 65,
+                "duration_min": 70,
+                "description": "Threshold",
+                "status": "planned",
+                "intervals_id": None,
+                "description_hash": None,
+            },
+            {
+                "session_id": "S999-06",
+                "date": "2026-03-07",
+                "name": "Long Ride",
+                "type": "END",
+                "version": "V001",
+                "tss_planned": 90,
+                "duration_min": 120,
+                "description": "Weekend ride",
+                "status": "planned",
+                "intervals_id": 44444,
+                "description_hash": None,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def shifter(tmp_path, planning_data):
+    """Create SessionShifter from temp file."""
+    planning_file = tmp_path / "week_planning_S999.json"
+    with open(planning_file, "w", encoding="utf-8") as f:
+        json.dump(planning_data, f, indent=2)
+    return SessionShifter(week_id="S999", planning_dir=tmp_path)
+
+
+class TestSyncSessionChanges:
+    """Test sync_session_changes with mock IntervalsClient."""
+
+    def test_sync_updates_events(self, shifter):
+        """Test successful sync with Intervals.icu."""
+        shifter.shift_sessions(from_day=2, shift_days=1)
+
+        client = MagicMock()
+        client.get_event.return_value = {"id": 22222, "start_date_local": "2026-03-03"}
+        client.update_event.return_value = True
+
+        result = shifter.sync_session_changes(client)
+
+        assert result is True
+        assert client.update_event.called
+
+    def test_sync_skips_no_intervals_id(self, shifter):
+        """Test sync skips sessions without intervals_id."""
+        # S999-04 has no intervals_id
+        shifter.shift_sessions(from_session_id="S999-04", shift_days=1, stop_at_completed=False)
+
+        client = MagicMock()
+        result = shifter.sync_session_changes(client)
+
+        # Should succeed without calling update_event for the no-id session
+        assert result is True
+
+    def test_sync_no_modifications(self, shifter):
+        """Test sync with no modified sessions."""
+        client = MagicMock()
+        result = shifter.sync_session_changes(client)
+
+        assert result is True
+        client.get_event.assert_not_called()
+
+    def test_sync_handles_missing_event(self, shifter):
+        """Test sync handles event not found on Intervals.icu."""
+        shifter.shift_sessions(from_day=2, shift_days=1)
+
+        client = MagicMock()
+        client.get_event.return_value = None
+
+        shifter.sync_session_changes(client)
+
+        # Not all synced, but shouldn't crash
+        client.update_event.assert_not_called()
+
+    def test_sync_handles_api_error(self, shifter):
+        """Test sync handles API errors gracefully."""
+        shifter.shift_sessions(from_day=2, shift_days=1)
+
+        client = MagicMock()
+        client.get_event.side_effect = Exception("API down")
+
+        # Should not raise
+        result = shifter.sync_session_changes(client)
+        assert result is False
+
+
+class TestShiftEdgeCases:
+    """Test edge cases for shift operations."""
+
+    def test_shift_backward(self, shifter):
+        """Test shifting sessions backward."""
+        # Shift from Thursday (day 4=S999-04) backward by 1
+        shifter.shift_sessions(from_session_id="S999-04", shift_days=-1)
+
+        # S999-04 was on 2026-03-05 (Thu) → 2026-03-04 (Wed)
+        session = next(s for s in shifter.plan.planned_sessions if s.session_id == "S999-04")
+        assert session.session_date == date(2026, 3, 4)
+
+    def test_shift_boundary_overflow_skipped(self, shifter):
+        """Test sessions outside week boundaries are skipped."""
+        # Shift S999-06 (Saturday) forward by 2 → would be Monday next week
+        shifter.shift_sessions(from_session_id="S999-06", shift_days=2)
+
+        # Should be skipped (outside week boundaries)
+        session = next(s for s in shifter.plan.planned_sessions if s.session_id == "S999-06")
+        assert session.session_date == date(2026, 3, 7)  # Unchanged
+
+    def test_shift_from_session_id(self, shifter):
+        """Test shifting from a specific session_id."""
+        modified = shifter.shift_sessions(from_session_id="S999-04", shift_days=1)
+
+        # Only S999-04 and S999-06 should be shifted (skip completed S999-01)
+        assert len(modified) == 2
+
+    def test_shift_requires_from_param(self, shifter):
+        """Test ValueError when neither from_session_id nor from_day given."""
+        with pytest.raises(ValueError, match="Must specify either"):
+            shifter.shift_sessions()
+
+    def test_shift_session_not_found(self, shifter):
+        """Test ValueError when session_id not found."""
+        with pytest.raises(ValueError, match="not found"):
+            shifter.shift_sessions(from_session_id="S999-99")
+
+    def test_shift_no_sessions_after_day(self, shifter):
+        """Test ValueError when no sessions on or after day."""
+        # No session on Sunday (day 7) or later
+        with pytest.raises(ValueError, match="No sessions found"):
+            shifter.shift_sessions(from_day=8)
+
+    def test_shift_all_completed_not_shifted(self, shifter):
+        """Test that stop_at_completed=True skips completed sessions."""
+        shifter.shift_sessions(from_day=1, shift_days=1, stop_at_completed=True)
+
+        # S999-01 is completed, should be skipped
+        completed = next(s for s in shifter.plan.planned_sessions if s.session_id == "S999-01")
+        assert completed.session_date == date(2026, 3, 2)
+
+
+class TestInsertRestDayEdgeCases:
+    """Test insert_rest_day edge cases."""
+
+    def test_insert_rest_on_existing_session(self, shifter):
+        """Test error when inserting rest on day with existing session."""
+        # Day 2 (Tuesday) already has S999-02
+        with pytest.raises(ValueError, match="already exists"):
+            shifter.insert_rest_day(2)
+
+
+class TestSwapEdgeCases:
+    """Test swap edge cases."""
+
+    def test_swap_nonexistent_session_by_id(self, shifter):
+        """Test error swapping non-existent session by ID."""
+        with pytest.raises(ValueError, match="not found"):
+            shifter.swap_sessions(session1_id="S999-02", session2_id="S999-99")
+
+    def test_swap_nonexistent_session_by_day(self, shifter):
+        """Test error swapping on day with no session."""
+        with pytest.raises(ValueError, match="No session found"):
+            shifter.swap_sessions(day1=2, day2=3)  # Day 3 has no session
+
+
+class TestRemoveEdgeCases:
+    """Test remove_session edge cases."""
+
+    def test_remove_nonexistent_session(self, shifter):
+        """Test removing non-existent session returns False."""
+        result = shifter.remove_session("S999-99")
+        assert result is False
+        assert len(shifter.plan.planned_sessions) == 4  # Unchanged
+
+
+class TestControlTowerMode:
+    """Test Control Tower mode behavior."""
+
+    def test_init_with_plan(self, tmp_path, planning_data):
+        """Test initialization with plan (Control Tower mode)."""
+        planning_file = tmp_path / "week_planning_S999.json"
+        with open(planning_file, "w", encoding="utf-8") as f:
+            json.dump(planning_data, f, indent=2)
+        plan = WeeklyPlan.from_json(planning_file)
+        shifter = SessionShifter(week_id="S999", plan=plan)
+
+        assert shifter.planning_file is None
+        assert len(shifter.plan.planned_sessions) == 4
+
+    def test_save_control_tower_mode(self, tmp_path, planning_data):
+        """Test save in Control Tower mode."""
+        planning_file = tmp_path / "week_planning_S999.json"
+        with open(planning_file, "w", encoding="utf-8") as f:
+            json.dump(planning_data, f, indent=2)
+        plan = WeeklyPlan.from_json(planning_file)
+        shifter = SessionShifter(week_id="S999", plan=plan)
+
+        result = shifter.save(dry_run=False, sync=False)
+
+        assert result is True

--- a/tests/test_weekly_aggregator_api.py
+++ b/tests/test_weekly_aggregator_api.py
@@ -1,0 +1,440 @@
+"""Tests for WeeklyAggregator API-dependent methods.
+
+Extends test_weekly_aggregator.py with mock IntervalsClient to cover:
+- collect_raw_data (full pipeline)
+- _fetch_weekly_activities (enrichment)
+- _fetch_daily_metrics
+- _fetch_wellness_data
+- _fetch_planned_workouts
+- _extract_gear_metrics
+- format_output
+- _compute_compliance
+- Edge cases: no API, empty data, None values
+"""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.analyzers.weekly_aggregator import WeeklyAggregator
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock IntervalsClient."""
+    api = MagicMock()
+    api.athlete_id = "i12345"
+    return api
+
+
+@pytest.fixture
+def aggregator(mock_api):
+    """Create WeeklyAggregator with mocked API."""
+    with patch(
+        "magma_cycling.analyzers.weekly_aggregator.create_intervals_client", return_value=mock_api
+    ):
+        agg = WeeklyAggregator(week="S090", start_date=date(2026, 3, 9))
+    return agg
+
+
+@pytest.fixture
+def aggregator_no_api():
+    """Create WeeklyAggregator without API."""
+    with patch(
+        "magma_cycling.analyzers.weekly_aggregator.create_intervals_client",
+        side_effect=ValueError("No API"),
+    ):
+        agg = WeeklyAggregator(week="S090", start_date=date(2026, 3, 9))
+    return agg
+
+
+class TestFetchWeeklyActivities:
+    """Test _fetch_weekly_activities with mock API."""
+
+    def test_enriches_each_activity(self, aggregator, mock_api):
+        """Test that each activity is enriched via get_activity."""
+        mock_api.get_activities.return_value = [
+            {"id": "i100", "name": "Session A", "start_date_local": "2026-03-09"},
+            {"id": "i101", "name": "Session B", "start_date_local": "2026-03-10"},
+        ]
+        mock_api.get_activity.side_effect = [
+            {
+                "id": "i100",
+                "name": "Session A",
+                "icu_training_load": 55,
+                "start_date_local": "2026-03-09",
+            },
+            {
+                "id": "i101",
+                "name": "Session B",
+                "icu_training_load": 70,
+                "start_date_local": "2026-03-10",
+            },
+        ]
+
+        activities = aggregator._fetch_weekly_activities()
+
+        assert len(activities) == 2
+        assert activities[0]["icu_training_load"] == 55
+        assert activities[1]["icu_training_load"] == 70
+        assert mock_api.get_activity.call_count == 2
+
+    def test_fallback_on_get_activity_error(self, aggregator, mock_api):
+        """Test fallback to basic data when get_activity fails."""
+        mock_api.get_activities.return_value = [
+            {"id": "i100", "name": "Session A", "start_date_local": "2026-03-09"},
+        ]
+        mock_api.get_activity.side_effect = Exception("API error")
+
+        activities = aggregator._fetch_weekly_activities()
+
+        assert len(activities) == 1
+        assert activities[0]["name"] == "Session A"
+
+    def test_activity_without_id(self, aggregator, mock_api):
+        """Test activity without ID is kept as-is."""
+        mock_api.get_activities.return_value = [
+            {"name": "No ID session", "start_date_local": "2026-03-09"},
+        ]
+
+        activities = aggregator._fetch_weekly_activities()
+
+        assert len(activities) == 1
+        assert activities[0]["name"] == "No ID session"
+        mock_api.get_activity.assert_not_called()
+
+    def test_no_api_returns_empty(self, aggregator_no_api):
+        """Test returns empty list when API not available."""
+        assert aggregator_no_api._fetch_weekly_activities() == []
+
+    def test_sorted_by_date(self, aggregator, mock_api):
+        """Test activities are sorted by start_date_local."""
+        mock_api.get_activities.return_value = [
+            {"id": "i101", "name": "B", "start_date_local": "2026-03-11"},
+            {"id": "i100", "name": "A", "start_date_local": "2026-03-09"},
+        ]
+        mock_api.get_activity.side_effect = [
+            {"id": "i101", "name": "B", "start_date_local": "2026-03-11"},
+            {"id": "i100", "name": "A", "start_date_local": "2026-03-09"},
+        ]
+
+        activities = aggregator._fetch_weekly_activities()
+
+        assert activities[0]["name"] == "A"
+        assert activities[1]["name"] == "B"
+
+
+class TestFetchDailyMetrics:
+    """Test _fetch_daily_metrics with mock API."""
+
+    def test_fetches_7_days(self, aggregator, mock_api):
+        """Test metrics are fetched for each day of the week."""
+        mock_api.get_wellness.return_value = [{"ctl": 60.0, "atl": 55.0, "tsb": 5.0}]
+
+        metrics = aggregator._fetch_daily_metrics()
+
+        assert len(metrics) == 7
+        assert mock_api.get_wellness.call_count == 7
+        assert metrics[0]["ctl"] == 60.0
+
+    def test_handles_empty_wellness(self, aggregator, mock_api):
+        """Test handles days with no wellness data."""
+        mock_api.get_wellness.return_value = []
+
+        metrics = aggregator._fetch_daily_metrics()
+
+        assert metrics == []
+
+    def test_handles_api_error(self, aggregator, mock_api):
+        """Test handles API errors gracefully."""
+        mock_api.get_wellness.side_effect = Exception("API error")
+
+        metrics = aggregator._fetch_daily_metrics()
+
+        assert metrics == []
+
+    def test_no_api_returns_empty(self, aggregator_no_api):
+        """Test returns empty when no API."""
+        assert aggregator_no_api._fetch_daily_metrics() == []
+
+    def test_dict_wellness_response(self, aggregator, mock_api):
+        """Test handles dict wellness response (not list)."""
+        mock_api.get_wellness.return_value = {"ctl": 50.0, "atl": 45.0, "tsb": 5.0}
+
+        metrics = aggregator._fetch_daily_metrics()
+
+        assert len(metrics) == 7
+
+
+class TestFetchWellnessData:
+    """Test _fetch_wellness_data."""
+
+    def test_fetches_wellness_for_week(self, aggregator, mock_api):
+        """Test wellness data is collected for each day."""
+        mock_api.get_wellness.return_value = [
+            {"sleepQuality": 3, "sleepSecs": 27000, "weight": 84.0, "hrvSDNN": 45, "restingHR": 55}
+        ]
+
+        wellness = aggregator._fetch_wellness_data()
+
+        assert len(wellness) == 7
+        first_day = wellness["2026-03-09"]
+        assert first_day["sleep_quality"] == 3
+        assert first_day["sleep_hours"] == 7.5
+        assert first_day["weight"] == 84.0
+
+    def test_no_api_returns_empty(self, aggregator_no_api):
+        """Test returns empty dict when no API."""
+        assert aggregator_no_api._fetch_wellness_data() == {}
+
+
+class TestFetchPlannedWorkouts:
+    """Test _fetch_planned_workouts."""
+
+    def test_filters_workout_category(self, aggregator, mock_api):
+        """Test only WORKOUT events are returned."""
+        mock_api.get_events.return_value = [
+            {"category": "WORKOUT", "name": "Sweet Spot"},
+            {"category": "NOTE", "name": "Rest note"},
+            {"category": "WORKOUT", "name": "Intervals"},
+        ]
+
+        planned = aggregator._fetch_planned_workouts()
+
+        assert len(planned) == 2
+        assert all(p["category"] == "WORKOUT" for p in planned)
+
+    def test_no_api_returns_empty(self, aggregator_no_api):
+        """Test returns empty when no API."""
+        assert aggregator_no_api._fetch_planned_workouts() == []
+
+    def test_api_error_returns_empty(self, aggregator, mock_api):
+        """Test returns empty on API error."""
+        mock_api.get_events.side_effect = Exception("API error")
+
+        assert aggregator._fetch_planned_workouts() == []
+
+
+class TestExtractGearMetrics:
+    """Test _extract_gear_metrics (Di2 data)."""
+
+    def test_extracts_gear_shifts(self, aggregator, mock_api):
+        """Test gear shift counting from streams."""
+        mock_api.get_activity_streams.return_value = [
+            {"type": "FrontGear", "data": [34, 34, 50, 50, 34]},
+            {"type": "RearGear", "data": [28, 25, 25, 23, 23]},
+            {"type": "GearRatio", "data": [1.21, 1.36, 2.0, 2.17, 1.48]},
+        ]
+
+        result = aggregator._extract_gear_metrics("i100")
+
+        assert result is not None
+        assert result["front_shifts"] == 2  # 34→50, 50→34
+        assert result["rear_shifts"] == 2  # 28→25, 25→23
+        assert result["shifts"] == 4
+        assert result["avg_gear_ratio"] is not None
+
+    def test_no_gear_data_returns_none(self, aggregator, mock_api):
+        """Test returns None when no gear streams."""
+        mock_api.get_activity_streams.return_value = [
+            {"type": "Watts", "data": [150, 160, 170]},
+        ]
+
+        assert aggregator._extract_gear_metrics("i100") is None
+
+    def test_api_error_returns_none(self, aggregator, mock_api):
+        """Test returns None on API error."""
+        mock_api.get_activity_streams.side_effect = Exception("No streams")
+
+        assert aggregator._extract_gear_metrics("i100") is None
+
+    def test_no_api_returns_none(self, aggregator_no_api):
+        """Test returns None when no API."""
+        assert aggregator_no_api._extract_gear_metrics("i100") is None
+
+
+class TestCollectRawData:
+    """Test collect_raw_data full pipeline."""
+
+    def test_collects_all_sections(self, aggregator, mock_api, tmp_path):
+        """Test all data sections are collected."""
+        mock_api.get_activities.return_value = [
+            {"id": "i100", "name": "A", "start_date_local": "2026-03-09"}
+        ]
+        mock_api.get_activity.return_value = {
+            "id": "i100",
+            "name": "A",
+            "start_date_local": "2026-03-09",
+            "icu_training_load": 55,
+        }
+        mock_api.get_wellness.return_value = [{"ctl": 60.0, "atl": 55.0, "tsb": 5.0}]
+        mock_api.get_events.return_value = [{"category": "WORKOUT", "name": "Test"}]
+
+        aggregator.data_dir = tmp_path
+
+        raw = aggregator.collect_raw_data()
+
+        assert "activities" in raw
+        assert "metrics_daily" in raw
+        assert "feedback" in raw
+        assert "wellness" in raw
+        assert "planned" in raw
+
+    def test_handles_all_api_errors(self, aggregator, mock_api, tmp_path):
+        """Test graceful degradation when all API calls fail."""
+        mock_api.get_activities.side_effect = Exception("Fail")
+        mock_api.get_wellness.side_effect = Exception("Fail")
+        mock_api.get_events.side_effect = Exception("Fail")
+
+        aggregator.data_dir = tmp_path
+
+        raw = aggregator.collect_raw_data()
+
+        assert raw["activities"] == []
+        assert raw["metrics_daily"] == []
+        assert raw["wellness"] == {}
+
+
+class TestFormatOutput:
+    """Test format_output."""
+
+    def test_markdown_summary(self, aggregator):
+        """Test markdown output generation."""
+        processed = {
+            "summary": {
+                "total_sessions": 5,
+                "total_tss": 300,
+                "total_duration": 7200,
+                "avg_tss": 60.0,
+                "final_metrics": {"ctl": 65.0, "atl": 60.0, "tsb": 5.0},
+            }
+        }
+
+        output = aggregator.format_output(processed)
+
+        assert "S090" in output
+        assert "300" in output
+        assert "5" in output  # sessions
+        assert "CTL" in output
+        assert "65.0" in output
+
+    def test_no_final_metrics(self, aggregator):
+        """Test output without final metrics."""
+        processed = {
+            "summary": {"total_sessions": 0, "total_tss": 0, "total_duration": 0, "avg_tss": 0}
+        }
+
+        output = aggregator.format_output(processed)
+
+        assert "S090" in output
+        assert "CTL" not in output
+
+
+class TestComputeCompliance:
+    """Test _compute_compliance."""
+
+    def test_full_compliance(self, aggregator):
+        """Test 100% compliance."""
+        activities = [{"name": "A"}, {"name": "B"}, {"name": "C"}]
+        planned = [{"name": "1"}, {"name": "2"}, {"name": "3"}]
+
+        result = aggregator._compute_compliance(activities, planned)
+
+        assert result["rate"] == 100.0
+        assert result["planned_count"] == 3
+        assert result["executed_count"] == 3
+
+    def test_partial_compliance(self, aggregator):
+        """Test partial compliance."""
+        activities = [{"name": "A"}, {"name": "B"}]
+        planned = [{"name": "1"}, {"name": "2"}, {"name": "3"}, {"name": "4"}]
+
+        result = aggregator._compute_compliance(activities, planned)
+
+        assert result["rate"] == 50.0
+        assert len(result["missed"]) == 2
+
+    def test_empty_planned(self, aggregator):
+        """Test with no planned workouts."""
+        result = aggregator._compute_compliance([{"name": "A"}], [])
+
+        assert result["rate"] == 0
+        assert result["planned_count"] == 0
+
+
+class TestPedalBalance:
+    """Test pedal balance detection in learnings and summary."""
+
+    def test_imbalance_detected_left(self, aggregator):
+        """Test left-heavy pedal imbalance detection."""
+        workouts = [
+            {"tss": 50, "if": 0.7, "pedal_balance": 53.5},
+            {"tss": 55, "if": 0.75, "pedal_balance": 54.0},
+        ]
+
+        learnings = aggregator._extract_training_learnings(workouts, {})
+
+        assert any("Déséquilibre pédalage" in lrn for lrn in learnings)
+
+    def test_no_imbalance(self, aggregator):
+        """Test no imbalance when balanced."""
+        workouts = [
+            {"tss": 50, "if": 0.7, "pedal_balance": 50.2},
+            {"tss": 55, "if": 0.75, "pedal_balance": 49.8},
+        ]
+
+        learnings = aggregator._extract_training_learnings(workouts, {})
+
+        assert not any("Déséquilibre" in lrn for lrn in learnings)
+
+    def test_summary_pedal_balance(self, aggregator):
+        """Test pedal balance in weekly summary."""
+        activities = [
+            {
+                "icu_training_load": 50,
+                "moving_time": 3600,
+                "icu_intensity": 70,
+                "distance": 40,
+                "avg_lr_balance": 53.5,
+            },
+        ]
+
+        summary = aggregator._compute_weekly_summary(activities)
+
+        assert summary["avg_pedal_balance"] == 53.5
+        assert summary["pedal_balance_imbalance"] is True
+
+
+class TestGearLearnings:
+    """Test gear-related learnings extraction."""
+
+    def test_frequent_shifts(self, aggregator):
+        """Test frequent gear shift detection."""
+        workouts = [
+            {
+                "tss": 50,
+                "if": 0.7,
+                "duration": 3600,
+                "gear_metrics": {"shifts": 200, "avg_gear_ratio": 2.0},
+            },
+        ]
+
+        learnings = aggregator._extract_training_learnings(workouts, {})
+
+        assert any("fréquents" in lrn for lrn in learnings)
+
+    def test_low_gear_ratio(self, aggregator):
+        """Test low gear ratio detection."""
+        workouts = [
+            {
+                "tss": 50,
+                "if": 0.7,
+                "duration": 7200,
+                "gear_metrics": {"shifts": 100, "avg_gear_ratio": 1.2},
+            },
+        ]
+
+        learnings = aggregator._extract_training_learnings(workouts, {})
+
+        assert any("Développement faible" in lrn for lrn in learnings)

--- a/tests/test_weekly_planner.py
+++ b/tests/test_weekly_planner.py
@@ -1,0 +1,228 @@
+"""Tests for WeeklyPlanner.
+
+Covers:
+- Initialization with mock API
+- Week number calculations
+- collect_current_metrics with mock API
+- _mock_current_metrics fallback
+- run() workflow with all mocks
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.weekly_planner import WeeklyPlanner
+
+
+@pytest.fixture
+def mock_api():
+    """Create mock IntervalsClient."""
+    api = MagicMock()
+    api.athlete_id = "i12345"
+    return api
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    """Create temporary project root with required structure."""
+    refs = tmp_path / "references"
+    refs.mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def planner(mock_api, project_root):
+    """Create WeeklyPlanner with mocked API and data config."""
+    with (
+        patch(
+            "magma_cycling.weekly_planner.create_intervals_client",
+            return_value=mock_api,
+        ),
+        patch("magma_cycling.config.get_data_config") as mock_config,
+    ):
+        config = MagicMock()
+        config.week_planning_dir = project_root / "planning"
+        config.data_repo_path = project_root / "data"
+        mock_config.return_value = config
+        (project_root / "planning").mkdir(exist_ok=True)
+
+        p = WeeklyPlanner(
+            week_number="S090",
+            start_date=datetime(2026, 3, 9),
+            project_root=project_root,
+        )
+    return p
+
+
+@pytest.fixture
+def planner_no_api(project_root):
+    """Create WeeklyPlanner without API."""
+    with (
+        patch(
+            "magma_cycling.weekly_planner.create_intervals_client",
+            side_effect=ValueError("No API"),
+        ),
+        patch("magma_cycling.config.get_data_config") as mock_config,
+    ):
+        config = MagicMock()
+        config.week_planning_dir = project_root / "planning"
+        config.data_repo_path = project_root / "data"
+        mock_config.return_value = config
+        (project_root / "planning").mkdir(exist_ok=True)
+
+        p = WeeklyPlanner(
+            week_number="S090",
+            start_date=datetime(2026, 3, 9),
+            project_root=project_root,
+        )
+    return p
+
+
+class TestInitialization:
+    """Test WeeklyPlanner initialization."""
+
+    def test_basic_init(self, planner):
+        """Test basic initialization."""
+        assert planner.week_number == "S090"
+        assert planner.start_date == datetime(2026, 3, 9)
+        assert planner.end_date == datetime(2026, 3, 15)
+        assert planner.api is not None
+
+    def test_init_without_api(self, planner_no_api):
+        """Test initialization when API is unavailable."""
+        assert planner_no_api.week_number == "S090"
+        assert planner_no_api.api is None
+
+
+class TestWeekNumberCalculations:
+    """Test week number helper methods."""
+
+    def test_previous_week_number(self, planner):
+        """Test previous week calculation."""
+        assert planner._previous_week_number() == "S089"
+
+    def test_next_week_number(self, planner):
+        """Test next week calculation."""
+        assert planner._next_week_number() == "S091"
+
+    def test_week_after_next(self, planner):
+        """Test week after next calculation."""
+        assert planner._week_after_next() == "S092"
+
+    def test_week_number_formatting(self, planner):
+        """Test 3-digit zero-padded formatting."""
+        planner.week_number = "S005"
+        assert planner._previous_week_number() == "S004"
+        assert planner._next_week_number() == "S006"
+
+
+class TestCollectCurrentMetrics:
+    """Test collect_current_metrics with mock API."""
+
+    def test_collects_from_api(self, planner, mock_api):
+        """Test metrics collection from API."""
+        mock_api.get_wellness.return_value = [
+            {
+                "ctl": 65.0,
+                "atl": 58.0,
+                "tsb": 7.0,
+                "weight": 84.5,
+                "restingHR": 52,
+                "hrv": 48,
+            }
+        ]
+
+        metrics = planner.collect_current_metrics()
+
+        assert metrics["ctl"] == 65.0
+        assert metrics["atl"] == 58.0
+        assert metrics["tsb"] == 7.0
+        assert metrics["weight"] == 84.5
+        assert metrics["resting_hr"] == 52
+
+    def test_fallback_when_no_wellness(self, planner, mock_api):
+        """Test fallback when API returns empty wellness."""
+        mock_api.get_wellness.return_value = []
+
+        metrics = planner.collect_current_metrics()
+
+        assert metrics["ctl"] == 0
+        assert "note" in metrics
+
+    def test_fallback_on_api_error(self, planner, mock_api):
+        """Test fallback when API raises error."""
+        mock_api.get_wellness.side_effect = Exception("API down")
+
+        metrics = planner.collect_current_metrics()
+
+        assert metrics["ctl"] == 0
+        assert "note" in metrics
+
+    def test_fallback_no_api(self, planner_no_api):
+        """Test fallback when no API configured."""
+        metrics = planner_no_api.collect_current_metrics()
+
+        assert metrics["ctl"] == 0
+        assert "note" in metrics
+
+
+class TestMockCurrentMetrics:
+    """Test _mock_current_metrics."""
+
+    def test_returns_zeroed_metrics(self, planner):
+        """Test mock metrics have all required keys."""
+        metrics = planner._mock_current_metrics()
+
+        assert metrics["ctl"] == 0
+        assert metrics["atl"] == 0
+        assert metrics["tsb"] == 0
+        assert metrics["weight"] == 0
+        assert "date" in metrics
+        assert "note" in metrics
+
+
+class TestRunWorkflow:
+    """Test the full run() workflow."""
+
+    def test_run_completes(self, planner, mock_api):
+        """Test run() executes all steps without errors."""
+        # Mock API for metrics collection
+        mock_api.get_wellness.return_value = [
+            {"ctl": 60.0, "atl": 55.0, "tsb": 5.0, "weight": 84.0, "restingHR": 55, "hrv": 40}
+        ]
+
+        # Mock all mixin methods
+        with (
+            patch.object(planner, "load_previous_week_bilan", return_value="## Bilan S089"),
+            patch.object(planner, "load_context_files", return_value={}),
+            patch.object(
+                planner,
+                "generate_planning_prompt",
+                return_value="Planning prompt",
+            ),
+            patch.object(planner, "save_planning_json"),
+            patch.object(planner, "copy_to_clipboard", return_value=True),
+        ):
+            planner.run()
+
+        assert planner.current_metrics["ctl"] == 60.0
+        assert planner.previous_week_bilan == "## Bilan S089"
+
+    def test_run_without_api(self, planner_no_api):
+        """Test run() works without API (fallback metrics)."""
+        with (
+            patch.object(planner_no_api, "load_previous_week_bilan", return_value=""),
+            patch.object(planner_no_api, "load_context_files", return_value={}),
+            patch.object(
+                planner_no_api,
+                "generate_planning_prompt",
+                return_value="Planning prompt",
+            ),
+            patch.object(planner_no_api, "save_planning_json"),
+            patch.object(planner_no_api, "copy_to_clipboard", return_value=False),
+        ):
+            planner_no_api.run()
+
+        assert planner_no_api.current_metrics["ctl"] == 0


### PR DESCRIPTION
## Summary

- **2B** (`weekly_aggregator`): 31 tests — API fetch, gear metrics, compliance, pedal balance, format_output
- **2C** (`shift_sessions`): 18 tests — sync with mock IntervalsClient, boundary overflow, backward shift, Control Tower mode
- **3F** (`weekly_planner`): 13 tests — init, week numbers, collect_current_metrics, run workflow

## Stats

- 62 new tests, 2619 total passing
- Pre-commit all green
- No regression

## Test plan

- [x] `pytest tests/ -x` — 2619 passed, 0 failed
- [x] Pre-commit hooks pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)