### PR TITLE
test(coverage): Phase 4 — baseline analysis + eow evaluation (100 tests)

### DIFF
--- a/tests/analysis/test_baseline_data_loading.py
+++ b/tests/analysis/test_baseline_data_loading.py
@@ -1,0 +1,290 @@
+"""Tests for analysis.baseline.data_loading module.
+
+Tests DataLoadingMixin : load_adherence_data, parse_skipped_replaced_sessions,
+_extract_reason, load_cardiovascular_coupling.
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from magma_cycling.analysis.baseline.data_loading import DataLoadingMixin
+
+
+class StubAnalyzer(DataLoadingMixin):
+    """Stub providing required attributes for DataLoadingMixin."""
+
+    def __init__(
+        self,
+        *,
+        start_date=date(2026, 1, 27),
+        end_date=date(2026, 2, 9),
+        adherence_file=None,
+        workout_history_dir=None,
+        client=None,
+    ):
+        self.start_date = start_date
+        self.end_date = end_date
+        self.adherence_file = adherence_file or Path("/nonexistent")
+        self.workout_history_dir = workout_history_dir or Path("/nonexistent")
+        self.client = client
+        self.adherence_data = []
+        self.wellness_data = []
+        self.activities_data = []
+        self.events_data = []
+        self.cv_coupling_values = []
+        self.skipped_sessions = []
+        self.replaced_sessions = []
+        self.cancelled_sessions = []
+
+
+class TestExtractReason:
+    """Tests for _extract_reason()."""
+
+    def test_reason_found(self):
+        analyzer = StubAnalyzer()
+        result = analyzer._extract_reason("SÉANCE ANNULÉE\nRaison: Fatigue accumulée\n---")
+        assert result == "Fatigue accumulée"
+
+    def test_no_reason_pattern(self):
+        analyzer = StubAnalyzer()
+        result = analyzer._extract_reason("Some description without reason")
+        assert result == "Non spécifiée"
+
+    def test_empty_description(self):
+        analyzer = StubAnalyzer()
+        result = analyzer._extract_reason("")
+        assert result == "Non spécifiée"
+
+    def test_reason_with_colon_spacing(self):
+        analyzer = StubAnalyzer()
+        result = analyzer._extract_reason("Raison: Too late from work")
+        assert result == "Too late from work"
+
+
+class TestLoadAdherenceData:
+    """Tests for load_adherence_data()."""
+
+    def test_file_not_found(self):
+        analyzer = StubAnalyzer(adherence_file=Path("/nonexistent/file.jsonl"))
+        analyzer.load_adherence_data()
+        assert analyzer.adherence_data == []
+
+    def test_loads_records_in_date_range(self, tmp_path):
+        jsonl = tmp_path / "adherence.jsonl"
+        records = [
+            {"date": "2026-01-27", "adherence_rate": 0.9, "timestamp": "2026-01-27T10:00:00"},
+            {"date": "2026-02-01", "adherence_rate": 0.85, "timestamp": "2026-02-01T10:00:00"},
+            {"date": "2026-02-15", "adherence_rate": 0.7, "timestamp": "2026-02-15T10:00:00"},
+        ]
+        jsonl.write_text("\n".join(json.dumps(r) for r in records))
+
+        analyzer = StubAnalyzer(adherence_file=jsonl)
+        analyzer.load_adherence_data()
+        # Only first two are in range (Jan 27 - Feb 9)
+        assert len(analyzer.adherence_data) == 2
+
+    def test_deduplicates_by_date(self, tmp_path):
+        jsonl = tmp_path / "adherence.jsonl"
+        records = [
+            {"date": "2026-01-27", "adherence_rate": 0.8, "timestamp": "2026-01-27T08:00:00"},
+            {"date": "2026-01-27", "adherence_rate": 0.9, "timestamp": "2026-01-27T18:00:00"},
+        ]
+        jsonl.write_text("\n".join(json.dumps(r) for r in records))
+
+        analyzer = StubAnalyzer(adherence_file=jsonl)
+        analyzer.load_adherence_data()
+        assert len(analyzer.adherence_data) == 1
+        # Should keep the most recent timestamp
+        assert analyzer.adherence_data[0]["adherence_rate"] == 0.9
+
+    def test_sorted_by_date(self, tmp_path):
+        jsonl = tmp_path / "adherence.jsonl"
+        records = [
+            {"date": "2026-02-01", "adherence_rate": 0.85, "timestamp": "T1"},
+            {"date": "2026-01-27", "adherence_rate": 0.9, "timestamp": "T2"},
+        ]
+        jsonl.write_text("\n".join(json.dumps(r) for r in records))
+
+        analyzer = StubAnalyzer(adherence_file=jsonl)
+        analyzer.load_adherence_data()
+        assert analyzer.adherence_data[0]["date"] == "2026-01-27"
+        assert analyzer.adherence_data[1]["date"] == "2026-02-01"
+
+
+class TestParseSkippedReplacedSessions:
+    """Tests for parse_skipped_replaced_sessions()."""
+
+    def test_empty_events(self):
+        analyzer = StubAnalyzer()
+        analyzer.events_data = []
+        analyzer.parse_skipped_replaced_sessions()
+        assert analyzer.skipped_sessions == []
+        assert analyzer.replaced_sessions == []
+        assert analyzer.cancelled_sessions == []
+
+    def test_skipped_session_parsed(self):
+        analyzer = StubAnalyzer()
+        analyzer.events_data = [
+            {
+                "category": "NOTE",
+                "name": "[SAUTÉE] S077-03-INT-Intervals-V001",
+                "description": "Raison: Fatigue",
+                "start_date_local": "2026-02-05T00:00:00",
+            }
+        ]
+        analyzer.parse_skipped_replaced_sessions()
+        assert len(analyzer.skipped_sessions) == 1
+        assert analyzer.skipped_sessions[0]["reason"] == "Fatigue"
+
+    def test_replaced_session_parsed(self):
+        analyzer = StubAnalyzer()
+        analyzer.events_data = [
+            {
+                "category": "NOTE",
+                "name": "[REMPLACÉE] S077-05-END-Endurance-V001",
+                "description": "Raison: Changed to recovery",
+                "start_date_local": "2026-02-07T00:00:00",
+            }
+        ]
+        analyzer.parse_skipped_replaced_sessions()
+        assert len(analyzer.replaced_sessions) == 1
+
+    def test_cancelled_session_parsed(self):
+        analyzer = StubAnalyzer()
+        analyzer.events_data = [
+            {
+                "category": "NOTE",
+                "name": "[ANNULÉE] S077-06-INT-Sprint-V001",
+                "description": "Raison: Illness",
+                "start_date_local": "2026-02-08T00:00:00",
+            }
+        ]
+        analyzer.parse_skipped_replaced_sessions()
+        assert len(analyzer.cancelled_sessions) == 1
+
+    def test_workout_events_ignored(self):
+        analyzer = StubAnalyzer()
+        analyzer.events_data = [
+            {
+                "category": "WORKOUT",
+                "name": "S077-01-END-Endurance-V001",
+                "description": "Normal workout",
+                "start_date_local": "2026-02-03T00:00:00",
+            }
+        ]
+        analyzer.parse_skipped_replaced_sessions()
+        assert len(analyzer.skipped_sessions) == 0
+        assert len(analyzer.replaced_sessions) == 0
+        assert len(analyzer.cancelled_sessions) == 0
+
+    def test_note_without_tag_ignored(self):
+        analyzer = StubAnalyzer()
+        analyzer.events_data = [
+            {
+                "category": "NOTE",
+                "name": "Regular note",
+                "description": "Just a note",
+                "start_date_local": "2026-02-04T00:00:00",
+            }
+        ]
+        analyzer.parse_skipped_replaced_sessions()
+        assert len(analyzer.skipped_sessions) == 0
+
+    def test_mixed_events(self):
+        analyzer = StubAnalyzer()
+        analyzer.events_data = [
+            {
+                "category": "NOTE",
+                "name": "[SAUTÉE] S077-01",
+                "description": "Raison: Weather",
+                "start_date_local": "2026-02-03T00:00:00",
+            },
+            {
+                "category": "NOTE",
+                "name": "[ANNULÉE] S077-02",
+                "description": "Raison: Sick",
+                "start_date_local": "2026-02-04T00:00:00",
+            },
+            {
+                "category": "WORKOUT",
+                "name": "S077-03-END",
+                "description": "Done",
+                "start_date_local": "2026-02-05T00:00:00",
+            },
+        ]
+        analyzer.parse_skipped_replaced_sessions()
+        assert len(analyzer.skipped_sessions) == 1
+        assert len(analyzer.cancelled_sessions) == 1
+        assert len(analyzer.replaced_sessions) == 0
+
+
+class TestLoadCardiovascularCoupling:
+    """Tests for load_cardiovascular_coupling()."""
+
+    def test_dir_not_found(self):
+        analyzer = StubAnalyzer(workout_history_dir=Path("/nonexistent"))
+        analyzer.load_cardiovascular_coupling()
+        assert analyzer.cv_coupling_values == []
+
+    def test_extracts_coupling_values(self, tmp_path):
+        week_dir = tmp_path / "S077"
+        week_dir.mkdir()
+        history_file = week_dir / "workout_history_S077.md"
+        history_file.write_text(
+            "## Session 1\n"
+            "découplage cardiovasculaire faible (3.2 %)\n"
+            "## Session 2\n"
+            "découplage cardiovasculaire modéré (5.8 %)\n"
+        )
+
+        analyzer = StubAnalyzer(workout_history_dir=tmp_path)
+        analyzer.load_cardiovascular_coupling()
+        assert len(analyzer.cv_coupling_values) == 2
+        # Values converted to decimal (3.2% → 0.032)
+        assert 0.03 < analyzer.cv_coupling_values[0] < 0.04
+        assert 0.05 < analyzer.cv_coupling_values[1] < 0.06
+
+    def test_empty_directory(self, tmp_path):
+        analyzer = StubAnalyzer(workout_history_dir=tmp_path)
+        analyzer.load_cardiovascular_coupling()
+        assert analyzer.cv_coupling_values == []
+
+    def test_no_coupling_in_file(self, tmp_path):
+        week_dir = tmp_path / "S077"
+        week_dir.mkdir()
+        history_file = week_dir / "workout_history_S077.md"
+        history_file.write_text("## Session\nJust a normal ride, nothing special\n")
+
+        analyzer = StubAnalyzer(workout_history_dir=tmp_path)
+        analyzer.load_cardiovascular_coupling()
+        assert analyzer.cv_coupling_values == []
+
+
+class TestLoadIntervalsData:
+    """Tests for load_intervals_data()."""
+
+    def test_loads_all_data(self):
+        mock_client = MagicMock()
+        mock_client.get_wellness.return_value = [{"id": "2026-01-27", "tsb": 5}]
+        mock_client.get_activities.return_value = [{"id": "a1"}]
+        mock_client.get_events.return_value = [{"id": "e1"}]
+
+        analyzer = StubAnalyzer(client=mock_client)
+        analyzer.load_intervals_data()
+
+        assert len(analyzer.wellness_data) == 1
+        assert len(analyzer.activities_data) == 1
+        assert len(analyzer.events_data) == 1
+
+    def test_handles_api_errors(self):
+        mock_client = MagicMock()
+        mock_client.get_wellness.side_effect = Exception("API Error")
+        mock_client.get_activities.side_effect = Exception("API Error")
+        mock_client.get_events.side_effect = Exception("API Error")
+
+        analyzer = StubAnalyzer(client=mock_client)
+        # Should not raise
+        analyzer.load_intervals_data()
+        assert analyzer.wellness_data == []

--- a/tests/analysis/test_baseline_metrics.py
+++ b/tests/analysis/test_baseline_metrics.py
@@ -1,0 +1,229 @@
+"""Tests for analysis.baseline.metrics module.
+
+Tests MetricsMixin : validate_data_quality, calculate_tss_metrics,
+analyze_tsb_trajectory, calculate_cv_coupling_metrics.
+(calculate_adherence_metrics needs PatternAnalysisMixin — tested separately.)
+"""
+
+from datetime import date
+
+import pytest
+
+from magma_cycling.analysis.baseline.metrics import MetricsMixin
+
+
+class StubAnalyzer(MetricsMixin):
+    """Stub providing required attributes for MetricsMixin."""
+
+    def __init__(
+        self,
+        *,
+        start_date=date(2026, 1, 27),
+        end_date=date(2026, 2, 9),
+        adherence_data=None,
+        wellness_data=None,
+        activities_data=None,
+        events_data=None,
+        cv_coupling_values=None,
+        skipped_sessions=None,
+        replaced_sessions=None,
+        cancelled_sessions=None,
+    ):
+        self.start_date = start_date
+        self.end_date = end_date
+        self.duration_days = (end_date - start_date).days + 1
+        self.adherence_data = adherence_data or []
+        self.wellness_data = wellness_data or []
+        self.activities_data = activities_data or []
+        self.events_data = events_data or []
+        self.cv_coupling_values = cv_coupling_values or []
+        self.skipped_sessions = skipped_sessions or []
+        self.replaced_sessions = replaced_sessions or []
+        self.cancelled_sessions = cancelled_sessions or []
+
+
+class TestValidateDataQuality:
+    """Tests for validate_data_quality()."""
+
+    def test_empty_data_low_score(self):
+        analyzer = StubAnalyzer()
+        quality = analyzer.validate_data_quality()
+        assert quality["score"] <= 50
+        assert quality["grade"] == "D"
+
+    def test_full_adherence_completeness(self):
+        # 14 days of data for 14-day period
+        adherence = (
+            [{"date": f"2026-02-{i:02d}", "adherence_rate": 0.9} for i in range(1, 10)]
+            + [{"date": f"2026-01-{i:02d}", "adherence_rate": 0.9} for i in range(27, 32)]
+            + [
+                {"date": "2026-02-09", "adherence_rate": 0.9},
+            ]
+        )
+        analyzer = StubAnalyzer(adherence_data=adherence)
+        quality = analyzer.validate_data_quality()
+        assert quality["completeness"]["adherence"] > 0.5
+
+    def test_gaps_detected(self):
+        # Only 1 day of data for 14-day period → many gaps
+        adherence = [{"date": "2026-01-27", "adherence_rate": 0.9}]
+        analyzer = StubAnalyzer(adherence_data=adherence)
+        quality = analyzer.validate_data_quality()
+        assert len(quality["gaps"]) > 0
+
+    def test_negative_adherence_anomaly(self):
+        adherence = [{"date": "2026-01-27", "adherence_rate": -0.5}]
+        analyzer = StubAnalyzer(adherence_data=adherence)
+        quality = analyzer.validate_data_quality()
+        assert len(quality["anomalies"]) == 1
+        assert quality["anomalies"][0]["type"] == "negative_adherence"
+
+    def test_no_anomalies_clean_data(self):
+        adherence = [{"date": "2026-01-27", "adherence_rate": 0.85}]
+        analyzer = StubAnalyzer(adherence_data=adherence)
+        quality = analyzer.validate_data_quality()
+        assert len(quality["anomalies"]) == 0
+
+    def test_grade_a_high_score(self):
+        # Full adherence + wellness + cv_coupling for high score
+        days = 14
+        adherence = [
+            {
+                "date": f"2026-0{1 if i < 5 else 2}-{(27 + i) if i < 5 else (i - 4):02d}",
+                "adherence_rate": 0.9,
+            }
+            for i in range(days)
+        ]
+        wellness = [{"id": f"2026-02-{i:02d}"} for i in range(1, 10)]
+        analyzer = StubAnalyzer(
+            adherence_data=adherence,
+            wellness_data=wellness,
+            cv_coupling_values=[0.03, 0.04],
+        )
+        quality = analyzer.validate_data_quality()
+        assert quality["score"] >= 80
+
+    def test_wellness_completeness(self):
+        wellness = [{"id": f"2026-02-{i:02d}"} for i in range(1, 8)]
+        analyzer = StubAnalyzer(wellness_data=wellness)
+        quality = analyzer.validate_data_quality()
+        assert quality["completeness"]["wellness"] == pytest.approx(7 / 14, abs=0.01)
+
+
+class TestCalculateTssMetrics:
+    """Tests for calculate_tss_metrics()."""
+
+    def test_empty_data(self):
+        analyzer = StubAnalyzer()
+        metrics = analyzer.calculate_tss_metrics()
+        assert metrics["planned_total"] == 0
+        assert metrics["actual_total"] == 0
+        assert metrics["completion_rate"] == 0
+
+    def test_planned_and_actual(self):
+        events = [
+            {"icu_training_load": 50},
+            {"icu_training_load": 70},
+        ]
+        activities = [
+            {"icu_training_load": 45},
+            {"icu_training_load": 65},
+        ]
+        analyzer = StubAnalyzer(events_data=events, activities_data=activities)
+        metrics = analyzer.calculate_tss_metrics()
+        assert metrics["planned_total"] == 120
+        assert metrics["actual_total"] == 110
+        assert metrics["completion_rate"] == pytest.approx(110 / 120, abs=0.01)
+
+    def test_none_training_load_handled(self):
+        events = [{"icu_training_load": None}, {"icu_training_load": 50}]
+        activities = [{"icu_training_load": None}]
+        analyzer = StubAnalyzer(events_data=events, activities_data=activities)
+        metrics = analyzer.calculate_tss_metrics()
+        assert metrics["planned_total"] == 50
+        assert metrics["actual_total"] == 0
+
+    def test_avg_daily(self):
+        events = [{"icu_training_load": 140}]
+        activities = [{"icu_training_load": 140}]
+        analyzer = StubAnalyzer(events_data=events, activities_data=activities)
+        metrics = analyzer.calculate_tss_metrics()
+        assert metrics["avg_daily_planned"] == pytest.approx(140 / 14, abs=0.1)
+
+
+class TestAnalyzeTsbTrajectory:
+    """Tests for analyze_tsb_trajectory()."""
+
+    def test_empty_wellness(self):
+        analyzer = StubAnalyzer()
+        result = analyzer.analyze_tsb_trajectory()
+        assert result == {}
+
+    def test_single_day(self):
+        wellness = [{"id": "2026-01-27", "tsb": 5.0, "ctl": 40.0, "atl": 35.0}]
+        analyzer = StubAnalyzer(wellness_data=wellness)
+        result = analyzer.analyze_tsb_trajectory()
+        assert result["start_tsb"] == 5.0
+        assert result["end_tsb"] == 5.0
+        assert result["start_ctl"] == 40.0
+
+    def test_trajectory_multiple_days(self):
+        wellness = [
+            {"id": "2026-01-27", "tsb": 10.0, "ctl": 38.0, "atl": 28.0},
+            {"id": "2026-01-28", "tsb": 5.0, "ctl": 39.0, "atl": 34.0},
+            {"id": "2026-01-29", "tsb": -2.0, "ctl": 40.0, "atl": 42.0},
+        ]
+        analyzer = StubAnalyzer(wellness_data=wellness)
+        result = analyzer.analyze_tsb_trajectory()
+        assert result["start_tsb"] == 10.0
+        assert result["end_tsb"] == -2.0
+        assert result["avg_tsb"] == pytest.approx((10 + 5 - 2) / 3, abs=0.1)
+        assert len(result["trajectory"]) == 3
+
+    def test_sorted_by_date(self):
+        wellness = [
+            {"id": "2026-01-29", "tsb": -2.0, "ctl": 40.0, "atl": 42.0},
+            {"id": "2026-01-27", "tsb": 10.0, "ctl": 38.0, "atl": 28.0},
+        ]
+        analyzer = StubAnalyzer(wellness_data=wellness)
+        result = analyzer.analyze_tsb_trajectory()
+        # Should be sorted by id (date)
+        assert result["start_tsb"] == 10.0
+        assert result["end_tsb"] == -2.0
+
+
+class TestCalculateCvCouplingMetrics:
+    """Tests for calculate_cv_coupling_metrics()."""
+
+    def test_no_data(self):
+        analyzer = StubAnalyzer()
+        result = analyzer.calculate_cv_coupling_metrics()
+        assert result["quality"] == "NO_DATA"
+        assert result["count"] == 0
+
+    def test_excellent_quality(self):
+        analyzer = StubAnalyzer(cv_coupling_values=[0.015, 0.020, 0.018])
+        result = analyzer.calculate_cv_coupling_metrics()
+        assert result["quality"] == "EXCELLENT"
+        assert result["count"] == 3
+
+    def test_good_quality(self):
+        analyzer = StubAnalyzer(cv_coupling_values=[0.035, 0.040, 0.038])
+        result = analyzer.calculate_cv_coupling_metrics()
+        assert result["quality"] == "GOOD"
+
+    def test_acceptable_quality(self):
+        analyzer = StubAnalyzer(cv_coupling_values=[0.060, 0.065])
+        result = analyzer.calculate_cv_coupling_metrics()
+        assert result["quality"] == "ACCEPTABLE"
+
+    def test_poor_quality(self):
+        analyzer = StubAnalyzer(cv_coupling_values=[0.08, 0.09, 0.10])
+        result = analyzer.calculate_cv_coupling_metrics()
+        assert result["quality"] == "POOR"
+
+    def test_avg_calculation(self):
+        values = [0.02, 0.04, 0.06]
+        analyzer = StubAnalyzer(cv_coupling_values=values)
+        result = analyzer.calculate_cv_coupling_metrics()
+        assert result["avg"] == pytest.approx(0.04, abs=0.001)

--- a/tests/analysis/test_baseline_pattern_analysis.py
+++ b/tests/analysis/test_baseline_pattern_analysis.py
@@ -1,0 +1,233 @@
+"""Tests for analysis.baseline.pattern_analysis module.
+
+Tests PatternAnalysisMixin : skip reasons clustering, day-of-week patterns, workout type patterns.
+"""
+
+from magma_cycling.analysis.baseline.pattern_analysis import PatternAnalysisMixin
+
+
+class StubAnalyzer(PatternAnalysisMixin):
+    """Stub providing PatternAnalysisMixin for isolated testing."""
+
+    pass
+
+
+class TestAnalyzeSkipReasons:
+    """Tests for analyze_skip_reasons()."""
+
+    def setup_method(self):
+        self.analyzer = StubAnalyzer()
+
+    def test_empty_sessions(self):
+        result = self.analyzer.analyze_skip_reasons([])
+        assert result["total"] == 0
+        assert result["categories"] == {}
+        assert result["distribution"] == {}
+
+    def test_work_schedule_reason(self):
+        sessions = [{"reason": "Too late from work", "date": "2026-03-01", "name": "S081-05"}]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert result["total"] == 1
+        assert "work_schedule" in result["distribution"]
+        assert result["distribution"]["work_schedule"]["count"] == 1
+
+    def test_health_reason(self):
+        sessions = [{"reason": "Fatigue accumulée", "date": "2026-03-02", "name": "S081-03"}]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert "health" in result["distribution"]
+
+    def test_mechanics_reason(self):
+        sessions = [
+            {"reason": "Bike issue trainer broken", "date": "2026-03-03", "name": "S081-04"}
+        ]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert "mechanics" in result["distribution"]
+
+    def test_weather_reason(self):
+        sessions = [{"reason": "Heavy rain all day", "date": "2026-03-04", "name": "S081-02"}]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert "weather" in result["distribution"]
+
+    def test_personal_reason(self):
+        sessions = [{"reason": "Family emergency", "date": "2026-03-05", "name": "S081-06"}]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert "personal" in result["distribution"]
+
+    def test_uncategorized_reason(self):
+        sessions = [{"reason": "No particular reason", "date": "2026-03-06", "name": "S081-07"}]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert "other" in result["distribution"]
+
+    def test_multiple_categories(self):
+        sessions = [
+            {"reason": "Too late from work", "date": "2026-03-01", "name": "S081-01"},
+            {"reason": "Fatigue", "date": "2026-03-02", "name": "S081-02"},
+            {"reason": "Heavy rain", "date": "2026-03-03", "name": "S081-03"},
+        ]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert result["total"] == 3
+        assert len(result["distribution"]) == 3
+
+    def test_percentage_calculation(self):
+        sessions = [
+            {"reason": "Work meeting", "date": "2026-03-01", "name": "S081-01"},
+            {"reason": "Office deadline", "date": "2026-03-02", "name": "S081-02"},
+        ]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert result["distribution"]["work_schedule"]["percentage"] == 100.0
+
+    def test_missing_reason_field(self):
+        sessions = [{"date": "2026-03-01", "name": "S081-01"}]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        assert result["total"] == 1
+        assert "other" in result["distribution"]
+
+    def test_categories_contain_session_details(self):
+        sessions = [{"reason": "Sick day", "date": "2026-03-01", "name": "S081-01"}]
+        result = self.analyzer.analyze_skip_reasons(sessions)
+        health_items = result["categories"]["health"]
+        assert len(health_items) == 1
+        assert health_items[0]["date"] == "2026-03-01"
+        assert health_items[0]["reason"] == "Sick day"
+
+
+class TestAnalyzeDayOfWeekPatterns:
+    """Tests for analyze_day_of_week_patterns()."""
+
+    def setup_method(self):
+        self.analyzer = StubAnalyzer()
+
+    def test_empty_patterns(self):
+        result = self.analyzer.analyze_day_of_week_patterns({})
+        assert result["days"] == {}
+        assert result["high_risk_days"] == []
+        assert result["recommendations"] == []
+
+    def test_perfect_adherence(self):
+        patterns = {"Monday": {"planned": 5, "completed": 5}}
+        result = self.analyzer.analyze_day_of_week_patterns(patterns)
+        assert result["days"]["Monday"]["adherence_rate"] == 1.0
+        assert result["days"]["Monday"]["risk_score"] == 0.0
+        assert result["days"]["Monday"]["risk_level"] == "LOW"
+
+    def test_zero_adherence_critical_risk(self):
+        patterns = {"Friday": {"planned": 5, "completed": 0}}
+        result = self.analyzer.analyze_day_of_week_patterns(patterns)
+        assert result["days"]["Friday"]["risk_score"] == 100.0
+        assert result["days"]["Friday"]["risk_level"] == "CRITICAL"
+
+    def test_moderate_risk(self):
+        patterns = {"Wednesday": {"planned": 10, "completed": 7}}
+        result = self.analyzer.analyze_day_of_week_patterns(patterns)
+        assert result["days"]["Wednesday"]["risk_level"] == "MODERATE"
+
+    def test_high_risk_day_detected(self):
+        patterns = {"Thursday": {"planned": 10, "completed": 4}}
+        result = self.analyzer.analyze_day_of_week_patterns(patterns)
+        assert len(result["high_risk_days"]) == 1
+        assert result["high_risk_days"][0]["day"] == "Thursday"
+
+    def test_high_risk_days_sorted_by_risk(self):
+        patterns = {
+            "Monday": {"planned": 10, "completed": 5},
+            "Friday": {"planned": 10, "completed": 2},
+        }
+        result = self.analyzer.analyze_day_of_week_patterns(patterns)
+        assert len(result["high_risk_days"]) == 2
+        assert result["high_risk_days"][0]["day"] == "Friday"
+
+    def test_recommendations_generated_for_critical(self):
+        patterns = {"Friday": {"planned": 10, "completed": 2}}
+        result = self.analyzer.analyze_day_of_week_patterns(patterns)
+        assert len(result["recommendations"]) > 0
+        assert "CRITICAL" in result["recommendations"][0]
+
+    def test_recommendations_generated_for_high(self):
+        patterns = {"Wednesday": {"planned": 10, "completed": 5}}
+        result = self.analyzer.analyze_day_of_week_patterns(patterns)
+        assert len(result["recommendations"]) > 0
+        assert "HIGH" in result["recommendations"][0]
+
+    def test_zero_planned_no_crash(self):
+        patterns = {"Sunday": {"planned": 0, "completed": 0}}
+        result = self.analyzer.analyze_day_of_week_patterns(patterns)
+        assert result["days"]["Sunday"]["adherence_rate"] == 0
+        assert result["days"]["Sunday"]["risk_score"] == 100.0
+
+
+class TestAnalyzeWorkoutTypePatterns:
+    """Tests for analyze_workout_type_patterns()."""
+
+    def setup_method(self):
+        self.analyzer = StubAnalyzer()
+
+    def test_empty_sessions(self):
+        result = self.analyzer.analyze_workout_type_patterns([], [])
+        assert result["types"] == {}
+        assert result["high_risk_types"] == []
+
+    def test_single_type_all_completed(self):
+        all_sessions = [
+            {"name": "S081-01-END-Endurance-V001"},
+            {"name": "S081-03-END-Endurance-V001"},
+        ]
+        completed = [
+            {"name": "S081-01-END-Endurance-V001"},
+            {"name": "S081-03-END-Endurance-V001"},
+        ]
+        result = self.analyzer.analyze_workout_type_patterns(completed, all_sessions)
+        assert "END" in result["types"]
+        assert result["types"]["END"]["adherence_rate"] == 1.0
+
+    def test_mixed_types(self):
+        all_sessions = [
+            {"name": "S081-01-END-Endurance-V001"},
+            {"name": "S081-03-INT-Intervals-V001"},
+            {"name": "S081-05-REC-Recovery-V001"},
+        ]
+        completed = [
+            {"name": "S081-01-END-Endurance-V001"},
+            {"name": "S081-05-REC-Recovery-V001"},
+        ]
+        result = self.analyzer.analyze_workout_type_patterns(completed, all_sessions)
+        assert len(result["types"]) == 3
+        assert result["types"]["END"]["completed"] == 1
+        assert result["types"]["INT"]["completed"] == 0
+        assert result["types"]["REC"]["completed"] == 1
+
+    def test_high_risk_type_detected(self):
+        all_sessions = [
+            {"name": "S081-01-INT-Intervals-V001"},
+            {"name": "S081-03-INT-Intervals-V001"},
+            {"name": "S081-05-INT-Intervals-V001"},
+        ]
+        completed = []
+        result = self.analyzer.analyze_workout_type_patterns(completed, all_sessions)
+        assert len(result["high_risk_types"]) == 1
+        assert result["high_risk_types"][0]["type"] == "INT"
+
+    def test_status_tags_stripped(self):
+        all_sessions = [
+            {"name": "[SAUTÉE] S081-01-INT-Intervals-V001"},
+            {"name": "[ANNULÉE] S081-03-END-Endurance-V001"},
+        ]
+        completed = []
+        result = self.analyzer.analyze_workout_type_patterns(completed, all_sessions)
+        assert "INT" in result["types"]
+        assert "END" in result["types"]
+
+    def test_no_matching_pattern_skipped(self):
+        all_sessions = [{"name": "RandomName"}]
+        completed = []
+        result = self.analyzer.analyze_workout_type_patterns(completed, all_sessions)
+        assert len(result["types"]) == 0
+
+    def test_recommendations_for_critical_type(self):
+        all_sessions = [
+            {"name": "S081-01-CAD-Cadence-V001"},
+            {"name": "S081-03-CAD-Cadence-V001"},
+        ]
+        completed = []
+        result = self.analyzer.analyze_workout_type_patterns(completed, all_sessions)
+        assert len(result["recommendations"]) > 0
+        assert "CRITICAL" in result["recommendations"][0]

--- a/tests/analysis/test_baseline_reporting.py
+++ b/tests/analysis/test_baseline_reporting.py
@@ -1,0 +1,240 @@
+"""Tests for analysis.baseline.reporting module.
+
+Tests ReportingMixin : generate_json_output, generate_markdown_report, _format_markdown_report.
+"""
+
+import json
+from datetime import date
+
+from magma_cycling.analysis.baseline.reporting import ReportingMixin
+
+
+class StubAnalyzer(ReportingMixin):
+    """Stub providing required attributes for ReportingMixin."""
+
+    def __init__(self, output_dir):
+        self.output_dir = output_dir
+
+
+def _make_results(
+    *,
+    adherence_rate=0.85,
+    tss_planned=500,
+    tss_actual=450,
+    tsb_start=5.0,
+    tsb_end=-3.0,
+    cv_avg=0.04,
+    quality_score=85,
+):
+    """Build a minimal results dict for reporting tests."""
+    return {
+        "metadata": {
+            "period_start": "2026-01-27",
+            "period_end": "2026-02-09",
+            "duration_days": 14,
+            "version": "1.0.0",
+        },
+        "quality": {
+            "score": quality_score,
+            "grade": "B",
+            "completeness": {"adherence": 0.9, "wellness": 0.8, "activities": 10},
+            "gaps": [],
+            "anomalies": [],
+        },
+        "adherence": {
+            "rate": adherence_rate,
+            "completed": 10,
+            "planned": 12,
+            "skipped": 1,
+            "replaced": 1,
+            "cancelled": 0,
+            "skipped_details": [
+                {"date": "2026-02-03", "name": "S077-01", "reason": "Fatigue"},
+            ],
+            "replaced_details": [],
+            "cancelled_details": [],
+            "day_patterns": {
+                "Monday": {"planned": 2, "completed": 2},
+                "Wednesday": {"planned": 2, "completed": 1},
+            },
+            "skip_reasons_analysis": {"total": 0, "categories": {}, "distribution": {}},
+            "day_patterns_analysis": {
+                "high_risk_days": [],
+                "recommendations": [],
+            },
+            "workout_type_patterns_analysis": {
+                "high_risk_types": [],
+                "recommendations": [],
+            },
+        },
+        "tss": {
+            "planned_total": tss_planned,
+            "actual_total": tss_actual,
+            "completion_rate": tss_actual / tss_planned if tss_planned else 0,
+            "avg_daily_planned": tss_planned / 14,
+            "avg_daily_actual": tss_actual / 14,
+        },
+        "tsb": {
+            "start_tsb": tsb_start,
+            "end_tsb": tsb_end,
+            "avg_tsb": (tsb_start + tsb_end) / 2,
+            "start_ctl": 40.0,
+            "end_ctl": 42.0,
+            "start_atl": 35.0,
+            "end_atl": 45.0,
+        },
+        "cardiovascular_coupling": {
+            "avg": cv_avg,
+            "count": 5,
+            "quality": "GOOD",
+        },
+    }
+
+
+class TestGenerateJsonOutput:
+    """Tests for generate_json_output()."""
+
+    def test_creates_json_file(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        path = analyzer.generate_json_output(results)
+        assert path.exists()
+        assert path.name == "baseline_preliminary.json"
+
+    def test_json_content_valid(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        path = analyzer.generate_json_output(results)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["metadata"]["duration_days"] == 14
+
+    def test_json_default_str_serialization(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        results["metadata"]["some_date"] = date(2026, 1, 27)
+        path = analyzer.generate_json_output(results)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["metadata"]["some_date"] == "2026-01-27"
+
+
+class TestGenerateMarkdownReport:
+    """Tests for generate_markdown_report()."""
+
+    def test_creates_markdown_file(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        path = analyzer.generate_markdown_report(results)
+        assert path.exists()
+        assert path.suffix == ".md"
+
+    def test_markdown_contains_title(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        path = analyzer.generate_markdown_report(results)
+        content = path.read_text(encoding="utf-8")
+        assert "# Rapport Baseline" in content
+
+
+class TestFormatMarkdownReport:
+    """Tests for _format_markdown_report()."""
+
+    def test_contains_period_section(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Période Analysée" in report
+        assert "2026-01-27" in report
+
+    def test_contains_adherence_section(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Synthèse Adhérence" in report
+        assert "85.0%" in report
+
+    def test_contains_tss_section(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Charge Entraînement" in report
+        assert "500" in report
+
+    def test_contains_tsb_section(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Evolution Fitness" in report
+
+    def test_contains_cv_section(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Qualité Cardiovasculaire" in report
+
+    def test_contains_quality_section(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Qualité Données" in report
+        assert "85/100" in report
+
+    def test_overcharge_warning(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results(tss_planned=400, tss_actual=500)
+        report = analyzer._format_markdown_report(results)
+        assert "Sur-charge" in report
+
+    def test_undercharge_warning(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results(tss_planned=500, tss_actual=350)
+        report = analyzer._format_markdown_report(results)
+        assert "Sous-charge" in report
+
+    def test_optimal_charge(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results(tss_planned=500, tss_actual=490)
+        report = analyzer._format_markdown_report(results)
+        assert "optimale" in report
+
+    def test_skipped_details_in_report(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Séances Sautées" in report
+        assert "Fatigue" in report
+
+    def test_no_skipped_shows_clean(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        results["adherence"]["skipped_details"] = []
+        results["adherence"]["replaced_details"] = []
+        results["adherence"]["cancelled_details"] = []
+        report = analyzer._format_markdown_report(results)
+        assert "Aucune séance manquée" in report
+
+    def test_high_tsb_excellent_form(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results(tsb_end=15.0)
+        results["tsb"]["end_tsb"] = 15.0
+        report = analyzer._format_markdown_report(results)
+        assert "excellente" in report
+
+    def test_negative_tsb_fatigue(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results(tsb_end=-10.0)
+        results["tsb"]["end_tsb"] = -10.0
+        report = analyzer._format_markdown_report(results)
+        assert "Fatigue" in report
+
+    def test_insights_section(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Insights" in report
+
+    def test_day_patterns_table(self, tmp_path):
+        analyzer = StubAnalyzer(output_dir=tmp_path)
+        results = _make_results()
+        report = analyzer._format_markdown_report(results)
+        assert "Monday" in report
+        assert "Wednesday" in report

--- a/tests/workflows/eow/test_evaluation.py
+++ b/tests/workflows/eow/test_evaluation.py
@@ -1,0 +1,203 @@
+"""Tests for workflows.eow.evaluation module.
+
+Tests EvaluationMixin : _step1b_pid_evaluation, _step1c_monthly_analysis_if_month_end.
+Uses sys.modules injection for locally-imported modules.
+"""
+
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from magma_cycling.workflows.eow.evaluation import EvaluationMixin
+
+
+class StubEowWorkflow(EvaluationMixin):
+    """Stub providing required attributes for EvaluationMixin."""
+
+    def __init__(
+        self,
+        *,
+        dry_run=False,
+        completed_start_date=date(2026, 2, 24),
+        completed_end_date=date(2026, 3, 1),
+        next_start_date=date(2026, 3, 2),
+        provider="claude",
+        reports_dir=None,
+    ):
+        self.dry_run = dry_run
+        self.completed_start_date = completed_start_date
+        self.completed_end_date = completed_end_date
+        self.next_start_date = next_start_date
+        self.provider = provider
+        self.reports_dir = reports_dir or Path("/tmp")
+
+
+class TestStep1bPidEvaluation:
+    """Tests for _step1b_pid_evaluation()."""
+
+    def test_dry_run_returns_true(self):
+        wf = StubEowWorkflow(dry_run=True)
+        assert wf._step1b_pid_evaluation() is True
+
+    def test_success(self):
+        mock_evaluator = MagicMock()
+        mock_evaluator.run_daily_evaluation.return_value = {}
+
+        mock_module = MagicMock()
+        mock_module.PIDDailyEvaluator.return_value = mock_evaluator
+
+        with patch.dict(sys.modules, {"magma_cycling.scripts.pid_daily_evaluation": mock_module}):
+            wf = StubEowWorkflow(dry_run=False)
+            result = wf._step1b_pid_evaluation()
+
+        assert result is True
+        mock_evaluator.run_daily_evaluation.assert_called_once_with(days_back=7)
+
+    def test_with_test_recommendation(self):
+        mock_evaluator = MagicMock()
+        mock_evaluator.run_daily_evaluation.return_value = {
+            "test_recommendation": {
+                "status": "RECOMMENDED",
+                "message": "Test FTP recommended",
+                "timing": "Next week",
+                "weeks_since_test": 8.0,
+                "tsb": 12.5,
+            }
+        }
+
+        mock_module = MagicMock()
+        mock_module.PIDDailyEvaluator.return_value = mock_evaluator
+
+        with patch.dict(sys.modules, {"magma_cycling.scripts.pid_daily_evaluation": mock_module}):
+            wf = StubEowWorkflow(dry_run=False)
+            result = wf._step1b_pid_evaluation()
+        assert result is True
+
+    def test_exception_non_blocking(self):
+        mock_module = MagicMock()
+        mock_module.PIDDailyEvaluator.side_effect = Exception("Import error")
+
+        with patch.dict(sys.modules, {"magma_cycling.scripts.pid_daily_evaluation": mock_module}):
+            wf = StubEowWorkflow(dry_run=False)
+            result = wf._step1b_pid_evaluation()
+        # Non-blocking: returns True even on error
+        assert result is True
+
+
+class TestStep1cMonthlyAnalysis:
+    """Tests for _step1c_monthly_analysis_if_month_end()."""
+
+    def test_no_month_transition_skips(self):
+        """When completed week and next week are same month, skip."""
+        wf = StubEowWorkflow(
+            completed_start_date=date(2026, 3, 9),
+            next_start_date=date(2026, 3, 16),
+        )
+        result = wf._step1c_monthly_analysis_if_month_end()
+        assert result is True
+
+    def test_month_transition_detected_dry_run(self):
+        """Dry run with month transition returns True."""
+        wf = StubEowWorkflow(
+            dry_run=True,
+            completed_start_date=date(2026, 2, 24),
+            next_start_date=date(2026, 3, 2),
+        )
+        result = wf._step1c_monthly_analysis_if_month_end()
+        assert result is True
+
+    def test_month_transition_generates_report(self, tmp_path):
+        mock_analyzer = MagicMock()
+        mock_analyzer.run.return_value = "# Monthly Report\nContent here"
+
+        mock_module = MagicMock()
+        mock_module.MonthlyAnalyzer.return_value = mock_analyzer
+
+        with patch.dict(sys.modules, {"magma_cycling.monthly_analysis": mock_module}):
+            wf = StubEowWorkflow(
+                dry_run=False,
+                completed_start_date=date(2026, 2, 24),
+                next_start_date=date(2026, 3, 2),
+                reports_dir=tmp_path,
+            )
+            result = wf._step1c_monthly_analysis_if_month_end()
+
+        assert result is True
+        report_file = tmp_path / "monthly_report_2026-02.md"
+        assert report_file.exists()
+        assert "Monthly Report" in report_file.read_text()
+
+    def test_empty_report_returns_true(self, tmp_path):
+        mock_analyzer = MagicMock()
+        mock_analyzer.run.return_value = None
+
+        mock_module = MagicMock()
+        mock_module.MonthlyAnalyzer.return_value = mock_analyzer
+
+        with patch.dict(sys.modules, {"magma_cycling.monthly_analysis": mock_module}):
+            wf = StubEowWorkflow(
+                dry_run=False,
+                completed_start_date=date(2026, 2, 24),
+                next_start_date=date(2026, 3, 2),
+                reports_dir=tmp_path,
+            )
+            result = wf._step1c_monthly_analysis_if_month_end()
+        assert result is True
+
+    def test_exception_non_blocking(self, tmp_path):
+        mock_module = MagicMock()
+        mock_module.MonthlyAnalyzer.side_effect = Exception("Analyzer error")
+
+        with patch.dict(sys.modules, {"magma_cycling.monthly_analysis": mock_module}):
+            wf = StubEowWorkflow(
+                dry_run=False,
+                completed_start_date=date(2026, 2, 24),
+                next_start_date=date(2026, 3, 2),
+                reports_dir=tmp_path,
+            )
+            result = wf._step1c_monthly_analysis_if_month_end()
+        # Non-blocking
+        assert result is True
+
+    def test_provider_passed_to_analyzer(self, tmp_path):
+        mock_analyzer = MagicMock()
+        mock_analyzer.run.return_value = "Report"
+
+        mock_module = MagicMock()
+        mock_module.MonthlyAnalyzer.return_value = mock_analyzer
+
+        with patch.dict(sys.modules, {"magma_cycling.monthly_analysis": mock_module}):
+            wf = StubEowWorkflow(
+                dry_run=False,
+                completed_start_date=date(2026, 2, 24),
+                next_start_date=date(2026, 3, 2),
+                reports_dir=tmp_path,
+                provider="mistral",
+            )
+            wf._step1c_monthly_analysis_if_month_end()
+
+        mock_module.MonthlyAnalyzer.assert_called_once_with(
+            month="2026-02", provider="mistral", no_ai=False
+        )
+
+    def test_clipboard_provider_sets_no_ai(self, tmp_path):
+        mock_analyzer = MagicMock()
+        mock_analyzer.run.return_value = "Report"
+
+        mock_module = MagicMock()
+        mock_module.MonthlyAnalyzer.return_value = mock_analyzer
+
+        with patch.dict(sys.modules, {"magma_cycling.monthly_analysis": mock_module}):
+            wf = StubEowWorkflow(
+                dry_run=False,
+                completed_start_date=date(2026, 2, 24),
+                next_start_date=date(2026, 3, 2),
+                reports_dir=tmp_path,
+                provider="clipboard",
+            )
+            wf._step1c_monthly_analysis_if_month_end()
+
+        mock_module.MonthlyAnalyzer.assert_called_once_with(
+            month="2026-02", provider="clipboard", no_ai=True
+        )


### PR DESCRIPTION
## Summary
- Add **100 tests** covering 5 modules with low coverage (Phase 4 — Stretch)
- `analysis/baseline/pattern_analysis.py`: skip reasons clustering, day-of-week patterns, workout type patterns (27 tests)
- `analysis/baseline/metrics.py`: data quality validation, TSS metrics, TSB trajectory, CV coupling metrics (21 tests)
- `analysis/baseline/reporting.py`: JSON output, markdown report formatting with edge cases (20 tests)
- `analysis/baseline/data_loading.py`: adherence JSONL loading, session parsing, CV coupling extraction (21 tests)
- `workflows/eow/evaluation.py`: PID evaluation, monthly analysis with month transition detection (11 tests)

## Test plan
- [x] 100/100 tests passing locally (`pytest -q`)
- [x] Pre-commit clean (Black, Ruff, isort)
- [ ] CI pipeline green (15/15 checks)
- [ ] Codecov delta: targeting ~+3pp toward 75%+

🤖 Generated with [Claude Code](https://claude.com/claude-code)