### PR TITLE
feat(mcp): add patch-coach-analysis tool (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Cyclisme Training Logs
+# Magma Cycling
 
 [![CI](https://github.com/stephanejouve/magma-cycling/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/stephanejouve/magma-cycling/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/stephanejouve/magma-cycling/branch/main/graph/badge.svg?token=K39R7YEOPN)](https://codecov.io/gh/stephanejouve/magma-cycling)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Poetry](https://img.shields.io/badge/poetry-managed-blue)](https://python-poetry.org/)
 [![Quality](https://img.shields.io/badge/Quality-Production%20Ready-brightgreen)](CODING_STANDARDS.md)
-[![MCP Tools](https://img.shields.io/badge/MCP_tools-48-8A2BE2)](magma_cycling/_mcp/)
+[![MCP Tools](https://img.shields.io/badge/MCP_tools-50-8A2BE2)](magma_cycling/_mcp/)
 
 A personal cycling training log system integrating Intervals.icu, AI coaching, and structured workout management.
 

--- a/magma_cycling/_mcp/handlers/rest.py
+++ b/magma_cycling/_mcp/handlers/rest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date
 from typing import TYPE_CHECKING
 
@@ -11,7 +12,7 @@ from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
 if TYPE_CHECKING:
     from mcp.types import TextContent
 
-__all__ = ["handle_pre_session_check"]
+__all__ = ["handle_pre_session_check", "handle_patch_coach_analysis"]
 
 logger = logging.getLogger(__name__)
 
@@ -199,3 +200,157 @@ async def handle_pre_session_check(args: dict) -> list[TextContent]:
             result["readiness"] = readiness_data
 
     return mcp_response(result)
+
+
+def _locate_entry(
+    content: str, activity_id: str | None, session_id: str | None
+) -> tuple[int, int] | None:
+    """Locate a coach analysis entry in workouts-history.md.
+
+    Returns (start, end) character offsets or None if not found.
+    """
+    anchor_pos = None
+
+    # Priority: activity_id
+    if activity_id:
+        m = re.search(rf"^ID\s*:\s*{re.escape(activity_id)}\s*$", content, re.MULTILINE)
+        if m:
+            anchor_pos = m.start()
+
+    # Fallback: session_id
+    if anchor_pos is None and session_id:
+        m = re.search(rf"^### {re.escape(session_id)}-", content, re.MULTILINE)
+        if m:
+            anchor_pos = m.start()
+
+    if anchor_pos is None:
+        return None
+
+    # Walk back to the ### header containing this anchor
+    header_start = content.rfind("\n### ", 0, anchor_pos)
+    if header_start == -1:
+        # Entry is at the very start of the file
+        header_start = 0
+    else:
+        header_start += 1  # skip the leading newline
+
+    # Find the next ### header (end of this entry)
+    next_header = content.find("\n### ", anchor_pos)
+    if next_header == -1:
+        entry_end = len(content)
+    else:
+        entry_end = next_header
+
+    return header_start, entry_end
+
+
+async def handle_patch_coach_analysis(args: dict) -> list[TextContent]:
+    """Patch a coach analysis entry in workouts-history.md."""
+    with suppress_stdout_stderr():
+        from magma_cycling.config import get_data_config
+
+        activity_id = args.get("activity_id")
+        session_id = args.get("session_id")
+        sleep_hours = args.get("sleep_hours")
+        note = args.get("note")
+
+        if not activity_id and not session_id:
+            raise ValueError("activity_id or session_id is required")
+
+        if sleep_hours is None and not note:
+            raise ValueError("At least one patch field (sleep_hours or note) is required")
+
+        # Load file
+        config = get_data_config()
+        history_path = config.workouts_history_path
+        content = history_path.read_text(encoding="utf-8")
+
+        # Locate entry
+        bounds = _locate_entry(content, activity_id, session_id)
+        if bounds is None:
+            lookup = activity_id or session_id
+            return mcp_response(
+                {
+                    "status": "error",
+                    "message": f"Entry not found for {lookup} in workouts-history.md",
+                }
+            )
+
+        start, end = bounds
+        block = content[start:end]
+        patches_applied = []
+
+        # Extract identifiers from the entry
+        found_activity_id = activity_id
+        found_session_id = session_id
+        id_match = re.search(r"^ID\s*:\s*(\S+)", block, re.MULTILINE)
+        if id_match:
+            found_activity_id = id_match.group(1)
+        header_match = re.match(r"^### (\S+)", block)
+        if header_match:
+            found_session_id = header_match.group(1)
+
+        # Patch sleep_hours
+        if sleep_hours is not None:
+            sleep_re = re.compile(r"^(- Sommeil\s*:\s*)([\d.]+)(h.*)$", re.MULTILINE)
+            m = sleep_re.search(block)
+            if m:
+                old_value = m.group(2)
+                new_value = str(sleep_hours)
+                marker = " [CORRIGÉ : sommeil canapé non détecté par Sleep Analyser]"
+
+                # Replace in Métriques Pré-séance line
+                block = sleep_re.sub(
+                    rf"\g<1>{new_value}h{marker}",
+                    block,
+                    count=1,
+                )
+
+                # Replace old_value occurrences in Points d'Attention section
+                attention_re = re.compile(
+                    r"(#### Points d'Attention.*?)(?=####|\Z)",
+                    re.DOTALL,
+                )
+                att_match = attention_re.search(block)
+                if att_match:
+                    att_section = att_match.group(0)
+                    patched_att = att_section.replace(f"{old_value}h", f"{new_value}h")
+                    block = block[: att_match.start()] + patched_att + block[att_match.end() :]
+
+                patches_applied.append(
+                    {
+                        "field": "sleep_hours",
+                        "old_value": float(old_value),
+                        "new_value": sleep_hours,
+                    }
+                )
+            else:
+                patches_applied.append(
+                    {
+                        "field": "sleep_hours",
+                        "warning": "Ligne 'Sommeil' non trouvée dans l'entrée",
+                    }
+                )
+
+        # Patch note
+        if note:
+            correction_section = (
+                f"\n#### Note de correction\n"
+                f"{note}\n"
+                f"*Patch appliqué le {date.today().isoformat()}*\n"
+            )
+            block = block.rstrip("\n") + "\n" + correction_section
+            patches_applied.append({"field": "note", "added": True})
+
+        # Rewrite file
+        new_content = content[:start] + block + content[end:]
+        history_path.write_text(new_content, encoding="utf-8")
+
+    return mcp_response(
+        {
+            "status": "success",
+            "activity_id": found_activity_id,
+            "session_id": found_session_id,
+            "patches_applied": patches_applied,
+        }
+    )

--- a/magma_cycling/_mcp/schemas/rest.py
+++ b/magma_cycling/_mcp/schemas/rest.py
@@ -39,4 +39,47 @@ def get_tools() -> list[Tool]:
                 },
             },
         ),
+        Tool(
+            name="patch-coach-analysis",
+            description=(
+                "Patch a coach analysis entry in workouts-history.md without "
+                "re-running the AI prompt. Useful for correcting metrics "
+                "(e.g. sleep hours) that were wrong at generation time."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "activity_id": {
+                        "type": "string",
+                        "description": (
+                            "Intervals.icu activity ID (e.g. i133337326). "
+                            "Takes priority over session_id if both provided."
+                        ),
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": (
+                            "Session ID prefix (e.g. S085-04). "
+                            "Used to locate the entry by ### header."
+                        ),
+                    },
+                    "sleep_hours": {
+                        "type": "number",
+                        "description": (
+                            "Corrected sleep hours value. Replaces the existing "
+                            "value in 'Métriques Pré-séance' and 'Points d'Attention'."
+                        ),
+                        "minimum": 0,
+                        "maximum": 24,
+                    },
+                    "note": {
+                        "type": "string",
+                        "description": (
+                            "Free-text correction note appended as "
+                            "'#### Note de correction' section."
+                        ),
+                    },
+                },
+            },
+        ),
     ]

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -82,6 +82,7 @@ from magma_cycling._mcp.handlers.planning import (  # noqa: F401
 # Re-exports — backward compat: all 43 handlers importable from mcp_server
 # ---------------------------------------------------------------------------
 from magma_cycling._mcp.handlers.rest import (  # noqa: F401
+    handle_patch_coach_analysis,
     handle_pre_session_check,
 )
 from magma_cycling._mcp.handlers.sessions import (  # noqa: F401
@@ -208,8 +209,9 @@ TOOL_HANDLERS = {
     "withings-sync-to-intervals": handle_withings_sync_to_intervals,
     "withings-analyze-trends": handle_withings_analyze_trends,
     "withings-enrich-session": handle_withings_enrich_session,
-    # Rest / Recovery (1)
+    # Rest / Recovery (2)
     "pre-session-check": handle_pre_session_check,
+    "patch-coach-analysis": handle_patch_coach_analysis,
 }
 
 


### PR DESCRIPTION
## Summary

- Add `patch-coach-analysis` MCP tool for surgical correction of coach analysis entries in `workouts-history.md` without re-running AI prompts
- Patches `sleep_hours` (with `[CORRIGÉ]` marker) and adds `#### Note de correction` sections
- Fix README title: `Cyclisme Training Logs` → `Magma Cycling`
- Update MCP tools badge: 48 → 50

## Files changed

- `magma_cycling/_mcp/schemas/rest.py` — tool schema
- `magma_cycling/_mcp/handlers/rest.py` — `handle_patch_coach_analysis` + `_locate_entry` helper
- `magma_cycling/mcp_server.py` — import + dispatch wiring
- `README.md` — title + badge fix

## Test plan

- [x] `poetry run pytest tests/ -x` — 3066 passed, 0 failed
- [x] `poetry run pre-commit run --all-files` — all green
- [x] `poetry run check-tools-docs` — all production tools documented
- [ ] Junior's 7 TDD tests (PR #157) validate handler behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)