### PR TITLE
test(phase5): coverage for manage_workflow_state + reports/generator

### DIFF
--- a/tests/reports/test_generator.py
+++ b/tests/reports/test_generator.py
@@ -1,49 +1,418 @@
-"""Tests for report generator.
+"""Tests for reports/generator.py — ReportGenerator pipeline.
 
-Sprint R10 MVP - Tests for ReportGenerator orchestration.
-
-Author: Claude Code
-Created: 2026-01-18
+Covers:
+- Input validation (week format, report_type)
+- _build_prompt() dispatch to correct builder
+- _save_report() file creation
+- _validate_report() delegation
+- _initialize_ai_analyzer() provider setup
+- _collect_week_data() week parsing
+- generate_report() full pipeline success + error chains
 """
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from magma_cycling.reports import ReportGenerator
+from magma_cycling.reports.generator import (
+    ReportGenerationError,
+    ReportGenerator,
+)
+from magma_cycling.reports.validators import ValidationResult
 
 
-class TestReportGenerator:
-    """Tests for ReportGenerator class."""
+@pytest.fixture
+def generator():
+    """Create ReportGenerator instance."""
+    return ReportGenerator(ai_provider="claude_api")
+
+
+@pytest.fixture
+def valid_week_data():
+    """Sample collected week data."""
+    return {
+        "week": "S090",
+        "activities": [
+            {"name": "Endurance Z2", "tss": 65},
+            {"name": "Sweet Spot", "tss": 85},
+        ],
+        "wellness": {"ctl": 65, "atl": 58},
+    }
+
+
+class TestReportGeneratorInit:
+    """Test ReportGenerator initialization."""
 
     def test_init_default_provider(self):
-        """Test generator initialization with default provider."""
-        generator = ReportGenerator()
-
-        assert generator.ai_provider == "claude_api"
-        assert generator.ai_analyzer is None
+        """Test default provider is claude_api."""
+        gen = ReportGenerator()
+        assert gen.ai_provider == "claude_api"
+        assert gen.ai_analyzer is None
 
     def test_init_custom_provider(self):
-        """Test generator initialization with custom provider."""
-        generator = ReportGenerator(ai_provider="openai")
+        """Test custom provider assignment."""
+        gen = ReportGenerator(ai_provider="mistral_api")
+        assert gen.ai_provider == "mistral_api"
 
-        assert generator.ai_provider == "openai"
 
-    def test_generate_report_invalid_week_format(self):
-        """Test generate_report rejects invalid week format."""
-        generator = ReportGenerator()
+class TestInputValidation:
+    """Test generate_report input validation."""
 
+    def test_invalid_week_format_none(self, generator):
+        """Test ValueError for None week."""
         with pytest.raises(ValueError, match="Invalid week format"):
-            generator.generate_report(week="076", report_type="workout_history")
+            generator.generate_report(week=None, report_type="workout_history")
 
+    def test_invalid_week_format_no_prefix(self, generator):
+        """Test ValueError for week without S prefix."""
+        with pytest.raises(ValueError, match="Invalid week format"):
+            generator.generate_report(week="090", report_type="workout_history")
+
+    def test_invalid_week_format_empty(self, generator):
+        """Test ValueError for empty week string."""
         with pytest.raises(ValueError, match="Invalid week format"):
             generator.generate_report(week="", report_type="workout_history")
 
-    def test_generate_report_invalid_report_type(self):
-        """Test generate_report rejects invalid report type."""
-        generator = ReportGenerator()
-
+    def test_invalid_report_type(self, generator):
+        """Test ValueError for unsupported report type."""
         with pytest.raises(ValueError, match="Invalid report type"):
-            generator.generate_report(week="S076", report_type="invalid_report")
+            generator.generate_report(week="S090", report_type="weekly_summary")
 
-    # Note: Full integration tests removed - generate_report now fully implemented
-    # Integration testing will be done with proper mocking of DataCollector and AIClient
-    # in dedicated integration test files (Day 3)
+    def test_valid_report_types_accepted(self, generator):
+        """Test both valid report types pass validation (fail later)."""
+        for rtype in ["workout_history", "bilan_final"]:
+            with pytest.raises(ReportGenerationError):
+                # Will fail at data collection, not validation
+                generator.generate_report(week="S090", report_type=rtype)
+
+
+class TestBuildPrompt:
+    """Test _build_prompt() dispatch."""
+
+    def test_workout_history_dispatch(self, generator, valid_week_data):
+        """Test workout_history dispatches to correct builder."""
+        with patch(
+            "magma_cycling.reports.generator.build_workout_history_prompt",
+            return_value="prompt-wh",
+        ) as mock_build:
+            result = generator._build_prompt(valid_week_data, "workout_history")
+
+        mock_build.assert_called_once_with(valid_week_data)
+        assert result == "prompt-wh"
+
+    def test_bilan_final_dispatch(self, generator, valid_week_data):
+        """Test bilan_final dispatches to correct builder."""
+        with patch(
+            "magma_cycling.reports.generator.build_bilan_final_prompt",
+            return_value="prompt-bf",
+        ) as mock_build:
+            result = generator._build_prompt(valid_week_data, "bilan_final")
+
+        mock_build.assert_called_once_with(valid_week_data)
+        assert result == "prompt-bf"
+
+    def test_unknown_type_raises(self, generator, valid_week_data):
+        """Test unknown report type raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown report type"):
+            generator._build_prompt(valid_week_data, "invalid_type")
+
+
+class TestSaveReport:
+    """Test _save_report() file creation."""
+
+    def test_save_creates_file(self, generator, tmp_path):
+        """Test report saved to correct path."""
+        content = "# Weekly Report\nContent here."
+        result = generator._save_report(content, "S090", "workout_history", tmp_path)
+
+        assert result == tmp_path / "workout_history_s090.md"
+        assert result.exists()
+        assert result.read_text() == content
+
+    def test_save_filename_format(self, generator, tmp_path):
+        """Test filename uses lowercase week."""
+        generator._save_report("content", "S076", "bilan_final", tmp_path)
+
+        assert (tmp_path / "bilan_final_s076.md").exists()
+
+    def test_save_error_raises(self, generator):
+        """Test save to invalid path raises ReportGenerationError."""
+        with pytest.raises(ReportGenerationError, match="Failed to save"):
+            generator._save_report(
+                "content",
+                "S090",
+                "workout_history",
+                Path("/nonexistent/path/that/cannot/exist"),
+            )
+
+
+class TestValidateReport:
+    """Test _validate_report() delegation."""
+
+    def test_validates_via_markdown_validator(self, generator, valid_week_data):
+        """Test _validate_report delegates to MarkdownValidator."""
+        mock_result = ValidationResult(
+            is_valid=True,
+            errors=[],
+            warnings=[],
+            metrics={"word_count": 500},
+        )
+
+        with patch("magma_cycling.reports.generator.MarkdownValidator") as MockValidator:
+            MockValidator.return_value.validate_report.return_value = mock_result
+            result = generator._validate_report("# Report", "workout_history", valid_week_data)
+
+        assert result.is_valid is True
+        MockValidator.return_value.validate_report.assert_called_once_with(
+            "# Report", "workout_history", valid_week_data
+        )
+
+
+class TestInitializeAiAnalyzer:
+    """Test _initialize_ai_analyzer() provider setup."""
+
+    def test_initializes_provider(self, generator):
+        """Test AI analyzer is created via factory."""
+        mock_analyzer = MagicMock()
+
+        with (
+            patch("magma_cycling.reports.generator.get_ai_config") as mock_config,
+            patch("magma_cycling.reports.generator.AIProviderFactory") as mock_factory,
+        ):
+            mock_config.return_value.get_provider_config.return_value = {"api_key": "k"}
+            mock_factory.create.return_value = mock_analyzer
+
+            generator._initialize_ai_analyzer("claude_api")
+
+        assert generator.ai_analyzer == mock_analyzer
+        mock_factory.create.assert_called_once()
+
+    def test_config_error_raises(self, generator):
+        """Test ConfigError during init is re-raised."""
+        from magma_cycling.ai_providers.factory import ConfigError
+
+        with (
+            patch("magma_cycling.reports.generator.get_ai_config") as mock_config,
+            patch("magma_cycling.reports.generator.AIProviderFactory") as mock_factory,
+        ):
+            mock_config.return_value.get_provider_config.return_value = {}
+            mock_factory.create.side_effect = ConfigError("No API key")
+
+            with pytest.raises(ConfigError, match="No API key"):
+                generator._initialize_ai_analyzer("claude_api")
+
+
+class TestCollectWeekData:
+    """Test _collect_week_data() week parsing."""
+
+    def test_invalid_week_number(self, generator):
+        """Test non-numeric week number raises error."""
+        with pytest.raises(ReportGenerationError, match="Invalid week format"):
+            generator._collect_week_data("SABC")
+
+    def test_delegates_to_data_collector(self, generator):
+        """Test data collection delegates to DataCollector."""
+        mock_data = {"activities": [], "wellness": {}}
+
+        with patch("magma_cycling.reports.generator.DataCollector") as MockCollector:
+            MockCollector.return_value.collect_week_data.return_value = mock_data
+            result = generator._collect_week_data("S090")
+
+        assert result == mock_data
+        MockCollector.return_value.collect_week_data.assert_called_once()
+
+
+class TestGenerateReportPipeline:
+    """Test generate_report() full pipeline."""
+
+    def test_full_pipeline_success(self, generator, tmp_path):
+        """Test successful end-to-end report generation."""
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze_session.return_value = "# Generated Report\nContent."
+
+        valid_result = ValidationResult(
+            is_valid=True,
+            errors=[],
+            warnings=[],
+            metrics={"word_count": 100, "section_count": 3},
+        )
+
+        with (
+            patch.object(
+                generator,
+                "_collect_week_data",
+                return_value={"activities": []},
+            ),
+            patch.object(
+                generator,
+                "_build_prompt",
+                return_value="Build this report",
+            ),
+            patch.object(generator, "_validate_report", return_value=valid_result),
+        ):
+            generator.ai_analyzer = mock_analyzer
+            result = generator.generate_report(
+                week="S090",
+                report_type="workout_history",
+                output_dir=tmp_path,
+            )
+
+        assert result == tmp_path / "workout_history_s090.md"
+        assert result.exists()
+        mock_analyzer.analyze_session.assert_called_once()
+
+    def test_pipeline_validation_failure(self, generator, tmp_path):
+        """Test pipeline raises when validation fails."""
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze_session.return_value = "Bad content"
+
+        invalid_result = ValidationResult(
+            is_valid=False,
+            errors=["Missing required section"],
+            warnings=[],
+        )
+
+        with (
+            patch.object(
+                generator,
+                "_collect_week_data",
+                return_value={"activities": []},
+            ),
+            patch.object(generator, "_build_prompt", return_value="prompt"),
+            patch.object(generator, "_validate_report", return_value=invalid_result),
+        ):
+            generator.ai_analyzer = mock_analyzer
+
+            with pytest.raises(ReportGenerationError, match="failed validation"):
+                generator.generate_report(
+                    week="S090",
+                    report_type="workout_history",
+                    output_dir=tmp_path,
+                )
+
+    def test_pipeline_data_collection_error(self, generator, tmp_path):
+        """Test DataCollectionError is wrapped in ReportGenerationError."""
+        from magma_cycling.reports.data_collector import DataCollectionError
+
+        with patch.object(
+            generator,
+            "_collect_week_data",
+            side_effect=DataCollectionError("No data found"),
+        ):
+            with pytest.raises(ReportGenerationError, match="Data collection failed"):
+                generator.generate_report(
+                    week="S090",
+                    report_type="workout_history",
+                    output_dir=tmp_path,
+                )
+
+    def test_pipeline_ai_error(self, generator, tmp_path):
+        """Test AI error is wrapped in ReportGenerationError."""
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze_session.side_effect = Exception("API timeout")
+
+        with (
+            patch.object(
+                generator,
+                "_collect_week_data",
+                return_value={"activities": []},
+            ),
+            patch.object(generator, "_build_prompt", return_value="prompt"),
+        ):
+            generator.ai_analyzer = mock_analyzer
+
+            with pytest.raises(ReportGenerationError, match="Unexpected error"):
+                generator.generate_report(
+                    week="S090",
+                    report_type="workout_history",
+                    output_dir=tmp_path,
+                )
+
+    def test_provider_override(self, generator, tmp_path):
+        """Test ai_provider parameter overrides default."""
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze_session.return_value = "# Report"
+
+        valid_result = ValidationResult(is_valid=True, errors=[], warnings=[], metrics={})
+
+        with (
+            patch.object(
+                generator,
+                "_collect_week_data",
+                return_value={"activities": []},
+            ),
+            patch.object(generator, "_build_prompt", return_value="prompt"),
+            patch.object(generator, "_validate_report", return_value=valid_result),
+            patch.object(generator, "_initialize_ai_analyzer") as mock_init,
+        ):
+            generator.ai_analyzer = mock_analyzer
+            generator.generate_report(
+                week="S090",
+                report_type="workout_history",
+                ai_provider="mistral_api",
+                output_dir=tmp_path,
+            )
+
+        # ai_analyzer was already set, so _initialize_ai_analyzer not called
+        mock_init.assert_not_called()
+
+    def test_default_output_dir(self, generator):
+        """Test default output dir is ~/data/reports/."""
+        with (
+            patch.object(
+                generator,
+                "_collect_week_data",
+                return_value={"activities": []},
+            ),
+            patch.object(generator, "_build_prompt", return_value="prompt"),
+            patch.object(
+                generator,
+                "_validate_report",
+                return_value=ValidationResult(is_valid=True, errors=[], warnings=[], metrics={}),
+            ),
+            patch.object(
+                generator, "_save_report", return_value=Path("/tmp/report.md")
+            ) as mock_save,
+        ):
+            generator.ai_analyzer = MagicMock()
+            generator.ai_analyzer.analyze_session.return_value = "report"
+
+            generator.generate_report(week="S090", report_type="workout_history")
+
+        # Verify default output_dir was used
+        call_args = mock_save.call_args
+        assert call_args[0][3] == Path.home() / "data" / "reports"
+
+    def test_validation_warnings_logged(self, generator, tmp_path, caplog):
+        """Test validation warnings are logged."""
+        import logging
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze_session.return_value = "# Report"
+
+        result_with_warnings = ValidationResult(
+            is_valid=True,
+            errors=[],
+            warnings=["Word count low: 50"],
+            metrics={"word_count": 50},
+        )
+
+        with (
+            patch.object(
+                generator,
+                "_collect_week_data",
+                return_value={"activities": []},
+            ),
+            patch.object(generator, "_build_prompt", return_value="prompt"),
+            patch.object(generator, "_validate_report", return_value=result_with_warnings),
+            caplog.at_level(logging.WARNING, logger="magma_cycling.reports.generator"),
+        ):
+            generator.ai_analyzer = mock_analyzer
+            generator.generate_report(
+                week="S090",
+                report_type="workout_history",
+                output_dir=tmp_path,
+            )
+
+        assert "Word count low" in caplog.text

--- a/tests/test_manage_workflow_state.py
+++ b/tests/test_manage_workflow_state.py
@@ -1,0 +1,371 @@
+"""Tests for manage_workflow_state.py — CLI workflow state management.
+
+Covers:
+- show_state() output formatting
+- list_activities() with empty/populated history
+- remove_activity() with confirm/cancel/not found
+- reset_state() with confirm/cancel
+- main() argparse and action routing
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.manage_workflow_state import (
+    list_activities,
+    main,
+    remove_activity,
+    reset_state,
+    show_state,
+)
+
+
+@pytest.fixture
+def mock_state():
+    """Create a mock WorkflowState with typical data."""
+    state = MagicMock()
+    state.get_stats.return_value = {
+        "total_analyses": 42,
+        "last_analyzed_id": "i129000001",
+        "last_analyzed_date": "2026-03-15T14:30:00",
+        "history_count": 42,
+    }
+    state.get_documented_specials.return_value = {}
+    state.state = {
+        "history": [
+            {
+                "activity_id": "i129000001",
+                "activity_date": "2026-03-15",
+                "analyzed_at": "2026-03-15T14:30:00",
+            },
+            {
+                "activity_id": "i129000002",
+                "activity_date": "2026-03-14",
+                "analyzed_at": "2026-03-14T10:00:00",
+            },
+            {
+                "activity_id": "i129000003",
+                "activity_date": "2026-03-13",
+                "analyzed_at": "2026-03-13T09:00:00",
+            },
+        ],
+        "last_analyzed_activity_id": "i129000001",
+        "last_analyzed_date": "2026-03-15T14:30:00",
+    }
+    return state
+
+
+class TestShowState:
+    """Test show_state() output formatting."""
+
+    def test_show_state_prints_stats(self, mock_state, capsys):
+        """Test show_state displays stats from WorkflowState."""
+        show_state(mock_state)
+
+        output = capsys.readouterr().out
+        assert "42" in output
+        assert "i129000001" in output
+        assert "ÉTAT DU WORKFLOW" in output
+
+    def test_show_state_with_specials(self, mock_state, capsys):
+        """Test show_state displays documented special sessions."""
+        mock_state.get_documented_specials.return_value = {
+            "S081-REST_2026-03-10": {
+                "session_id": "S081-REST",
+                "date": "2026-03-10",
+                "type": "rest",
+            }
+        }
+
+        show_state(mock_state)
+
+        output = capsys.readouterr().out
+        assert "S081-REST" in output
+        assert "2026-03-10" in output
+        assert "rest" in output
+
+    def test_show_state_no_specials(self, mock_state, capsys):
+        """Test show_state without special sessions omits section."""
+        show_state(mock_state)
+
+        output = capsys.readouterr().out
+        assert "Sessions spéciales" not in output
+
+
+class TestListActivities:
+    """Test list_activities() with various history states."""
+
+    def test_list_empty_history(self, mock_state, capsys):
+        """Test list_activities with empty history."""
+        mock_state.state = {"history": []}
+
+        list_activities(mock_state, count=10)
+
+        output = capsys.readouterr().out
+        assert "Aucune activité" in output
+
+    def test_list_activities_default_count(self, mock_state, capsys):
+        """Test list_activities shows entries in reverse order."""
+        list_activities(mock_state, count=10)
+
+        output = capsys.readouterr().out
+        assert "i129000001" in output
+        assert "i129000002" in output
+        assert "i129000003" in output
+
+    def test_list_activities_limited_count(self, mock_state, capsys):
+        """Test list_activities respects count parameter."""
+        list_activities(mock_state, count=2)
+
+        output = capsys.readouterr().out
+        # Only last 2 entries (i129000002 and i129000003 are positions 2-3)
+        assert "i129000002" in output
+        assert "i129000003" in output
+
+    def test_list_activities_formats_datetime(self, mock_state, capsys):
+        """Test list_activities formats analyzed_at datetime."""
+        list_activities(mock_state, count=10)
+
+        output = capsys.readouterr().out
+        assert "2026-03-15 14:30:00" in output
+
+    def test_list_activities_handles_invalid_datetime(self, mock_state, capsys):
+        """Test list_activities handles invalid analyzed_at gracefully."""
+        mock_state.state["history"] = [
+            {
+                "activity_id": "i999999999",
+                "activity_date": "2026-01-01",
+                "analyzed_at": "not-a-date",
+            }
+        ]
+
+        list_activities(mock_state, count=10)
+
+        output = capsys.readouterr().out
+        assert "i999999999" in output
+        assert "not-a-date" in output  # Passed through as-is
+
+    def test_list_activities_handles_missing_fields(self, mock_state, capsys):
+        """Test list_activities handles entries with missing fields."""
+        mock_state.state["history"] = [
+            {"activity_id": "i111111111"}  # No activity_date, no analyzed_at
+        ]
+
+        list_activities(mock_state, count=10)
+
+        output = capsys.readouterr().out
+        assert "i111111111" in output
+        assert "N/A" in output
+
+
+class TestRemoveActivity:
+    """Test remove_activity() with confirm/cancel/not found."""
+
+    def test_remove_not_found(self, mock_state, capsys):
+        """Test remove_activity returns False when activity not found."""
+        result = remove_activity(mock_state, "i999999999")
+
+        assert result is False
+        output = capsys.readouterr().out
+        assert "non trouvée" in output
+
+    def test_remove_confirmed(self, mock_state, capsys):
+        """Test remove_activity deletes entry when confirmed."""
+        with patch("builtins.input", return_value="o"):
+            result = remove_activity(mock_state, "i129000002")
+
+        assert result is True
+        # Verify entry was removed from history
+        remaining_ids = [h["activity_id"] for h in mock_state.state["history"]]
+        assert "i129000002" not in remaining_ids
+        mock_state._save_state.assert_called_once()
+
+    def test_remove_cancelled(self, mock_state, capsys):
+        """Test remove_activity aborts when user declines."""
+        with patch("builtins.input", return_value="n"):
+            result = remove_activity(mock_state, "i129000002")
+
+        assert result is False
+        output = capsys.readouterr().out
+        assert "annulée" in output
+        mock_state._save_state.assert_not_called()
+
+    def test_remove_last_analyzed_updates_pointer(self, mock_state, capsys):
+        """Test removing last_analyzed activity updates the pointer."""
+        with patch("builtins.input", return_value="o"):
+            result = remove_activity(mock_state, "i129000001")
+
+        assert result is True
+        # last_analyzed should be updated to next-to-last
+        assert mock_state.state["last_analyzed_activity_id"] != "i129000001"
+
+    def test_remove_last_entry_clears_pointer(self, mock_state, capsys):
+        """Test removing the only entry clears last_analyzed."""
+        mock_state.state = {
+            "history": [
+                {
+                    "activity_id": "i129000001",
+                    "activity_date": "2026-03-15",
+                    "analyzed_at": "2026-03-15T14:30:00",
+                }
+            ],
+            "last_analyzed_activity_id": "i129000001",
+            "last_analyzed_date": "2026-03-15T14:30:00",
+        }
+
+        with patch("builtins.input", return_value="o"):
+            result = remove_activity(mock_state, "i129000001")
+
+        assert result is True
+        assert mock_state.state["last_analyzed_activity_id"] is None
+        assert mock_state.state["last_analyzed_date"] is None
+
+    def test_remove_shows_occurrence_count(self, mock_state, capsys):
+        """Test remove_activity shows how many occurrences found."""
+        # Add duplicate
+        mock_state.state["history"].append(
+            {
+                "activity_id": "i129000002",
+                "activity_date": "2026-03-14",
+                "analyzed_at": "2026-03-14T12:00:00",
+            }
+        )
+
+        with patch("builtins.input", return_value="o"):
+            remove_activity(mock_state, "i129000002")
+
+        output = capsys.readouterr().out
+        assert "2 occurrence(s)" in output
+
+
+class TestResetState:
+    """Test reset_state() with confirm/cancel."""
+
+    def test_reset_confirmed(self, mock_state, capsys):
+        """Test reset_state calls state.reset() when confirmed."""
+        with patch("builtins.input", return_value="o"):
+            result = reset_state(mock_state)
+
+        assert result is True
+        mock_state.reset.assert_called_once()
+        output = capsys.readouterr().out
+        assert "réinitialisé" in output
+
+    def test_reset_cancelled(self, mock_state, capsys):
+        """Test reset_state aborts when user declines."""
+        with patch("builtins.input", return_value="n"):
+            result = reset_state(mock_state)
+
+        assert result is False
+        mock_state.reset.assert_not_called()
+        output = capsys.readouterr().out
+        assert "annulé" in output
+
+
+class TestMain:
+    """Test main() CLI entry point."""
+
+    def test_no_action_exits_with_error(self):
+        """Test main exits with code 1 when no action specified."""
+        with (
+            patch("sys.argv", ["manage-state"]),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            main()
+
+    def test_show_action(self, mock_state):
+        """Test --show action calls show_state."""
+        with (
+            patch("sys.argv", ["manage-state", "--show"]),
+            patch(
+                "magma_cycling.manage_workflow_state.WorkflowState",
+                return_value=mock_state,
+            ),
+            pytest.raises(SystemExit, match="0"),
+        ):
+            main()
+
+        mock_state.get_stats.assert_called_once()
+
+    def test_list_action_default(self, mock_state):
+        """Test --list action with default count."""
+        with (
+            patch("sys.argv", ["manage-state", "--list"]),
+            patch(
+                "magma_cycling.manage_workflow_state.WorkflowState",
+                return_value=mock_state,
+            ),
+            pytest.raises(SystemExit, match="0"),
+        ):
+            main()
+
+    def test_list_action_custom_count(self, mock_state):
+        """Test --list N action with custom count."""
+        with (
+            patch("sys.argv", ["manage-state", "--list", "25"]),
+            patch(
+                "magma_cycling.manage_workflow_state.WorkflowState",
+                return_value=mock_state,
+            ),
+            pytest.raises(SystemExit, match="0"),
+        ):
+            main()
+
+    def test_remove_action(self, mock_state):
+        """Test --remove action calls remove_activity."""
+        with (
+            patch("sys.argv", ["manage-state", "--remove", "i129000001"]),
+            patch(
+                "magma_cycling.manage_workflow_state.WorkflowState",
+                return_value=mock_state,
+            ),
+            patch("builtins.input", return_value="o"),
+            pytest.raises(SystemExit, match="0"),
+        ):
+            main()
+
+        mock_state._save_state.assert_called_once()
+
+    def test_reset_action(self, mock_state):
+        """Test --reset action calls reset_state."""
+        with (
+            patch("sys.argv", ["manage-state", "--reset"]),
+            patch(
+                "magma_cycling.manage_workflow_state.WorkflowState",
+                return_value=mock_state,
+            ),
+            patch("builtins.input", return_value="o"),
+            pytest.raises(SystemExit, match="0"),
+        ):
+            main()
+
+        mock_state.reset.assert_called_once()
+
+    def test_workflow_state_load_error(self):
+        """Test main exits with 1 when WorkflowState fails to load."""
+        with (
+            patch("sys.argv", ["manage-state", "--show"]),
+            patch(
+                "magma_cycling.manage_workflow_state.WorkflowState",
+                side_effect=Exception("State file corrupt"),
+            ),
+            pytest.raises(SystemExit, match="1"),
+        ):
+            main()
+
+    def test_combined_actions(self, mock_state):
+        """Test --reset --show runs both actions in order."""
+        with (
+            patch("sys.argv", ["manage-state", "--reset", "--show"]),
+            patch(
+                "magma_cycling.manage_workflow_state.WorkflowState",
+                return_value=mock_state,
+            ),
+            patch("builtins.input", return_value="o"),
+            pytest.raises(SystemExit, match="0"),
+        ):
+            main()
+
+        mock_state.reset.assert_called_once()
+        mock_state.get_stats.assert_called_once()


### PR DESCRIPTION
## Summary
- **manage_workflow_state.py**: 25 tests covering `show_state()`, `list_activities()`, `remove_activity()`, `reset_state()`, `main()` CLI (0% → covered)
- **reports/generator.py**: 25 tests covering input validation, `_build_prompt` dispatch, `_save_report`, `_validate_report`, `_initialize_ai_analyzer`, `_collect_week_data`, full pipeline + error chains (0% → covered)

## Context
Phase 5 coverage push toward 75% — Lead assignment (2/4 modules)

## Test plan
- [x] 50/50 tests passing
- [x] Full suite: 2839 passed, 0 failures
- [x] Pre-commit hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)