### PR TITLE
fix(mcp): persist extra_sleep_hours correction to Intervals.icu

### DIFF
--- a/magma_cycling/_mcp/handlers/rest.py
+++ b/magma_cycling/_mcp/handlers/rest.py
@@ -124,6 +124,18 @@ async def handle_pre_session_check(args: dict) -> list[TextContent]:
             wellness["sleep_hours"] = round(wellness["sleep_hours"] + extra_sleep_hours, 2)
             wellness["sleep_hours_source"] = "withings+manual_override"
 
+            # Persist corrected sleep to Intervals.icu so daily reports use it
+            try:
+                corrected_secs = int(wellness["sleep_hours"] * 3600)
+                client.update_wellness(date_str, {"sleepSecs": corrected_secs})
+                logger.info(
+                    "Persisted corrected sleepSecs=%d to Intervals.icu for %s",
+                    corrected_secs,
+                    date_str,
+                )
+            except Exception as exc:
+                logger.warning("Failed to persist sleep override: %s", exc)
+
         # 5. Planned session from planning
         week_id = args.get("week_id") or _find_week_id_for_date(target)
         session_info = None


### PR DESCRIPTION
## Summary
- `extra_sleep_hours` override in `pre-session-check` was only applied in memory for the veto check
- Daily reports pulled uncorrected sleep from Intervals.icu, ignoring the manual compensation
- Now persists corrected `sleepSecs` via `update_wellness()` so downstream consumers see the accurate total

## Test plan
- [x] Full test suite: 3066 passed, 0 failures
- [x] Pre-commit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)