### PR TITLE
feat(mcp): expose active provider in MCP responses + system-info

### DIFF
--- a/magma_cycling/_mcp/_utils.py
+++ b/magma_cycling/_mcp/_utils.py
@@ -40,12 +40,17 @@ def load_workout_descriptions(week_id: str) -> dict[str, str]:
     return _load(week_id)
 
 
-def mcp_response(result: dict, **json_kwargs) -> list[TextContent]:
+def mcp_response(
+    result: dict, *, provider_info: dict | None = None, **json_kwargs
+) -> list[TextContent]:
     """Wrap a result dict with _metadata and return as MCP TextContent."""
     now = datetime.now()
-    result["_metadata"] = {
+    metadata: dict = {
         "response_date": date.today().isoformat(),
         "response_timestamp": now.isoformat(),
     }
+    if provider_info:
+        metadata["provider"] = provider_info
+    result["_metadata"] = metadata
     json_kwargs.setdefault("indent", 2)
     return [TextContent(type="text", text=json.dumps(result, **json_kwargs))]

--- a/magma_cycling/_mcp/handlers/admin.py
+++ b/magma_cycling/_mcp/handlers/admin.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from magma_cycling._mcp._utils import mcp_response
+from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
 
 __all__ = [
     "handle_reload_server",
+    "handle_system_info",
 ]
 
 
@@ -63,3 +64,80 @@ async def handle_reload_server(args: dict) -> list[TextContent]:
                 "message": "⚠️ Module reload error - may need full restart",
             }
         )
+
+
+async def handle_system_info(args: dict) -> list[TextContent]:
+    """Return active providers and system metadata."""
+    with suppress_stdout_stderr():
+        from magma_cycling.health import create_health_provider
+
+        # Health provider
+        try:
+            health_provider = create_health_provider()
+            health_info = health_provider.get_provider_info()
+        except Exception as e:
+            health_info = {"provider": "unavailable", "status": "error", "error": str(e)}
+
+        # Calendar provider
+        try:
+            from magma_cycling.config import create_intervals_client
+
+            calendar_client = create_intervals_client()
+            calendar_info = calendar_client.get_provider_info()
+        except Exception as e:
+            calendar_info = {"provider": "unavailable", "status": "error", "error": str(e)}
+
+        # AI providers (list configured ones)
+        ai_info: list[str] = []
+        try:
+            from magma_cycling.ai_providers.factory import AIProviderFactory
+
+            for provider_name in ("claude_api", "mistral_api", "ollama"):
+                try:
+                    analyzer = AIProviderFactory.create(provider_name)
+                    if analyzer.validate_config():
+                        ai_info.append(provider_name)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+        # Tool count
+        try:
+            from magma_cycling._mcp.schemas import admin as _s_admin
+            from magma_cycling._mcp.schemas import analysis as _s_analysis
+            from magma_cycling._mcp.schemas import athlete as _s_athlete
+            from magma_cycling._mcp.schemas import catalog as _s_catalog
+            from magma_cycling._mcp.schemas import health as _s_health
+            from magma_cycling._mcp.schemas import planning as _s_planning
+            from magma_cycling._mcp.schemas import remote as _s_remote
+            from magma_cycling._mcp.schemas import rest as _s_rest
+            from magma_cycling._mcp.schemas import sessions as _s_sessions
+            from magma_cycling._mcp.schemas import workouts as _s_workouts
+
+            tool_count = sum(
+                len(mod.get_tools())
+                for mod in (
+                    _s_planning,
+                    _s_sessions,
+                    _s_workouts,
+                    _s_remote,
+                    _s_athlete,
+                    _s_analysis,
+                    _s_admin,
+                    _s_catalog,
+                    _s_health,
+                    _s_rest,
+                )
+            )
+        except Exception:
+            tool_count = -1
+
+        result = {
+            "health": health_info,
+            "calendar": calendar_info,
+            "ai_providers": ai_info,
+            "tool_count": tool_count,
+        }
+
+    return mcp_response(result)

--- a/magma_cycling/_mcp/handlers/health.py
+++ b/magma_cycling/_mcp/handlers/health.py
@@ -32,12 +32,17 @@ async def handle_health_auth_status(args: dict) -> list[TextContent]:
     """Check health provider OAuth authentication status."""
     with suppress_stdout_stderr():
         from magma_cycling.config import get_withings_config
+        from magma_cycling.health import create_health_provider
 
         config = get_withings_config()
+        provider = create_health_provider()
+        provider_info = provider.get_provider_info()
 
         status = {
             "configured": config.is_configured(),
             "has_credentials": config.has_valid_credentials(),
+            "provider_name": provider_info["provider"],
+            "provider_class": type(provider).__name__,
         }
 
         if not config.is_configured():
@@ -68,15 +73,18 @@ async def handle_health_auth_status(args: dict) -> list[TextContent]:
             except Exception:
                 pass
 
-    return mcp_response(status)
+    return mcp_response(status, provider_info=provider_info)
 
 
 async def handle_health_authorize(args: dict) -> list[TextContent]:
     """Handle health provider OAuth authorization flow."""
     with suppress_stdout_stderr():
         from magma_cycling.config import create_withings_client
+        from magma_cycling.health import create_health_provider
 
         client = create_withings_client()
+        provider = create_health_provider()
+        provider_info = provider.get_provider_info()
         authorization_code = args.get("authorization_code")
 
         if not authorization_code:
@@ -112,7 +120,7 @@ async def handle_health_authorize(args: dict) -> list[TextContent]:
             except Exception as e:
                 result = {"step": "authorization_failed", "status": "error", "error": str(e)}
 
-    return mcp_response(result)
+    return mcp_response(result, provider_info=provider_info)
 
 
 async def handle_get_sleep(args: dict) -> list[TextContent]:
@@ -121,6 +129,7 @@ async def handle_get_sleep(args: dict) -> list[TextContent]:
         from magma_cycling.health import create_health_provider
 
         provider = create_health_provider()
+        provider_info = provider.get_provider_info()
 
         last_night_only = args.get("last_night_only", False)
 
@@ -150,7 +159,7 @@ async def handle_get_sleep(args: dict) -> list[TextContent]:
                 "count": len(sessions),
             }
 
-    return mcp_response(result, default=str)
+    return mcp_response(result, provider_info=provider_info, default=str)
 
 
 async def handle_get_body_composition(args: dict) -> list[TextContent]:
@@ -159,6 +168,7 @@ async def handle_get_body_composition(args: dict) -> list[TextContent]:
         from magma_cycling.health import create_health_provider
 
         provider = create_health_provider()
+        provider_info = provider.get_provider_info()
 
         latest_only = args.get("latest_only", False)
 
@@ -188,7 +198,7 @@ async def handle_get_body_composition(args: dict) -> list[TextContent]:
                 "count": len(measurements),
             }
 
-    return mcp_response(result, default=str)
+    return mcp_response(result, provider_info=provider_info, default=str)
 
 
 async def handle_get_readiness(args: dict) -> list[TextContent]:
@@ -197,6 +207,7 @@ async def handle_get_readiness(args: dict) -> list[TextContent]:
         from magma_cycling.health import create_health_provider
 
         provider = create_health_provider()
+        provider_info = provider.get_provider_info()
 
         eval_date_str = args.get("date")
         eval_date = date.fromisoformat(eval_date_str) if eval_date_str else date.today()
@@ -232,7 +243,7 @@ async def handle_get_readiness(args: dict) -> list[TextContent]:
                     f"\u2014 les donn\u00e9es Magma sont correctes ({detail})."
                 )
 
-    return mcp_response(result, default=str)
+    return mcp_response(result, provider_info=provider_info, default=str)
 
 
 def _extract_422_detail(http_err: requests.exceptions.HTTPError) -> str:
@@ -417,14 +428,24 @@ def sync_health_to_calendar(
 async def handle_sync_health_to_calendar(args: dict) -> list[TextContent]:
     """Synchronize health data to training calendar wellness via HealthProvider."""
     with suppress_stdout_stderr():
+        from magma_cycling.config import create_intervals_client
+        from magma_cycling.health import create_health_provider
+
         start_date_val = date.fromisoformat(args["start_date"])
         end_date_str = args.get("end_date")
         end_date_val = date.fromisoformat(end_date_str) if end_date_str else None
         data_types = args.get("data_types", ["all"])
 
-        result = sync_health_to_calendar(start_date_val, end_date_val, data_types)
+        provider = create_health_provider()
+        client = create_intervals_client()
 
-    return mcp_response(result)
+        result = sync_health_to_calendar(start_date_val, end_date_val, data_types)
+        result["providers"] = {
+            "health": provider.get_provider_info(),
+            "calendar": client.get_provider_info(),
+        }
+
+    return mcp_response(result, provider_info=provider.get_provider_info())
 
 
 async def handle_analyze_health_trends(args: dict) -> list[TextContent]:
@@ -433,6 +454,7 @@ async def handle_analyze_health_trends(args: dict) -> list[TextContent]:
         from magma_cycling.health import create_health_provider
 
         provider = create_health_provider()
+        provider_info = provider.get_provider_info()
 
         period = args.get("period", "week")
 
@@ -451,7 +473,7 @@ async def handle_analyze_health_trends(args: dict) -> list[TextContent]:
                     "error": "start_date and end_date required for custom period",
                     "status": "error",
                 }
-                return mcp_response(result)
+                return mcp_response(result, provider_info=provider_info)
 
             start_date_val = date.fromisoformat(start_date_str)
             end_date_val = date.fromisoformat(end_date_str)
@@ -534,7 +556,7 @@ async def handle_analyze_health_trends(args: dict) -> list[TextContent]:
             "alerts": alerts,
         }
 
-    return mcp_response(result)
+    return mcp_response(result, provider_info=provider_info)
 
 
 async def handle_enrich_session_health(args: dict) -> list[TextContent]:
@@ -548,6 +570,7 @@ async def handle_enrich_session_health(args: dict) -> list[TextContent]:
         auto_readiness_check = args.get("auto_readiness_check", True)
 
         provider = create_health_provider()
+        provider_info = provider.get_provider_info()
 
         # Load session
         with planning_tower.modify_week(
@@ -565,7 +588,7 @@ async def handle_enrich_session_health(args: dict) -> list[TextContent]:
                     "error": f"Session {session_id} not found in week {week_id}",
                     "status": "error",
                 }
-                return mcp_response(result)
+                return mcp_response(result, provider_info=provider_info)
 
             # Get session date
             session_date = session.session_date
@@ -609,4 +632,4 @@ async def handle_enrich_session_health(args: dict) -> list[TextContent]:
                 "status": "success",
             }
 
-    return mcp_response(result)
+    return mcp_response(result, provider_info=provider_info)

--- a/magma_cycling/_mcp/handlers/remote_activities.py
+++ b/magma_cycling/_mcp/handlers/remote_activities.py
@@ -26,6 +26,7 @@ async def handle_get_activity_details(args: dict) -> list[TextContent]:
     try:
         with suppress_stdout_stderr():
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
             activity = client.get_activity(activity_id)
 
             average_watts = activity.get("average_watts")
@@ -160,7 +161,7 @@ async def handle_get_activity_details(args: dict) -> list[TextContent]:
                     {"type": s["type"], "data_points": len(s["data"])} for s in streams
                 ]
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except Exception as e:
         error = {
@@ -179,6 +180,7 @@ async def handle_get_activity_intervals(args: dict) -> list[TextContent]:
     try:
         with suppress_stdout_stderr():
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
             raw_intervals = client.get_activity_intervals(activity_id)
 
         keep_fields = {
@@ -222,7 +224,7 @@ async def handle_get_activity_intervals(args: dict) -> list[TextContent]:
             "intervals": intervals,
         }
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except Exception as e:
         error = {
@@ -244,6 +246,7 @@ async def handle_get_activity_streams(args: dict) -> list[TextContent]:
     try:
         with suppress_stdout_stderr():
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
             streams = client.get_activity_streams(activity_id)
 
         if not streams:
@@ -308,7 +311,7 @@ async def handle_get_activity_streams(args: dict) -> list[TextContent]:
         if missing_types:
             result["missing_types"] = missing_types
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except Exception as e:
         error = {

--- a/magma_cycling/_mcp/handlers/remote_analysis.py
+++ b/magma_cycling/_mcp/handlers/remote_analysis.py
@@ -69,6 +69,7 @@ async def handle_compare_activity_intervals(args: dict) -> list[TextContent]:
     try:
         with suppress_stdout_stderr():
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
 
         if activity_ids:
             mode = "explicit"
@@ -220,7 +221,7 @@ async def handle_compare_activity_intervals(args: dict) -> list[TextContent]:
             "comparison": comparison,
         }
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except Exception as e:
         error = {"error": f"Failed to compare intervals: {str(e)}"}
@@ -246,6 +247,7 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
     try:
         with suppress_stdout_stderr():
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
 
         if manual_intervals is not None:
             if dry_run:
@@ -257,7 +259,7 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
                     "intervals": manual_intervals,
                     "message": "Preview only. Set dry_run=false to apply.",
                 }
-                return mcp_response(preview)
+                return mcp_response(preview, provider_info=_provider_info)
             with suppress_stdout_stderr():
                 result = client.put_activity_intervals(activity_id, manual_intervals)
             applied = {
@@ -267,7 +269,7 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
                 "applied": True,
                 "result": result,
             }
-            return mcp_response(applied)
+            return mcp_response(applied, provider_info=_provider_info)
 
         session_id = args.get("session_id")
         if not session_id:
@@ -280,7 +282,7 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
                     "error": f"Cannot extract session_id from activity name: '{activity_name}'",
                     "hint": "Provide session_id parameter explicitly (e.g. S082-02)",
                 }
-                return mcp_response(error)
+                return mcp_response(error, provider_info=_provider_info)
             session_id = m.group()
 
         week_id = session_id.split("-")[0]
@@ -297,14 +299,14 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
                 "error": f"No workout found for session {session_id} in {week_id}_workouts.txt",
                 "available_workouts": list(descriptions.keys()),
             }
-            return mcp_response(error)
+            return mcp_response(error, provider_info=_provider_info)
 
         blocks = parse_workout_text(workout_text)
         if not blocks:
             error = {
                 "error": f"Workout {session_id} is a rest day (no blocks to apply)",
             }
-            return mcp_response(error)
+            return mcp_response(error, provider_info=_provider_info)
 
         with suppress_stdout_stderr():
             streams = client.get_activity_streams(activity_id)
@@ -313,7 +315,7 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
             error = {
                 "error": f"No stream data found for activity {activity_id}",
             }
-            return mcp_response(error)
+            return mcp_response(error, provider_info=_provider_info)
         total_points = len(streams[0]["data"])
 
         computed = compute_intervals(blocks, total_points)
@@ -349,13 +351,13 @@ async def handle_apply_workout_intervals(args: dict) -> list[TextContent]:
 
         if dry_run:
             summary["message"] = "Preview only. Set dry_run=false to apply."
-            return mcp_response(summary)
+            return mcp_response(summary, provider_info=_provider_info)
 
         with suppress_stdout_stderr():
             result = client.put_activity_intervals(activity_id, interval_dicts)
         summary["applied"] = True
         summary["result"] = result
-        return mcp_response(summary)
+        return mcp_response(summary, provider_info=_provider_info)
 
     except Exception as e:
         error = {

--- a/magma_cycling/_mcp/handlers/remote_events.py
+++ b/magma_cycling/_mcp/handlers/remote_events.py
@@ -67,6 +67,7 @@ async def handle_delete_remote_event(args: dict) -> list[TextContent]:
                         break
 
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
             success = client.delete_event(event_id)
 
             if not success:
@@ -121,7 +122,7 @@ async def handle_delete_remote_event(args: dict) -> list[TextContent]:
                 "local_planning_update": local_update_status,
             }
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except Exception as e:
         error = {
@@ -142,6 +143,7 @@ async def handle_list_remote_events(args: dict) -> list[TextContent]:
     try:
         with suppress_stdout_stderr():
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
             events = client.get_events(oldest=start_date_str, newest=end_date_str)
 
             if category_filter:
@@ -169,7 +171,7 @@ async def handle_list_remote_events(args: dict) -> list[TextContent]:
             if category_filter:
                 result["filtered_by"] = category_filter
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except Exception as e:
         error = {
@@ -220,6 +222,7 @@ async def handle_update_remote_event(args: dict) -> list[TextContent]:
                         continue
 
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
             updated_event = client.update_event(event_id, updates)
 
             if updated_event:
@@ -271,7 +274,7 @@ async def handle_update_remote_event(args: dict) -> list[TextContent]:
                     "message": f"❌ Failed to update event {event_id}",
                 }
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except Exception as e:
         error = {"error": f"Update error: {str(e)}", "event_id": event_id}
@@ -303,6 +306,7 @@ async def handle_create_remote_note(args: dict) -> list[TextContent]:
     try:
         with suppress_stdout_stderr():
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
 
             event_data = {
                 "category": "NOTE",
@@ -373,7 +377,7 @@ async def handle_create_remote_note(args: dict) -> list[TextContent]:
                     "message": "❌ Failed to create NOTE - no ID returned from Intervals.icu",
                 }
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except Exception as e:
         error = {

--- a/magma_cycling/_mcp/handlers/remote_sync.py
+++ b/magma_cycling/_mcp/handlers/remote_sync.py
@@ -37,6 +37,7 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
         with suppress_stdout_stderr():
             plan = planning_tower.read_week(week_id)
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
 
             start_date = str(plan.start_date)
             end_date = str(plan.end_date)
@@ -252,7 +253,7 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
             "message": f"Sync {'preview' if dry_run else 'completed'} for {week_id}",
         }
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)
 
     except FileNotFoundError:
         error = {"error": f"Planning file not found for week {week_id}"}
@@ -273,6 +274,7 @@ async def handle_sync_remote_to_local(args: dict) -> list[TextContent]:
             strategy = args.get("strategy", "merge")
 
             client = create_intervals_client()
+            _provider_info = client.get_provider_info()
 
             stats = planning_tower.sync_from_remote(
                 week_id=week_id,
@@ -313,7 +315,7 @@ async def handle_sync_remote_to_local(args: dict) -> list[TextContent]:
 
             result["changes"] = changes
 
-            return mcp_response(result)
+            return mcp_response(result, provider_info=_provider_info)
     except Exception as e:
         error = {
             "error": str(e),
@@ -353,6 +355,7 @@ async def handle_backfill_activities(args: dict) -> list[TextContent]:
             date_source = f"{start_date_val} to {end_date_val}"
 
         client = create_intervals_client()
+        _provider_info = client.get_provider_info()
         activities = client.get_activities(oldest=start_date_val, newest=end_date_val)
 
         if not activities:
@@ -362,7 +365,7 @@ async def handle_backfill_activities(args: dict) -> list[TextContent]:
                 "end_date": str(end_date_val),
                 "activities_count": 0,
             }
-            return mcp_response(info)
+            return mcp_response(info, provider_info=_provider_info)
 
         data_config = get_data_config()
         tracking_file = data_config.data_repo_path / ".backfill_tracking.json"
@@ -473,4 +476,4 @@ async def handle_backfill_activities(args: dict) -> list[TextContent]:
                     }
                 )
 
-        return mcp_response(result)
+        return mcp_response(result, provider_info=_provider_info)

--- a/magma_cycling/_mcp/schemas/admin.py
+++ b/magma_cycling/_mcp/schemas/admin.py
@@ -11,4 +11,9 @@ def get_tools() -> list[Tool]:
             description="[DEV] Reload MCP server modules to pick up code changes without restarting Claude Desktop",
             inputSchema={"type": "object", "properties": {}},
         ),
+        Tool(
+            name="system-info",
+            description="Return active providers and system metadata (health, calendar, AI). Use at conversation start to discover the runtime configuration.",
+            inputSchema={"type": "object", "properties": {}},
+        ),
     ]

--- a/magma_cycling/api/intervals_client.py
+++ b/magma_cycling/api/intervals_client.py
@@ -522,6 +522,14 @@ class IntervalsClient:
             logger.error(f"Error updating event {event_id}: {e}")
             return None
 
+    def get_provider_info(self) -> dict[str, str]:
+        """Return provider metadata for MCP response enrichment."""
+        return {
+            "provider": "intervals_icu",
+            "athlete_id": self.athlete_id,
+            "status": "ready",
+        }
+
     def create_activity_note(self, activity_id: str, note: str) -> bool:
         """Post a note to an activity on Intervals.icu.
 

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -32,6 +32,7 @@ from mcp_http_transport import MCPTransportManager
 
 from magma_cycling._mcp.handlers.admin import (  # noqa: F401
     handle_reload_server,
+    handle_system_info,
 )
 from magma_cycling._mcp.handlers.analysis import (  # noqa: F401
     handle_analyze_session_adherence,
@@ -196,8 +197,9 @@ TOOL_HANDLERS = {
     "restore-week-from-backup": handle_restore_week_from_backup,
     "analyze-training-patterns": handle_analyze_training_patterns,
     "get-coach-analysis": handle_get_coach_analysis,
-    # Admin (1)
+    # Admin (2)
     "reload-server": handle_reload_server,
+    "system-info": handle_system_info,
     # Catalog (1)
     "list-workout-catalog": handle_list_workout_catalog,
     # Health (8)

--- a/tests/_mcp/handlers/test_remote_events.py
+++ b/tests/_mcp/handlers/test_remote_events.py
@@ -17,6 +17,9 @@ from magma_cycling._mcp.handlers.remote_events import (
 # ---------------------------------------------------------------------------
 
 
+MOCK_PROVIDER_INFO = {"provider": "intervals_icu", "athlete_id": "iXXXXXX", "status": "ready"}
+
+
 @pytest.fixture
 def mock_client():
     """Mock IntervalsClient returned by create_intervals_client."""
@@ -25,6 +28,7 @@ def mock_client():
     client.get_events.return_value = []
     client.update_event.return_value = {"id": 42, "name": "updated"}
     client.create_event.return_value = {"id": 99}
+    client.get_provider_info.return_value = MOCK_PROVIDER_INFO
     return client
 
 
@@ -152,7 +156,9 @@ class TestHandleDeleteRemoteEvent:
     @patch("magma_cycling.config.create_intervals_client")
     async def test_blocks_delete_of_completed_session(self, mock_factory, patch_tower):
         """Cannot delete a completed session (protection)."""
-        mock_factory.return_value = MagicMock()
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        mock_factory.return_value = client
 
         result = await handle_delete_remote_event({"event_id": 55, "confirm": True})
 
@@ -187,6 +193,7 @@ class TestHandleListRemoteEvents:
     async def test_list_events_with_results(self, mock_factory):
         """Returns formatted events."""
         client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
         client.get_events.return_value = [
             {
                 "id": 1,
@@ -211,6 +218,7 @@ class TestHandleListRemoteEvents:
     async def test_list_events_with_category_filter(self, mock_factory):
         """Filters events by category."""
         client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
         client.get_events.return_value = [
             {"id": 1, "category": "WORKOUT", "name": "W1"},
             {"id": 2, "category": "NOTE", "name": "N1"},
@@ -250,6 +258,7 @@ class TestHandleUpdateRemoteEvent:
     async def test_update_success_no_local_match(self, mock_factory):
         """Updates event on API when no local planning match."""
         client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
         client.update_event.return_value = {"id": 42, "name": "Updated"}
         mock_factory.return_value = client
 
@@ -269,6 +278,7 @@ class TestHandleUpdateRemoteEvent:
     async def test_update_failure(self, mock_factory):
         """Returns error when API update fails."""
         client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
         client.update_event.return_value = None
         mock_factory.return_value = client
 
@@ -284,7 +294,9 @@ class TestHandleUpdateRemoteEvent:
     @patch("magma_cycling.config.create_intervals_client")
     async def test_blocks_update_of_completed_session(self, mock_factory, patch_tower):
         """Cannot update a completed session."""
-        mock_factory.return_value = MagicMock()
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        mock_factory.return_value = client
 
         result = await handle_update_remote_event({"event_id": 55, "updates": {"name": "X"}})
         data = json.loads(result[0].text)
@@ -336,6 +348,7 @@ class TestHandleCreateRemoteNote:
     async def test_create_note_api_failure(self, mock_factory):
         """Returns error when API create fails."""
         client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
         client.create_event.return_value = {}  # no 'id' key
         mock_factory.return_value = client
 
@@ -358,6 +371,7 @@ class TestHandleCreateRemoteNote:
     async def test_create_note_with_local_planning_update(self, mock_factory, patch_tower):
         """Creates note and updates local planning when session_id found."""
         client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
         client.create_event.return_value = {"id": 99}
         mock_factory.return_value = client
 

--- a/tests/test_mcp_extra_handlers.py
+++ b/tests/test_mcp_extra_handlers.py
@@ -17,6 +17,14 @@ pytest_plugins = ("pytest_asyncio",)
 
 TOWER_PATCH = "magma_cycling.planning.control_tower.planning_tower"
 INTERVALS_PATCH = "magma_cycling.config.create_intervals_client"
+_PROVIDER_INFO = {"provider": "intervals_icu", "athlete_id": "i12345", "status": "ready"}
+
+
+def _mock_intervals_client(**kwargs):
+    """Create a Mock IntervalsClient with get_provider_info pre-configured."""
+    client = Mock(**kwargs)
+    client.get_provider_info.return_value = _PROVIDER_INFO
+    return client
 
 
 # =======================
@@ -143,7 +151,7 @@ class TestHandleUpdateSession:
         mock_session.intervals_id = 12345
         mock_session.status = "pending"
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.update_event.return_value = {"id": 12345}
 
         args = {
@@ -176,7 +184,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.intervals_id = None
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_events.return_value = []
 
         args = {"week_id": "S081", "dry_run": True}
@@ -199,7 +207,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.intervals_id = 12345
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_events.return_value = []
 
         args = {"week_id": "S081", "dry_run": True}
@@ -217,7 +225,7 @@ class TestHandleSyncWeekToIntervals:
         from magma_cycling.mcp_server import handle_sync_week_to_calendar
 
         mock_tower.read_week.side_effect = FileNotFoundError("not found")
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         args = {"week_id": "S099"}
         with patch(TOWER_PATCH, mock_tower):
             with patch(INTERVALS_PATCH, return_value=mock_client):
@@ -237,7 +245,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.description = valid_desc
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         # Remote event with full intervals_name, matching start_date and description (no conflict)
         mock_client.get_events.return_value = [
             {
@@ -270,7 +278,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.description = "Warmup\n- 10m ramp 50-75% 85rpm\n\nMain set 3x\n- 10m 88% 90rpm\n- 3m 60% 85rpm\n\nCooldown\n- 10m ramp 70-50% 85rpm"
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         # Remote event has different name (manually modified in Intervals.icu)
         mock_client.get_events.return_value = [
             {
@@ -299,7 +307,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.intervals_id = None
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_events.return_value = []
 
         args = {"week_id": "S081", "dry_run": True}
@@ -321,7 +329,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.intervals_id = None
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_events.return_value = []
 
         args = {"week_id": "S081", "dry_run": True}
@@ -346,7 +354,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.version = "V001"
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         # Remote has short name (old bug would match wrongly)
         mock_client.get_events.return_value = [
             {
@@ -380,7 +388,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.description = valid_desc
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         # Remote has different date (triggers update)
         mock_client.get_events.return_value = [
             {
@@ -428,7 +436,7 @@ class TestHandleSyncWeekToIntervals:
         mock_session.intervals_id = None
         mock_plan.planned_sessions = [mock_session, session2]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_events.return_value = []
 
         # Only sync session2
@@ -464,7 +472,7 @@ class TestSyncValidationGate:
         mock_session.status = "pending"
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_events.return_value = []
 
         # Workout with invalid duration (5min instead of 5m)
@@ -495,7 +503,7 @@ class TestSyncValidationGate:
         mock_session.status = "pending"
         mock_plan.planned_sessions = [mock_session]
         tower = make_tower(mock_plan)
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_events.return_value = []
         mock_client.create_event.return_value = {"id": "evt999"}
 
@@ -529,7 +537,7 @@ class TestHandleGetMetrics:
         mock_config = Mock()
         mock_config.athlete_id = "iXXXXXX"
         mock_config.api_key = "apikey123"
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_wellness.return_value = [
             {
                 "id": "2026-02-24",
@@ -559,7 +567,7 @@ class TestHandleGetMetrics:
         mock_config = Mock()
         mock_config.athlete_id = "iXXXXXX"
         mock_config.api_key = "apikey123"
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_wellness.return_value = []
 
         with patch("magma_cycling.config.get_intervals_config", return_value=mock_config):
@@ -1082,7 +1090,7 @@ class TestHandleGetActivityIntervals:
         """Success path: 3 intervals returned with filtered fields."""
         from magma_cycling.mcp_server import handle_get_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity_intervals.return_value = [
             {
                 "type": "RECOVERY",
@@ -1177,7 +1185,7 @@ class TestHandleGetActivityIntervals:
         """API error returns error JSON."""
         from magma_cycling.mcp_server import handle_get_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity_intervals.side_effect = RuntimeError("API timeout")
 
         with patch(INTERVALS_PATCH, return_value=mock_client):
@@ -1192,7 +1200,7 @@ class TestHandleGetActivityIntervals:
         """Empty intervals list returns total_intervals == 0."""
         from magma_cycling.mcp_server import handle_get_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity_intervals.return_value = []
 
         with patch(INTERVALS_PATCH, return_value=mock_client):
@@ -1214,7 +1222,7 @@ class TestHandleApplyWorkoutIntervals:
         """Manual mode with dry_run=true returns preview without PUT."""
         from magma_cycling.mcp_server import handle_apply_workout_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
 
         intervals = [
             {"type": "RECOVERY", "label": "Warmup", "start_index": 0, "end_index": 499},
@@ -1242,7 +1250,7 @@ class TestHandleApplyWorkoutIntervals:
         """Manual mode with dry_run=false calls PUT."""
         from magma_cycling.mcp_server import handle_apply_workout_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.put_activity_intervals.return_value = {"status": "ok"}
 
         intervals = [
@@ -1268,7 +1276,7 @@ class TestHandleApplyWorkoutIntervals:
         """Auto mode parses workout and returns preview."""
         from magma_cycling.mcp_server import handle_apply_workout_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity_streams.return_value = [{"type": "watts", "data": [0] * 3000}]
 
         workout_text = """\
@@ -1315,7 +1323,7 @@ Cooldown
         """Activity name without session pattern → error with hint."""
         from magma_cycling.mcp_server import handle_apply_workout_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity.return_value = {"name": "Morning Ride"}
 
         args = {"activity_id": "i127869034"}
@@ -1333,7 +1341,7 @@ Cooldown
         """dry_run defaults to true when not specified (safety)."""
         from magma_cycling.mcp_server import handle_apply_workout_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
 
         intervals = [
             {"type": "WORK", "label": "Set1", "start_index": 0, "end_index": 999},
@@ -1356,7 +1364,7 @@ Cooldown
         """API exception → JSON error response."""
         from magma_cycling.mcp_server import handle_apply_workout_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.put_activity_intervals.side_effect = RuntimeError("API timeout")
 
         args = {
@@ -1398,7 +1406,7 @@ class TestHandleCompareIntervals:
         """3 explicit IDs with common labels → comparison + trends."""
         from magma_cycling.mcp_server import handle_compare_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity.side_effect = [
             {"name": "S079-03-CAD", "start_date_local": "2026-02-04T10:00:00"},
             {"name": "S080-03-CAD", "start_date_local": "2026-02-11T10:00:00"},
@@ -1430,7 +1438,7 @@ class TestHandleCompareIntervals:
         """name_pattern + weeks_back → filters matching activities, mode='search'."""
         from magma_cycling.mcp_server import handle_compare_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activities.return_value = [
             {
                 "id": "i100",
@@ -1465,7 +1473,7 @@ class TestHandleCompareIntervals:
         """Pattern that matches nothing → error."""
         from magma_cycling.mcp_server import handle_compare_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activities.return_value = [
             {"id": "i100", "name": "S079-01-Endurance", "start_date_local": "2026-02-04T10:00:00"},
         ]
@@ -1496,7 +1504,7 @@ class TestHandleCompareIntervals:
         """Intervals with elapsed_time <= 2 are excluded."""
         from magma_cycling.mcp_server import handle_compare_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity.side_effect = [
             {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
         ]
@@ -1521,7 +1529,7 @@ class TestHandleCompareIntervals:
         """label_filter='95rpm' → only 95rpm intervals kept."""
         from magma_cycling.mcp_server import handle_compare_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity.side_effect = [
             {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
         ]
@@ -1545,7 +1553,7 @@ class TestHandleCompareIntervals:
         """type_filter='WORK' → only WORK intervals kept."""
         from magma_cycling.mcp_server import handle_compare_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity.side_effect = [
             {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
         ]
@@ -1568,7 +1576,7 @@ class TestHandleCompareIntervals:
         """metrics=['average_watts','average_heartrate'] → only those 2 in data."""
         from magma_cycling.mcp_server import handle_compare_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity.side_effect = [
             {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
         ]
@@ -1609,7 +1617,7 @@ class TestHandleCompareIntervals:
         """A has Set1+Set2, B has Set1 only → Set2 data=null for B."""
         from magma_cycling.mcp_server import handle_compare_activity_intervals
 
-        mock_client = Mock()
+        mock_client = _mock_intervals_client()
         mock_client.get_activity.side_effect = [
             {"name": "A1", "start_date_local": "2026-02-04T10:00:00"},
             {"name": "A2", "start_date_local": "2026-02-11T10:00:00"},

--- a/tests/test_mcp_handlers.py
+++ b/tests/test_mcp_handlers.py
@@ -89,6 +89,9 @@ def mock_intervals_client():
     )
     client.get_events = Mock(return_value=[])
     client.update_athlete = Mock(return_value={"ftp": 223, "weight": 75})
+    client.get_provider_info = Mock(
+        return_value={"provider": "intervals_icu", "athlete_id": "i12345", "status": "ready"}
+    )
     return client
 
 

--- a/tests/test_mcp_new_handlers.py
+++ b/tests/test_mcp_new_handlers.py
@@ -18,6 +18,15 @@ pytest_plugins = ("pytest_asyncio",)
 TOWER_PATCH = "magma_cycling.planning.control_tower.planning_tower"
 INTERVALS_PATCH = "magma_cycling.config.create_intervals_client"
 DATA_CONFIG_PATCH = "magma_cycling.config.get_data_config"
+HEALTH_PROVIDER_PATCH = "magma_cycling.health.create_health_provider"
+_HEALTH_PROVIDER_INFO = {"provider": "WithingsProvider", "status": "ready"}
+
+
+def _mock_health_provider(**kwargs):
+    """Create a Mock HealthProvider with get_provider_info pre-configured."""
+    provider = Mock(**kwargs)
+    provider.get_provider_info.return_value = _HEALTH_PROVIDER_INFO
+    return provider
 
 
 # =======================
@@ -138,6 +147,11 @@ def mock_intervals():
     client.create_event.return_value = {"id": "evt123"}
     client.update_event.return_value = True
     client.delete_event.return_value = True
+    client.get_provider_info.return_value = {
+        "provider": "intervals_icu",
+        "athlete_id": "i12345",
+        "status": "ready",
+    }
     return client
 
 
@@ -1367,7 +1381,7 @@ class TestHandleAnalyzeHealthTrends:
     async def test_week_period_no_data(self):
         from magma_cycling.mcp_server import handle_analyze_health_trends
 
-        mock_provider = Mock()
+        mock_provider = _mock_health_provider()
         mock_provider.get_sleep_range.return_value = []
         mock_provider.get_body_composition_range.return_value = []
         with patch("magma_cycling.health.create_health_provider", return_value=mock_provider):
@@ -1381,7 +1395,7 @@ class TestHandleAnalyzeHealthTrends:
         from magma_cycling.mcp_server import handle_analyze_health_trends
         from magma_cycling.models.withings_models import SleepData, WeightMeasurement
 
-        mock_provider = Mock()
+        mock_provider = _mock_health_provider()
         mock_provider.get_sleep_range.return_value = [
             SleepData(
                 date=date(2026, 2, 1),
@@ -1418,7 +1432,7 @@ class TestHandleAnalyzeHealthTrends:
     async def test_custom_period_missing_dates_returns_error(self):
         from magma_cycling.mcp_server import handle_analyze_health_trends
 
-        mock_provider = Mock()
+        mock_provider = _mock_health_provider()
         with patch("magma_cycling.health.create_health_provider", return_value=mock_provider):
             result = await handle_analyze_health_trends({"period": "custom"})
         data = json.loads(result[0].text)
@@ -1428,7 +1442,7 @@ class TestHandleAnalyzeHealthTrends:
     async def test_custom_period_with_dates(self):
         from magma_cycling.mcp_server import handle_analyze_health_trends
 
-        mock_provider = Mock()
+        mock_provider = _mock_health_provider()
         mock_provider.get_sleep_range.return_value = []
         mock_provider.get_body_composition_range.return_value = []
         with patch("magma_cycling.health.create_health_provider", return_value=mock_provider):
@@ -1614,7 +1628,7 @@ class TestHandleEnrichSessionHealth:
             WeightMeasurement,
         )
 
-        mock_provider = Mock()
+        mock_provider = _mock_health_provider()
         mock_provider.get_sleep_range.return_value = [
             SleepData(
                 date=date(2026, 2, 25),
@@ -1666,7 +1680,7 @@ class TestHandleEnrichSessionHealth:
         """Returns error when session not found."""
         from magma_cycling.mcp_server import handle_enrich_session_health
 
-        mock_provider = Mock()
+        mock_provider = _mock_health_provider()
 
         with (
             patch(TOWER_PATCH, mock_tower),


### PR DESCRIPTION
## Summary

- Add `provider_info` kwarg to `mcp_response()` — injects provider metadata into `_metadata.provider` for all health (8) and remote (12) handlers
- Add `get_provider_info()` to `IntervalsClient` (returns `{provider: "intervals_icu", athlete_id, status}`)
- Enrich `health-auth-status` with `provider_name` / `provider_class` fields for conversation-start discovery
- New `system-info` meta-tool returns all active providers (health, calendar, AI) + tool count
- Fix mock `get_provider_info` in 4 test files to maintain backward compat

## Context

PR #160 made the MCP surface brand-agnostic (tool names, descriptions), but **responses** didn't indicate which concrete provider is active. Claude Desktop would deduce "Withings" from conversation memory — if the provider changed, it would be wrong.

Now every MCP response from health/remote handlers includes `_metadata.provider`, and `system-info` gives a complete picture at conversation start.

## Files changed

| File | Change |
|---|---|
| `_mcp/_utils.py` | `provider_info` kwarg on `mcp_response()` |
| `api/intervals_client.py` | `get_provider_info()` method |
| `_mcp/handlers/health.py` | provider_info in 8 handlers + enriched auth-status |
| `_mcp/handlers/remote_*.py` | provider_info in 12 handlers |
| `_mcp/handlers/admin.py` | `handle_system_info` handler |
| `_mcp/schemas/admin.py` | `system-info` tool schema |
| `mcp_server.py` | Register `system-info` in TOOL_HANDLERS |
| `tests/` (4 files) | Fix mock `get_provider_info` |

## Test plan

- [x] 3086 tests pass (`poetry run pytest tests/ -x`)
- [x] All pre-commit hooks pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)