### PR TITLE
fix(test): resolve 16 pre-existing test failures

### DIFF
--- a/tests/config/test_athlete_profile.py
+++ b/tests/config/test_athlete_profile.py
@@ -16,6 +16,7 @@ class TestAthleteProfileFromEnv:
         monkeypatch.setenv("ATHLETE_RECOVERY_CAPACITY", "exceptional")
         monkeypatch.setenv("ATHLETE_SLEEP_DEPENDENT", "true")
         monkeypatch.setenv("ATHLETE_FTP", "240")
+        monkeypatch.setenv("ATHLETE_FTP_TARGET", "260")
         monkeypatch.setenv("ATHLETE_WEIGHT", "72.5")
 
         profile = AthleteProfile.from_env()
@@ -25,6 +26,7 @@ class TestAthleteProfileFromEnv:
         assert profile.recovery_capacity == "exceptional"
         assert profile.sleep_dependent is True
         assert profile.ftp == 240
+        assert profile.ftp_target == 260
         assert profile.weight == 72.5
 
     def test_from_env_sleep_dependent_variations(self, monkeypatch):
@@ -34,6 +36,7 @@ class TestAthleteProfileFromEnv:
             "ATHLETE_CATEGORY": "master",
             "ATHLETE_RECOVERY_CAPACITY": "exceptional",
             "ATHLETE_FTP": "240",
+            "ATHLETE_FTP_TARGET": "260",
             "ATHLETE_WEIGHT": "72.5",
         }
 
@@ -328,6 +331,7 @@ class TestAthleteProfileBiomechanics:
         monkeypatch.setenv("ATHLETE_RECOVERY_CAPACITY", "normal")
         monkeypatch.setenv("ATHLETE_SLEEP_DEPENDENT", "false")
         monkeypatch.setenv("ATHLETE_FTP", "280")
+        monkeypatch.setenv("ATHLETE_FTP_TARGET", "300")
         monkeypatch.setenv("ATHLETE_WEIGHT", "70.0")
         monkeypatch.setenv("ATHLETE_PROFIL_FIBRES", "explosif")
         monkeypatch.setenv("ATHLETE_CADENCE_OFFSET", "5")
@@ -344,6 +348,7 @@ class TestAthleteProfileBiomechanics:
         monkeypatch.setenv("ATHLETE_RECOVERY_CAPACITY", "normal")
         monkeypatch.setenv("ATHLETE_SLEEP_DEPENDENT", "false")
         monkeypatch.setenv("ATHLETE_FTP", "280")
+        monkeypatch.setenv("ATHLETE_FTP_TARGET", "300")
         monkeypatch.setenv("ATHLETE_WEIGHT", "70.0")
         # Biomechanics fields not set
 

--- a/tests/test_mcp_edge_cases.py
+++ b/tests/test_mcp_edge_cases.py
@@ -52,7 +52,7 @@ def test_update_completed_sessions_returns_dict_not_none():
         mock_data_config.week_planning_dir.mkdir()
 
         with patch(
-            "magma_cycling.config.create_intervals_client",
+            "magma_cycling.daily_sync.create_intervals_client",
             return_value=mock_client,
         ):
             with patch(
@@ -97,7 +97,7 @@ def test_update_completed_sessions_exception_returns_dict():
         mock_data_config.week_planning_dir.mkdir()
 
         with patch(
-            "magma_cycling.config.create_intervals_client",
+            "magma_cycling.daily_sync.create_intervals_client",
             return_value=mock_client,
         ):
             with patch(

--- a/tests/test_mcp_handlers.py
+++ b/tests/test_mcp_handlers.py
@@ -138,7 +138,7 @@ async def test_daily_sync_empty_activities_returns_dict(mock_intervals_client, t
     reports_dir.mkdir()
 
     with patch(
-        "magma_cycling.config.create_intervals_client",
+        "magma_cycling.daily_sync.create_intervals_client",
         return_value=mock_intervals_client,
     ):
         from magma_cycling.daily_sync import DailySync
@@ -173,7 +173,7 @@ async def test_daily_sync_api_error_returns_dict(tmp_path):
     mock_client.get_events.side_effect = Exception("API error")
 
     with patch(
-        "magma_cycling.config.create_intervals_client",
+        "magma_cycling.daily_sync.create_intervals_client",
         return_value=mock_client,
     ):
         from magma_cycling.daily_sync import DailySync
@@ -627,6 +627,10 @@ async def test_backfill_activities_handler_returns_json(mock_intervals_client, t
     with (
         patch(
             "magma_cycling.config.create_intervals_client",
+            return_value=mock_intervals_client,
+        ),
+        patch(
+            "magma_cycling.daily_sync.create_intervals_client",
             return_value=mock_intervals_client,
         ),
         patch("magma_cycling.config.get_data_config") as mock_get_config,

--- a/tests/test_mcp_tools_comprehensive.py
+++ b/tests/test_mcp_tools_comprehensive.py
@@ -100,7 +100,7 @@ class TestDailySyncComprehensive:
             mock_intervals_client.get_activities.return_value = []
 
             with patch(
-                "magma_cycling.config.create_intervals_client",
+                "magma_cycling.daily_sync.create_intervals_client",
                 return_value=mock_intervals_client,
             ):
                 sync = DailySync(tracking_file=tracking_file, reports_dir=reports_dir)
@@ -138,7 +138,7 @@ class TestDailySyncComprehensive:
             mock_intervals_client.get_events.return_value = []
 
             with patch(
-                "magma_cycling.config.create_intervals_client",
+                "magma_cycling.daily_sync.create_intervals_client",
                 return_value=mock_intervals_client,
             ):
                 sync = DailySync(tracking_file=tracking_file, reports_dir=reports_dir)
@@ -182,7 +182,7 @@ class TestDailySyncComprehensive:
             reports_dir.mkdir()
 
             with patch(
-                "magma_cycling.config.create_intervals_client",
+                "magma_cycling.daily_sync.create_intervals_client",
                 return_value=mock_intervals_client,
             ):
                 sync = DailySync(tracking_file=tracking_file, reports_dir=reports_dir)
@@ -213,7 +213,7 @@ class TestDailySyncComprehensive:
             mock_intervals_client.get_events.return_value = []
 
             with patch(
-                "magma_cycling.config.create_intervals_client",
+                "magma_cycling.daily_sync.create_intervals_client",
                 return_value=mock_intervals_client,
             ):
                 sync = DailySync(tracking_file=tracking_file, reports_dir=reports_dir)
@@ -240,7 +240,7 @@ class TestDailySyncComprehensive:
             mock_intervals_client.get_events.return_value = []
 
             with patch(
-                "magma_cycling.config.create_intervals_client",
+                "magma_cycling.daily_sync.create_intervals_client",
                 return_value=mock_intervals_client,
             ):
                 sync = DailySync(tracking_file=tracking_file, reports_dir=reports_dir)

--- a/tests/workflows/test_upload_workouts_bugs.py
+++ b/tests/workflows/test_upload_workouts_bugs.py
@@ -6,10 +6,11 @@ from unittest.mock import Mock, patch
 from magma_cycling.upload_workouts import WorkoutUploader
 
 
+@patch("magma_cycling.config.create_intervals_client", return_value=Mock())
 class TestValidationTiretsManquants:
     """Test bug: tirets manquants non détectés (S076)."""
 
-    def test_detect_missing_dashes_in_warmup(self):
+    def test_detect_missing_dashes_in_warmup(self, _mock_client):
         """Test détection tirets manquants dans Warmup."""
         uploader = WorkoutUploader("S076", datetime.now())
 
@@ -28,7 +29,7 @@ class TestValidationTiretsManquants:
         assert len(critical_warnings) >= 1
         assert "12m ramp" in critical_warnings[0]
 
-    def test_detect_missing_dashes_in_main_set(self):
+    def test_detect_missing_dashes_in_main_set(self, _mock_client):
         """Test détection tirets manquants dans Main set."""
         uploader = WorkoutUploader("S076", datetime.now())
 
@@ -50,7 +51,7 @@ Main set
         assert len(critical_warnings) >= 1
         assert "35m" in critical_warnings[0]
 
-    def test_detect_missing_dashes_in_cooldown(self):
+    def test_detect_missing_dashes_in_cooldown(self, _mock_client):
         """Test détection tirets manquants dans Cooldown."""
         uploader = WorkoutUploader("S076", datetime.now())
 
@@ -76,7 +77,7 @@ Cooldown
         assert len(critical_warnings) >= 1
         assert "10m ramp 65-50%" in critical_warnings[0]
 
-    def test_accept_correct_format_with_dashes(self):
+    def test_accept_correct_format_with_dashes(self, _mock_client):
         """Test acceptance format correct avec tirets (S075)."""
         uploader = WorkoutUploader("S075", datetime.now())
 
@@ -160,7 +161,8 @@ class TestReposDaysUpload:
         assert stats["success"] == 1
         assert stats["failed"] == 0
 
-    def test_validation_allows_repos_without_warmup_cooldown(self):
+    @patch("magma_cycling.config.create_intervals_client", return_value=Mock())
+    def test_validation_allows_repos_without_warmup_cooldown(self, _mock_client):
         """Test que validation n'exige pas warmup/cooldown pour REPOS."""
         uploader = WorkoutUploader("S076", datetime.now())
 
@@ -179,7 +181,8 @@ class TestReposDaysUpload:
 class TestIntegrationS076:
     """Test intégration complète pour S076."""
 
-    def test_s076_planning_validation_would_block(self):
+    @patch("magma_cycling.config.create_intervals_client", return_value=Mock())
+    def test_s076_planning_validation_would_block(self, _mock_client):
         """Test que S076 (tirets manquants) serait maintenant bloqué."""
         uploader = WorkoutUploader("S076", datetime.now())
 


### PR DESCRIPTION
## Summary
- Fix 16 tests qui échouaient quand les env vars Intervals.icu / athlete ne sont pas définies
- 2 causes racines : mauvais chemin de patch (`magma_cycling.config` au lieu de `magma_cycling.daily_sync`) et env var `ATHLETE_FTP_TARGET` manquante
- **2916 passed, 0 failed** (était 2881 passed, 16 failed)

## Fichiers modifiés
- `tests/config/test_athlete_profile.py` — ajout `ATHLETE_FTP_TARGET` (4 tests)
- `tests/test_mcp_tools_comprehensive.py` — patch path DailySync (5 tests)
- `tests/workflows/test_upload_workouts_bugs.py` — ajout mock WorkoutUploader (6 tests)
- `tests/test_mcp_handlers.py` — patch path DailySync + backfill (3 tests)
- `tests/test_mcp_edge_cases.py` — patch path DailySync (2 tests)

## Test plan
- [x] `poetry run pytest tests/ --ignore=tests/reports` — 2916 passed, 0 failed, 5 skipped
- [x] Aucune modification de code source, uniquement des tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)