### PR TITLE
fix(test): mock create_intervals_client in baseline_preliminary

### DIFF
--- a/tests/analysis/test_baseline_preliminary.py
+++ b/tests/analysis/test_baseline_preliminary.py
@@ -83,13 +83,17 @@ def mock_events_data():
 @pytest.fixture
 def analyzer(tmp_path):
     """Create BaselineAnalyzer with temp paths."""
-    return BaselineAnalyzer(
-        start_date="2026-01-04",
-        end_date="2026-01-06",
-        adherence_file=tmp_path / "adherence.jsonl",
-        workout_history_dir=tmp_path / "workout_history",
-        output_dir=tmp_path / "output",
-    )
+    with patch(
+        "magma_cycling.analysis.baseline_preliminary.create_intervals_client"
+    ) as mock_factory:
+        mock_factory.return_value = MagicMock()
+        yield BaselineAnalyzer(
+            start_date="2026-01-04",
+            end_date="2026-01-06",
+            adherence_file=tmp_path / "adherence.jsonl",
+            workout_history_dir=tmp_path / "workout_history",
+            output_dir=tmp_path / "output",
+        )
 
 
 def test_analyzer_initialization(analyzer):


### PR DESCRIPTION
## Summary
- Mock `create_intervals_client` dans la fixture `analyzer` de `test_baseline_preliminary.py`
- Sans ce mock, `BaselineAnalyzer.__init__()` appelle la factory qui raise si les env vars Intervals.icu ne sont pas définies
- **38 tests passent de ERROR à PASSED** (0 régression)

## Changement
- `return` → `yield` dans un context manager `patch()` sur la fixture `analyzer`
- 1 fichier modifié, 6 lignes de diff

## Test plan
- [x] `poetry run pytest tests/analysis/test_baseline_preliminary.py` — 38/38 passed
- [x] Suite complète — 2881 passed (vs 2843 avant), 0 nouvelle régression
- [x] Échecs pré-existants non liés (athlete_profile, daily_sync, upload_workouts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)