### PR TITLE
feat(mcp): add extra_sleep_hours to pre-session-check

### DIFF
--- a/magma_cycling/_mcp/handlers/rest.py
+++ b/magma_cycling/_mcp/handlers/rest.py
@@ -65,10 +65,11 @@ async def handle_pre_session_check(args: dict) -> list[TextContent]:
         from magma_cycling.health import create_health_provider
         from magma_cycling.workflows.rest.veto_check import check_pre_session_veto
 
-        # 1. Parse date
+        # 1. Parse date + extra_sleep_hours
         date_str = args.get("date")
         target = date.fromisoformat(date_str) if date_str else date.today()
         date_str = target.isoformat()
+        extra_sleep_hours = float(args.get("extra_sleep_hours", 0.0))
 
         # 2. Withings sync (best-effort — fallback to cached data)
         wellness_source = "fresh"
@@ -118,6 +119,11 @@ async def handle_pre_session_check(args: dict) -> list[TextContent]:
         except Exception:
             pass
 
+        # 4b. Apply extra_sleep_hours override (couch sleep, nap, etc.)
+        if extra_sleep_hours > 0 and wellness.get("sleep_hours") is not None:
+            wellness["sleep_hours"] = round(wellness["sleep_hours"] + extra_sleep_hours, 2)
+            wellness["sleep_hours_source"] = "withings+manual_override"
+
         # 5. Planned session from planning
         week_id = args.get("week_id") or _find_week_id_for_date(target)
         session_info = None
@@ -161,6 +167,10 @@ async def handle_pre_session_check(args: dict) -> list[TextContent]:
             "recommendation": veto_result["recommendation"],
             "wellness": wellness,
             "wellness_source": wellness_source,
+            "override": {
+                "extra_sleep_hours": extra_sleep_hours,
+                "applied": extra_sleep_hours > 0,
+            },
         }
 
         if session_info:

--- a/magma_cycling/_mcp/schemas/rest.py
+++ b/magma_cycling/_mcp/schemas/rest.py
@@ -26,6 +26,16 @@ def get_tools() -> list[Tool]:
                         "description": "Week ID (default: auto-detect from date)",
                         "pattern": "^S\\d{3}$",
                     },
+                    "extra_sleep_hours": {
+                        "type": "number",
+                        "description": (
+                            "Additional sleep hours not detected by Sleep Analyser "
+                            "(e.g. nap or couch sleep). "
+                            "Added to wellness sleep_hours before veto evaluation."
+                        ),
+                        "minimum": 0,
+                        "maximum": 6,
+                    },
                 },
             },
         ),


### PR DESCRIPTION
## Summary
- Sleep Analyser misses couch/nap sleep — biases veto verdicts
- New optional `extra_sleep_hours` param (0-6) injected before veto check
- Traceability via `override` block in response + `sleep_hours_source` tag

## Changes
- `_mcp/schemas/rest.py`: added `extra_sleep_hours` property
- `_mcp/handlers/rest.py`: parse param, apply to wellness, expose in result

## Test plan
- [x] `poetry run pytest tests/ -x` → 2997 passed, 0 failures
- [x] `poetry run pre-commit run --all-files` → all passed
- [ ] Junior's 7 TDD tests ready to land on top (5 pass already, 2 will pass with this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)