### PR TITLE
feat(terrain): outdoor workout adaptation to terrain circuits

### DIFF
--- a/magma_cycling/_mcp/handlers/terrain.py
+++ b/magma_cycling/_mcp/handlers/terrain.py
@@ -1,0 +1,107 @@
+"""MCP handlers for terrain circuit extraction and workout adaptation."""
+
+from mcp.types import TextContent
+
+from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
+
+
+async def handle_extract_terrain_circuit(args: dict) -> list[TextContent]:
+    """Extract terrain profile from a past activity."""
+    try:
+        with suppress_stdout_stderr():
+            from magma_cycling.config import create_intervals_client
+            from magma_cycling.terrain.extraction import (
+                extract_terrain_from_activity,
+            )
+            from magma_cycling.terrain.storage import save_circuit
+
+            client = create_intervals_client()
+            provider_info = client.get_provider_info()
+
+            activity_id = args["activity_id"]
+            should_save = args.get("save", True)
+
+            circuit = extract_terrain_from_activity(client, activity_id)
+
+            saved_path = None
+            if should_save:
+                saved_path = save_circuit(circuit)
+
+            result = {
+                "status": "success",
+                "circuit": circuit.model_dump(mode="json"),
+            }
+            if saved_path:
+                result["_saved_to"] = str(saved_path)
+
+        return mcp_response(result, provider_info=provider_info, default=str)
+
+    except Exception as e:
+        return mcp_response({"error": f"Extraction failed: {e}"})
+
+
+async def handle_adapt_workout_to_terrain(args: dict) -> list[TextContent]:
+    """Adapt a structured workout to a terrain circuit."""
+    try:
+        with suppress_stdout_stderr():
+            circuit_id = args.get("circuit_id")
+            activity_id = args.get("activity_id")
+
+            if not circuit_id and not activity_id:
+                return mcp_response(
+                    {
+                        "error": (
+                            "Fournir soit circuit_id (circuit sauvegarde) "
+                            "soit activity_id (extraction a la volee)"
+                        )
+                    }
+                )
+
+            provider_info = None
+
+            if circuit_id:
+                from magma_cycling.terrain.storage import load_circuit
+
+                circuit = load_circuit(circuit_id)
+                if circuit is None:
+                    return mcp_response({"error": f"Circuit non trouve: {circuit_id}"})
+            else:
+                from magma_cycling.config import create_intervals_client
+                from magma_cycling.terrain.extraction import (
+                    extract_terrain_from_activity,
+                )
+
+                client = create_intervals_client()
+                provider_info = client.get_provider_info()
+                circuit = extract_terrain_from_activity(client, activity_id)
+
+            from magma_cycling.terrain.adaptation import (
+                adapt_workout_to_terrain,
+            )
+
+            workout = args["workout"]
+            ftp_watts = args["ftp_watts"]
+            athlete_weight_kg = args.get("athlete_weight_kg", 70.0)
+            profil_fibres = args.get("profil_fibres", "mixte")
+            workout_name = args.get("workout_name", "Workout")
+            original_tss = args.get("original_tss", 0)
+
+            adapted = adapt_workout_to_terrain(
+                workout=workout,
+                circuit=circuit,
+                ftp_watts=ftp_watts,
+                athlete_weight_kg=athlete_weight_kg,
+                profil_fibres=profil_fibres,
+                original_workout_name=workout_name,
+                original_tss=original_tss,
+            )
+
+            result = {
+                "status": "success",
+                "adapted_workout": adapted.model_dump(mode="json"),
+            }
+
+        return mcp_response(result, provider_info=provider_info, default=str)
+
+    except Exception as e:
+        return mcp_response({"error": f"Adaptation failed: {e}"})

--- a/magma_cycling/_mcp/schemas/terrain.py
+++ b/magma_cycling/_mcp/schemas/terrain.py
@@ -1,0 +1,95 @@
+"""MCP schema for terrain circuit and workout adaptation tools."""
+
+from mcp.types import Tool
+
+
+def get_tools() -> list[Tool]:
+    """Return terrain tool schemas."""
+    return [
+        Tool(
+            name="extract-terrain-circuit",
+            description=(
+                "Extrait le profil terrain (segments par km, denivele, pentes, "
+                "braquets observes) depuis une activite passee. "
+                "Sauvegarde optionnelle en YAML pour reutilisation."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "activity_id": {
+                        "type": "string",
+                        "description": ("ID de l'activite source (ex: i131572602)"),
+                    },
+                    "save": {
+                        "type": "boolean",
+                        "description": ("Sauvegarder le circuit en YAML (defaut: true)"),
+                        "default": True,
+                    },
+                },
+                "required": ["activity_id"],
+            },
+        ),
+        Tool(
+            name="adapt-workout-to-terrain",
+            description=(
+                "Adapte un workout structure a un circuit terrain. "
+                "Ajuste puissance, cadence et braquet par segment km "
+                "selon le profil de pente. Utilise la biomecanique Grappe "
+                "pour la cadence optimale."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "workout": {
+                        "type": ["object", "string"],
+                        "description": (
+                            "Workout a adapter. Soit un dict avec 'phases' "
+                            "(liste de {duration_min, power_pct}), soit une "
+                            "notation simple (ex: '10min@65% + 3x10min@88%')"
+                        ),
+                    },
+                    "ftp_watts": {
+                        "type": "integer",
+                        "description": "FTP de l'athlete en watts",
+                        "minimum": 50,
+                    },
+                    "circuit_id": {
+                        "type": "string",
+                        "description": (
+                            "ID d'un circuit sauvegarde (ex: TC_i131572602). "
+                            "Mutuellement exclusif avec activity_id."
+                        ),
+                    },
+                    "activity_id": {
+                        "type": "string",
+                        "description": (
+                            "ID d'activite pour extraction a la volee. "
+                            "Mutuellement exclusif avec circuit_id."
+                        ),
+                    },
+                    "athlete_weight_kg": {
+                        "type": "number",
+                        "description": "Poids de l'athlete en kg (defaut: 70)",
+                        "default": 70.0,
+                    },
+                    "profil_fibres": {
+                        "type": "string",
+                        "description": "Profil fibres musculaires",
+                        "enum": ["explosif", "mixte", "endurant"],
+                        "default": "mixte",
+                    },
+                    "workout_name": {
+                        "type": "string",
+                        "description": "Nom du workout (defaut: Workout)",
+                        "default": "Workout",
+                    },
+                    "original_tss": {
+                        "type": "integer",
+                        "description": "TSS original pour calcul delta",
+                        "default": 0,
+                    },
+                },
+                "required": ["workout", "ftp_watts"],
+            },
+        ),
+    ]

--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -76,6 +76,11 @@ class DataRepoConfig:
         return self.data_dir / "workout_templates"
 
     @property
+    def terrain_circuits_dir(self) -> Path:
+        """Path to data/terrain_circuits/ directory in data repo."""
+        return self.data_dir / "terrain_circuits"
+
+    @property
     def workflow_state_path(self) -> Path:
         """Path to .workflow_state.json in data repo."""
         return self.data_repo_path / ".workflow_state.json"
@@ -85,6 +90,7 @@ class DataRepoConfig:
         self.bilans_dir.mkdir(parents=True, exist_ok=True)
         self.week_planning_dir.mkdir(parents=True, exist_ok=True)
         self.workout_templates_dir.mkdir(parents=True, exist_ok=True)
+        self.terrain_circuits_dir.mkdir(parents=True, exist_ok=True)
 
     def validate(self) -> bool:
         """Validate data repository structure.

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -101,6 +101,10 @@ from magma_cycling._mcp.handlers.sessions import (  # noqa: F401
     handle_duplicate_session,
     handle_swap_sessions,
 )
+from magma_cycling._mcp.handlers.terrain import (  # noqa: F401
+    handle_adapt_workout_to_terrain,
+    handle_extract_terrain_circuit,
+)
 from magma_cycling._mcp.handlers.workouts import (  # noqa: F401
     handle_get_workout,
     handle_validate_workout,
@@ -116,6 +120,7 @@ from magma_cycling._mcp.schemas import planning as _s_planning
 from magma_cycling._mcp.schemas import remote as _s_remote
 from magma_cycling._mcp.schemas import rest as _s_rest
 from magma_cycling._mcp.schemas import sessions as _s_sessions
+from magma_cycling._mcp.schemas import terrain as _s_terrain
 from magma_cycling._mcp.schemas import workouts as _s_workouts
 
 # ---------------------------------------------------------------------------
@@ -146,6 +151,7 @@ async def list_tools() -> list[Tool]:
         *_s_catalog.get_tools(),
         *_s_health.get_tools(),
         *_s_rest.get_tools(),
+        *_s_terrain.get_tools(),
     ]
 
 
@@ -214,6 +220,9 @@ TOOL_HANDLERS = {
     # Rest / Recovery (2)
     "pre-session-check": handle_pre_session_check,
     "patch-coach-analysis": handle_patch_coach_analysis,
+    # Terrain (2)
+    "extract-terrain-circuit": handle_extract_terrain_circuit,
+    "adapt-workout-to-terrain": handle_adapt_workout_to_terrain,
 }
 
 

--- a/magma_cycling/terrain/__init__.py
+++ b/magma_cycling/terrain/__init__.py
@@ -1,0 +1,1 @@
+"""Terrain circuit extraction and workout adaptation for outdoor sessions."""

--- a/magma_cycling/terrain/adaptation.py
+++ b/magma_cycling/terrain/adaptation.py
@@ -1,0 +1,447 @@
+"""Adapt structured workouts to terrain circuits."""
+
+import math
+
+from magma_cycling.intelligence.biomechanics import calculer_cadence_optimale
+from magma_cycling.terrain.models import (
+    AdaptedSegment,
+    AdaptedWorkout,
+    GearObservation,
+    GradeCategory,
+    TerrainCircuit,
+)
+
+# Power adjustment by grade category (negative = reduction)
+POWER_ADJUSTMENTS: dict[GradeCategory, float] = {
+    GradeCategory.descente_raide: -15.0,
+    GradeCategory.descente: -10.0,
+    GradeCategory.faux_plat_descendant: -3.0,
+    GradeCategory.plat: 0.0,
+    GradeCategory.faux_plat_montant: 0.0,
+    GradeCategory.montee: -3.0,
+    GradeCategory.montee_raide: -5.0,
+}
+
+# Cadence overlay by grade category (applied on top of biomechanics)
+CADENCE_OVERLAY: dict[GradeCategory, int] = {
+    GradeCategory.descente_raide: 0,
+    GradeCategory.descente: 0,
+    GradeCategory.faux_plat_descendant: 0,
+    GradeCategory.plat: 0,
+    GradeCategory.faux_plat_montant: 0,
+    GradeCategory.montee: -3,
+    GradeCategory.montee_raide: -5,
+}
+
+
+def _estimate_speed_kmh(
+    power_watts: float,
+    grade_pct: float,
+    weight_kg: float,
+) -> float:
+    """Estimate cycling speed from power, grade, and weight.
+
+    Simplified model: P = (CdA * 0.5 * rho * v^3) + (m * g * sin(theta) * v) + (Crr * m * g * cos(theta) * v)
+
+    For simplicity we use an iterative approach with reasonable defaults.
+
+    Args:
+        power_watts: Power output in watts.
+        grade_pct: Road grade in percent.
+        weight_kg: Total weight (rider + bike) in kg.
+
+    Returns:
+        Estimated speed in km/h (minimum 5 km/h).
+    """
+    if power_watts <= 0:
+        return 5.0
+
+    # Constants
+    cda = 0.32  # Drag coefficient * frontal area (m^2)
+    rho = 1.225  # Air density (kg/m^3)
+    crr = 0.005  # Rolling resistance
+    g = 9.81
+    total_mass = weight_kg + 8.0  # Bike weight
+
+    grade_rad = math.atan(grade_pct / 100.0)
+
+    # Iterative solve: find v where P_required(v) == power_watts
+    # Start with a rough estimate and refine
+    v = 8.0  # m/s initial guess
+    for _ in range(20):
+        p_aero = 0.5 * cda * rho * v**3
+        p_gravity = total_mass * g * math.sin(grade_rad) * v
+        p_rolling = crr * total_mass * g * math.cos(grade_rad) * v
+        p_total = p_aero + p_gravity + p_rolling
+
+        if abs(p_total) < 1e-6:
+            break
+
+        # Newton-like step
+        dp_dv = (
+            1.5 * cda * rho * v**2
+            + total_mass * g * math.sin(grade_rad)
+            + crr * total_mass * g * math.cos(grade_rad)
+        )
+        if abs(dp_dv) < 1e-6:
+            break
+
+        v = v - (p_total - power_watts) / dp_dv
+        v = max(v, 1.0)  # Floor at 1 m/s
+
+    speed_kmh = v * 3.6
+    return max(speed_kmh, 5.0)
+
+
+def _parse_workout_phases(workout: dict | str) -> list[dict]:
+    """Parse a workout into sequential phases with duration and power.
+
+    Supports:
+    - Dict with 'phases' key (list of {duration_min, power_pct})
+    - String with simple notation like '10min@65% + 3x10min@88% + 10min@55%'
+    - Dict with 'intervals_description' from catalog
+
+    Args:
+        workout: Workout definition.
+
+    Returns:
+        List of dicts with 'duration_min' and 'power_pct' keys.
+    """
+    if isinstance(workout, dict):
+        if "phases" in workout:
+            return workout["phases"]
+        if "intervals_description" in workout:
+            return _parse_intervals_description(workout["intervals_description"])
+        if "segments" in workout:
+            return [
+                {
+                    "duration_min": s.get("duration_min", 5),
+                    "power_pct": s.get("power_pct", 75),
+                }
+                for s in workout["segments"]
+            ]
+        return [{"duration_min": 60, "power_pct": 75}]
+
+    if isinstance(workout, str):
+        return _parse_simple_notation(workout)
+
+    return [{"duration_min": 60, "power_pct": 75}]
+
+
+def _parse_simple_notation(notation: str) -> list[dict]:
+    """Parse simple workout notation like '10min@65% + 3x10min@88%'.
+
+    Args:
+        notation: Workout notation string.
+
+    Returns:
+        List of phase dicts.
+    """
+    phases = []
+    parts = [p.strip() for p in notation.split("+")]
+
+    for part in parts:
+        if not part:
+            continue
+
+        # Handle repetitions: 3x10min@88%
+        if "x" in part.split("@")[0]:
+            rep_part, rest = part.split("x", 1)
+            reps = int(rep_part.strip())
+        else:
+            reps = 1
+            rest = part
+
+        # Parse duration and power
+        if "@" in rest:
+            dur_str, pwr_str = rest.split("@")
+        else:
+            dur_str = rest
+            pwr_str = "75%"
+
+        duration = int(dur_str.replace("min", "").strip())
+        power = float(pwr_str.replace("%", "").strip())
+
+        for _ in range(reps):
+            phases.append({"duration_min": duration, "power_pct": power})
+
+    return phases
+
+
+def _parse_intervals_description(description: str) -> list[dict]:
+    r"""Parse Intervals.icu workout description to phases.
+
+    Handles format like: '- 10m 65% FTP\n- 3x 10m 88% FTP...'
+
+    Args:
+        description: Intervals description text.
+
+    Returns:
+        List of phase dicts.
+    """
+    phases = []
+    for line in description.strip().split("\n"):
+        line = line.strip().lstrip("-").strip()
+        if not line:
+            continue
+
+        # Handle repetitions
+        reps = 1
+        if line[0].isdigit() and "x" in line.split()[0]:
+            rep_str = line.split("x")[0].strip()
+            if rep_str.isdigit():
+                reps = int(rep_str)
+                line = line.split("x", 1)[1].strip()
+
+        # Extract duration (e.g. '10m', '5m')
+        duration = 5  # default
+        power = 75.0  # default
+        parts = line.split()
+        for i, p in enumerate(parts):
+            if p.endswith("m") and p[:-1].replace(".", "").isdigit():
+                duration = int(float(p[:-1]))
+            if p.endswith("%"):
+                try:
+                    power = float(p[:-1])
+                except ValueError:
+                    pass
+
+        for _ in range(reps):
+            phases.append({"duration_min": duration, "power_pct": power})
+
+    return phases if phases else [{"duration_min": 60, "power_pct": 75}]
+
+
+def _find_gear_for_category(
+    circuit: TerrainCircuit,
+    category: GradeCategory,
+) -> GearObservation | None:
+    """Find the primary gear observation for a terrain category.
+
+    Args:
+        circuit: TerrainCircuit with gear profiles.
+        category: Grade category to look up.
+
+    Returns:
+        Primary GearObservation or None.
+    """
+    for profile in circuit.gear_profiles:
+        if profile.grade_category == category:
+            return profile.primary_gear
+    return None
+
+
+def adapt_workout_to_terrain(
+    workout: dict | str,
+    circuit: TerrainCircuit,
+    ftp_watts: int,
+    *,
+    athlete_weight_kg: float = 70.0,
+    profil_fibres: str = "mixte",
+    original_workout_name: str = "Workout",
+    original_tss: int = 0,
+) -> AdaptedWorkout:
+    """Adapt a structured workout to a terrain circuit.
+
+    Maps workout phases to terrain km segments based on estimated speed,
+    then adjusts power, cadence, and gear recommendations per segment.
+
+    Args:
+        workout: Workout definition (dict with phases or string notation).
+        circuit: TerrainCircuit to adapt to.
+        ftp_watts: Athlete FTP in watts.
+        athlete_weight_kg: Athlete weight in kg.
+        profil_fibres: Fiber profile for cadence calculation.
+        original_workout_name: Display name for the workout.
+        original_tss: Original TSS estimate for delta tracking.
+
+    Returns:
+        AdaptedWorkout with per-km adapted segments.
+    """
+    phases = _parse_workout_phases(workout)
+    if not phases:
+        return AdaptedWorkout(
+            workout_name=original_workout_name,
+            circuit_id=circuit.circuit_id,
+            circuit_name=circuit.name,
+            ftp_watts=ftp_watts,
+            athlete_weight_kg=athlete_weight_kg,
+            warnings=["No workout phases found"],
+        )
+
+    # Build timeline: for each phase, compute total seconds
+    phase_timeline = []
+    for phase in phases:
+        phase_timeline.append(
+            {
+                "duration_s": phase["duration_min"] * 60,
+                "power_pct": phase["power_pct"],
+                "power_watts": phase["power_pct"] / 100.0 * ftp_watts,
+                "remaining_s": phase["duration_min"] * 60,
+            }
+        )
+
+    # Map phases onto terrain segments
+    adapted_segments = []
+    warnings = []
+    total_work_kj = 0.0
+    phase_idx = 0
+
+    for seg in circuit.segments:
+        if phase_idx >= len(phase_timeline):
+            warnings.append(
+                f"km {seg.km_index}: workout phases exhausted, " "remaining terrain not covered"
+            )
+            break
+
+        current_phase = phase_timeline[phase_idx]
+        original_power_pct = current_phase["power_pct"]
+        power_watts = current_phase["power_watts"]
+
+        # Estimate time to traverse this km segment
+        speed_kmh = _estimate_speed_kmh(power_watts, seg.grade_pct, athlete_weight_kg)
+        time_s = (seg.distance_m / 1000.0) / speed_kmh * 3600
+
+        # Consume phase time
+        current_phase["remaining_s"] -= time_s
+        if current_phase["remaining_s"] <= 0:
+            phase_idx += 1
+
+        # Power adjustment
+        adjustment = POWER_ADJUSTMENTS.get(seg.grade_category, 0.0)
+        adapted_power_pct = original_power_pct + adjustment
+
+        # Cadence from biomechanics
+        zone_ftp = max(0.5, min(1.5, original_power_pct / 100.0))
+        total_workout_min = sum(p["duration_min"] for p in phases)
+        cadence_result = calculer_cadence_optimale(
+            zone_ftp=zone_ftp,
+            duree_minutes=total_workout_min,
+            profil_fibres=profil_fibres,
+            objectif="terrain",
+        )
+
+        # Apply terrain cadence overlay
+        overlay = CADENCE_OVERLAY.get(seg.grade_category, 0)
+        target_cadence = cadence_result["cadence_cible"] + overlay
+        cadence_min = cadence_result["cadence_min"] + overlay
+        cadence_max = cadence_result["cadence_max"] + overlay
+
+        # Gear recommendation from circuit profiles
+        recommended_gear = _find_gear_for_category(circuit, seg.grade_category)
+
+        # Build instruction
+        instruction = _build_instruction(
+            seg.km_index,
+            seg.grade_pct,
+            seg.grade_category,
+            adapted_power_pct,
+            target_cadence,
+            recommended_gear,
+        )
+
+        # Track work for TSS
+        adapted_watts = adapted_power_pct / 100.0 * ftp_watts
+        total_work_kj += adapted_watts * time_s / 1000.0
+
+        adapted_segments.append(
+            AdaptedSegment(
+                km_index=seg.km_index,
+                terrain_grade_pct=seg.grade_pct,
+                terrain_category=seg.grade_category,
+                original_power_pct=original_power_pct,
+                adapted_power_pct=round(adapted_power_pct, 1),
+                power_adjustment_pct=adjustment,
+                target_cadence_rpm=max(0, target_cadence),
+                cadence_min_rpm=max(0, cadence_min),
+                cadence_max_rpm=max(0, cadence_max),
+                recommended_gear=recommended_gear,
+                instruction=instruction,
+            )
+        )
+
+    # Estimate TSS: TSS = (duration_s * NP * IF) / (FTP * 3600) * 100
+    # Simplified: TSS = sum(work_kj) / (FTP * 3600 / 1000) * 100
+    total_duration_s = sum(
+        (s.distance_m / 1000.0)
+        / max(
+            5.0,
+            _estimate_speed_kmh(
+                s.grade_pct,  # Not used as power here, but consistent
+                s.grade_pct,
+                athlete_weight_kg,
+            ),
+        )
+        * 3600
+        for s in circuit.segments[: len(adapted_segments)]
+    )
+    if ftp_watts > 0 and total_duration_s > 0:
+        avg_power_pct = (
+            sum(s.adapted_power_pct for s in adapted_segments) / len(adapted_segments)
+            if adapted_segments
+            else 75
+        )
+        avg_if = avg_power_pct / 100.0
+        estimated_tss = (total_duration_s * avg_if**2) / 3600 * 100
+    else:
+        estimated_tss = 0
+
+    delta_tss = estimated_tss - original_tss if original_tss > 0 else 0
+
+    return AdaptedWorkout(
+        workout_name=original_workout_name,
+        circuit_id=circuit.circuit_id,
+        circuit_name=circuit.name,
+        ftp_watts=ftp_watts,
+        athlete_weight_kg=athlete_weight_kg,
+        segments=adapted_segments,
+        estimated_tss=round(estimated_tss, 1),
+        original_tss=float(original_tss),
+        delta_tss=round(delta_tss, 1),
+        warnings=warnings,
+    )
+
+
+def _build_instruction(
+    km_index: int,
+    grade_pct: float,
+    category: GradeCategory,
+    adapted_power_pct: float,
+    target_cadence: int,
+    gear: GearObservation | None,
+) -> str:
+    """Build a human-readable instruction for a terrain segment.
+
+    Args:
+        km_index: Kilometer index.
+        grade_pct: Grade percentage.
+        category: Grade category.
+        adapted_power_pct: Adapted power target.
+        target_cadence: Target cadence.
+        gear: Optional gear recommendation.
+
+    Returns:
+        Instruction string.
+    """
+    cat_labels = {
+        GradeCategory.descente_raide: "Descente raide",
+        GradeCategory.descente: "Descente",
+        GradeCategory.faux_plat_descendant: "Faux-plat descendant",
+        GradeCategory.plat: "Plat",
+        GradeCategory.faux_plat_montant: "Faux-plat montant",
+        GradeCategory.montee: "Montee",
+        GradeCategory.montee_raide: "Montee raide",
+    }
+
+    label = cat_labels.get(category, category.value)
+    parts = [
+        f"km {km_index}-{km_index + 1}",
+        f"{label} {grade_pct:+.1f}%",
+        f"{adapted_power_pct:.0f}% FTP",
+        f"{target_cadence} rpm",
+    ]
+
+    if gear:
+        parts.append(f"braquet {gear.front_teeth}/{gear.rear_teeth}")
+
+    return " | ".join(parts)

--- a/magma_cycling/terrain/extraction.py
+++ b/magma_cycling/terrain/extraction.py
@@ -1,0 +1,351 @@
+"""Extract terrain circuits from activity streams."""
+
+from collections import defaultdict
+
+from magma_cycling.terrain.models import (
+    GearObservation,
+    GearProfile,
+    GradeCategory,
+    TerrainCircuit,
+    TerrainSegment,
+)
+
+# Segment length in meters
+SEGMENT_LENGTH_M = 1000.0
+
+
+def classify_grade(grade_pct: float) -> GradeCategory:
+    """Classify a grade percentage into a terrain category.
+
+    Args:
+        grade_pct: Grade in percent.
+
+    Returns:
+        Matching GradeCategory.
+    """
+    return GradeCategory.from_grade(grade_pct)
+
+
+def _get_stream_data(streams: list[dict], stream_type: str) -> list | None:
+    """Extract data array for a given stream type.
+
+    Args:
+        streams: List of stream dicts with 'type' and 'data' keys.
+        stream_type: Stream type name (e.g. 'altitude', 'distance').
+
+    Returns:
+        Data list or None if not found.
+    """
+    for s in streams:
+        if s.get("type") == stream_type:
+            return s.get("data")
+    return None
+
+
+def extract_terrain_from_streams(
+    activity_id: str,
+    streams: list[dict],
+    *,
+    activity_name: str = "",
+) -> TerrainCircuit:
+    """Build a TerrainCircuit from activity streams (pure logic, no API).
+
+    Aggregates per-second streams into per-km segments. Extracts gear
+    profiles if FrontGear/RearGear streams are present.
+
+    Args:
+        activity_id: Source activity ID.
+        streams: List of stream dicts with 'type' and 'data' fields.
+        activity_name: Optional display name for the circuit.
+
+    Returns:
+        TerrainCircuit with per-km segments and gear profiles.
+
+    Raises:
+        ValueError: If required streams (altitude, distance) are missing.
+    """
+    altitude_data = _get_stream_data(streams, "altitude")
+    distance_data = _get_stream_data(streams, "distance")
+
+    if not altitude_data or not distance_data:
+        raise ValueError(
+            "Streams must contain 'altitude' and 'distance' data. "
+            f"Available: {[s.get('type') for s in streams]}"
+        )
+
+    if len(altitude_data) != len(distance_data):
+        raise ValueError(
+            f"altitude ({len(altitude_data)}) and distance ({len(distance_data)}) "
+            "streams must have the same length"
+        )
+
+    # Optional gear streams
+    front_gear_data = _get_stream_data(streams, "FrontGear")
+    rear_gear_data = _get_stream_data(streams, "RearGear")
+    has_gear = (
+        front_gear_data is not None
+        and rear_gear_data is not None
+        and len(front_gear_data) == len(altitude_data)
+        and len(rear_gear_data) == len(altitude_data)
+    )
+
+    # Optional cadence/power for gear profiles
+    cadence_data = _get_stream_data(streams, "cadence")
+    watts_data = _get_stream_data(streams, "watts")
+
+    # Build per-km segments
+    segments: list[TerrainSegment] = []
+    total_gain = 0.0
+    total_loss = 0.0
+
+    # Per-category gear accumulator: category -> list of (front, rear, cadence, watts)
+    gear_by_category: dict[GradeCategory, list[tuple]] = defaultdict(list)
+
+    km_index = 0
+    seg_start_idx = 0
+    seg_start_dist = distance_data[0] if distance_data[0] is not None else 0.0
+
+    for i in range(1, len(distance_data)):
+        if distance_data[i] is None or altitude_data[i] is None:
+            continue
+
+        current_dist = distance_data[i]
+        seg_distance = current_dist - seg_start_dist
+
+        if seg_distance >= SEGMENT_LENGTH_M:
+            # Finalize this km segment
+            seg = _build_segment(
+                km_index=km_index,
+                altitude_data=altitude_data,
+                distance_data=distance_data,
+                start_idx=seg_start_idx,
+                end_idx=i,
+                seg_start_dist=seg_start_dist,
+            )
+            segments.append(seg)
+            total_gain += seg.elevation_gain_m
+            total_loss += seg.elevation_loss_m
+
+            # Collect gear data for this segment's category
+            if has_gear:
+                _collect_gear_data(
+                    gear_by_category,
+                    seg.grade_category,
+                    front_gear_data,
+                    rear_gear_data,
+                    cadence_data,
+                    watts_data,
+                    seg_start_idx,
+                    i,
+                )
+
+            km_index += 1
+            seg_start_idx = i
+            seg_start_dist = current_dist
+
+    # Handle last partial segment (if > 200m remaining)
+    if seg_start_idx < len(distance_data) - 1:
+        last_dist = distance_data[-1]
+        if last_dist is not None:
+            remaining = last_dist - seg_start_dist
+            if remaining > 200:
+                seg = _build_segment(
+                    km_index=km_index,
+                    altitude_data=altitude_data,
+                    distance_data=distance_data,
+                    start_idx=seg_start_idx,
+                    end_idx=len(distance_data) - 1,
+                    seg_start_dist=seg_start_dist,
+                )
+                segments.append(seg)
+                total_gain += seg.elevation_gain_m
+                total_loss += seg.elevation_loss_m
+
+                if has_gear:
+                    _collect_gear_data(
+                        gear_by_category,
+                        seg.grade_category,
+                        front_gear_data,
+                        rear_gear_data,
+                        cadence_data,
+                        watts_data,
+                        seg_start_idx,
+                        len(distance_data) - 1,
+                    )
+
+    # Build gear profiles
+    gear_profiles = _build_gear_profiles(gear_by_category)
+
+    total_distance = 0.0
+    if distance_data[-1] is not None and distance_data[0] is not None:
+        total_distance = (distance_data[-1] - distance_data[0]) / 1000.0
+
+    return TerrainCircuit(
+        circuit_id=f"TC_{activity_id}",
+        name=activity_name or f"Circuit {activity_id}",
+        source_type="activity",
+        source_activity_id=activity_id,
+        total_distance_km=round(total_distance, 2),
+        total_elevation_gain_m=round(total_gain, 1),
+        total_elevation_loss_m=round(total_loss, 1),
+        segments=segments,
+        gear_profiles=gear_profiles,
+    )
+
+
+def _build_segment(
+    km_index: int,
+    altitude_data: list,
+    distance_data: list,
+    start_idx: int,
+    end_idx: int,
+    seg_start_dist: float,
+) -> TerrainSegment:
+    """Build a TerrainSegment from stream slice."""
+    elev_start = altitude_data[start_idx]
+    elev_end = altitude_data[end_idx]
+    dist = distance_data[end_idx] - seg_start_dist
+
+    # Calculate gain/loss by walking through each point
+    gain = 0.0
+    loss = 0.0
+    for j in range(start_idx + 1, end_idx + 1):
+        if altitude_data[j] is not None and altitude_data[j - 1] is not None:
+            delta = altitude_data[j] - altitude_data[j - 1]
+            if delta > 0:
+                gain += delta
+            else:
+                loss += abs(delta)
+
+    grade = ((elev_end - elev_start) / dist * 100) if dist > 0 else 0.0
+
+    return TerrainSegment(
+        km_index=km_index,
+        distance_m=round(dist, 1),
+        elevation_start_m=round(elev_start, 1),
+        elevation_end_m=round(elev_end, 1),
+        elevation_gain_m=round(gain, 1),
+        elevation_loss_m=round(loss, 1),
+        grade_pct=round(grade, 2),
+        grade_category=classify_grade(grade),
+    )
+
+
+def _collect_gear_data(
+    gear_by_category: dict,
+    category: GradeCategory,
+    front_gear_data: list,
+    rear_gear_data: list,
+    cadence_data: list | None,
+    watts_data: list | None,
+    start_idx: int,
+    end_idx: int,
+) -> None:
+    """Collect gear observations for a segment into the category accumulator."""
+    for j in range(start_idx, end_idx + 1):
+        front = front_gear_data[j]
+        rear = rear_gear_data[j]
+        if front is not None and rear is not None and front > 0 and rear > 0:
+            cad = (
+                cadence_data[j] if cadence_data and j < len(cadence_data) and cadence_data[j] else 0
+            )
+            pwr = watts_data[j] if watts_data and j < len(watts_data) and watts_data[j] else 0
+            gear_by_category[category].append((int(front), int(rear), cad, pwr))
+
+
+def _build_gear_profiles(
+    gear_by_category: dict[GradeCategory, list[tuple]],
+) -> list[GearProfile]:
+    """Aggregate raw gear data into GearProfile objects per category."""
+    profiles = []
+
+    for category, observations in gear_by_category.items():
+        if not observations:
+            continue
+
+        # Count gear combos
+        combo_counts: dict[tuple[int, int], int] = defaultdict(int)
+        combo_cadence: dict[tuple[int, int], list[float]] = defaultdict(list)
+        combo_power: dict[tuple[int, int], list[float]] = defaultdict(list)
+
+        for front, rear, cad, pwr in observations:
+            combo_counts[(front, rear)] += 1
+            if cad > 0:
+                combo_cadence[(front, rear)].append(cad)
+            if pwr > 0:
+                combo_power[(front, rear)].append(pwr)
+
+        total = sum(combo_counts.values())
+        sorted_combos = sorted(combo_counts.items(), key=lambda x: -x[1])
+
+        # Primary gear = most used
+        primary_combo = sorted_combos[0]
+        primary_front, primary_rear = primary_combo[0]
+        primary_usage = primary_combo[1] / total * 100
+
+        # Average cadence/power across all observations for this category
+        all_cadences = [c for _, _, c, _ in observations if c > 0]
+        all_powers = [p for _, _, _, p in observations if p > 0]
+        avg_cad = sum(all_cadences) / len(all_cadences) if all_cadences else 0
+        avg_pwr = sum(all_powers) / len(all_powers) if all_powers else 0
+
+        primary_gear = GearObservation(
+            front_teeth=primary_front,
+            rear_teeth=primary_rear,
+            ratio=round(primary_front / primary_rear, 3),
+            usage_pct=round(primary_usage, 1),
+        )
+
+        alternatives = []
+        for combo, count in sorted_combos[1:4]:  # Up to 3 alternatives
+            front, rear = combo
+            usage = count / total * 100
+            if usage >= 5.0:  # Only include if >= 5% usage
+                alternatives.append(
+                    GearObservation(
+                        front_teeth=front,
+                        rear_teeth=rear,
+                        ratio=round(front / rear, 3),
+                        usage_pct=round(usage, 1),
+                    )
+                )
+
+        profiles.append(
+            GearProfile(
+                grade_category=category,
+                primary_gear=primary_gear,
+                alternatives=alternatives,
+                avg_cadence_rpm=round(avg_cad, 1),
+                avg_power_watts=round(avg_pwr, 1),
+            )
+        )
+
+    return profiles
+
+
+def extract_terrain_from_activity(
+    client,
+    activity_id: str,
+) -> TerrainCircuit:
+    """Extract terrain circuit from an Intervals.icu activity.
+
+    High-level wrapper: fetches activity details and streams,
+    then delegates to extract_terrain_from_streams().
+
+    Args:
+        client: IntervalsClient instance.
+        activity_id: Activity ID (e.g. 'i131572602').
+
+    Returns:
+        TerrainCircuit built from the activity's streams.
+    """
+    activity = client.get_activity(activity_id)
+    streams = client.get_activity_streams(activity_id)
+
+    activity_name = activity.get("name", "")
+
+    return extract_terrain_from_streams(
+        activity_id=activity_id,
+        streams=streams,
+        activity_name=activity_name,
+    )

--- a/magma_cycling/terrain/models.py
+++ b/magma_cycling/terrain/models.py
@@ -1,0 +1,125 @@
+"""Pydantic v2 models for terrain circuits and adapted workouts."""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class GradeCategory(str, Enum):
+    """Terrain grade categories with thresholds from validated POC."""
+
+    descente_raide = "descente_raide"
+    descente = "descente"
+    faux_plat_descendant = "faux_plat_descendant"
+    plat = "plat"
+    faux_plat_montant = "faux_plat_montant"
+    montee = "montee"
+    montee_raide = "montee_raide"
+
+    @classmethod
+    def from_grade(cls, grade_pct: float) -> "GradeCategory":
+        """Classify a grade percentage into a category.
+
+        Args:
+            grade_pct: Grade in percent (e.g. 5.0 for 5%).
+
+        Returns:
+            Matching GradeCategory.
+        """
+        if grade_pct < -4.0:
+            return cls.descente_raide
+        if grade_pct < -1.5:
+            return cls.descente
+        if grade_pct < -0.5:
+            return cls.faux_plat_descendant
+        if grade_pct <= 0.5:
+            return cls.plat
+        if grade_pct <= 1.5:
+            return cls.faux_plat_montant
+        if grade_pct <= 4.0:
+            return cls.montee
+        return cls.montee_raide
+
+
+class GearObservation(BaseModel):
+    """Observed gear combination on a terrain segment (brand-agnostic)."""
+
+    front_teeth: int = Field(..., ge=1, description="Front chainring teeth count")
+    rear_teeth: int = Field(..., ge=1, description="Rear cog teeth count")
+    ratio: float = Field(..., gt=0, description="Gear ratio (front/rear)")
+    usage_pct: float = Field(..., ge=0, le=100, description="Usage percentage in segment")
+
+
+class GearProfile(BaseModel):
+    """Aggregated gear usage for a terrain grade category."""
+
+    grade_category: GradeCategory
+    primary_gear: GearObservation
+    alternatives: list[GearObservation] = Field(default_factory=list)
+    avg_cadence_rpm: float = Field(..., ge=0)
+    avg_power_watts: float = Field(..., ge=0)
+
+
+class TerrainSegment(BaseModel):
+    """Per-km terrain segment with elevation data."""
+
+    km_index: int = Field(..., ge=0, description="Kilometer index (0-based)")
+    distance_m: float = Field(..., gt=0, description="Segment distance in meters")
+    elevation_start_m: float = Field(..., description="Elevation at segment start")
+    elevation_end_m: float = Field(..., description="Elevation at segment end")
+    elevation_gain_m: float = Field(..., ge=0, description="Elevation gain in segment")
+    elevation_loss_m: float = Field(..., ge=0, description="Elevation loss in segment")
+    grade_pct: float = Field(..., description="Average grade in percent")
+    grade_category: GradeCategory
+
+
+class TerrainCircuit(BaseModel):
+    """Complete terrain circuit extracted from activity or other source."""
+
+    circuit_id: str = Field(..., description="Unique circuit ID (e.g. TC_i131572602)")
+    name: str = Field(default="", description="Circuit display name")
+    source_type: Literal["activity", "gpx", "manual"] = Field(
+        default="activity", description="Data source type"
+    )
+    source_activity_id: str = Field(default="", description="Source activity ID if from activity")
+    total_distance_km: float = Field(..., ge=0)
+    total_elevation_gain_m: float = Field(..., ge=0)
+    total_elevation_loss_m: float = Field(..., ge=0)
+    segments: list[TerrainSegment] = Field(default_factory=list)
+    gear_profiles: list[GearProfile] = Field(default_factory=list)
+
+
+class AdaptedSegment(BaseModel):
+    """Workout segment adapted to terrain."""
+
+    km_index: int = Field(..., ge=0)
+    terrain_grade_pct: float
+    terrain_category: GradeCategory
+    original_power_pct: float = Field(..., description="Original target power as %% FTP")
+    adapted_power_pct: float = Field(..., description="Adapted target power as %% FTP")
+    power_adjustment_pct: float = Field(
+        ..., description="Power adjustment applied (negative = reduction)"
+    )
+    target_cadence_rpm: int = Field(..., ge=0)
+    cadence_min_rpm: int = Field(..., ge=0)
+    cadence_max_rpm: int = Field(..., ge=0)
+    recommended_gear: GearObservation | None = Field(
+        default=None, description="Recommended gear from circuit gear profiles"
+    )
+    instruction: str = Field(default="", description="Human-readable instruction for this segment")
+
+
+class AdaptedWorkout(BaseModel):
+    """Complete workout adapted to a terrain circuit."""
+
+    workout_name: str
+    circuit_id: str
+    circuit_name: str = ""
+    ftp_watts: int = Field(..., gt=0)
+    athlete_weight_kg: float = Field(default=70.0, gt=0)
+    segments: list[AdaptedSegment] = Field(default_factory=list)
+    estimated_tss: float = Field(default=0, ge=0)
+    original_tss: float = Field(default=0, ge=0)
+    delta_tss: float = Field(default=0, description="TSS difference (estimated - original)")
+    warnings: list[str] = Field(default_factory=list)

--- a/magma_cycling/terrain/storage.py
+++ b/magma_cycling/terrain/storage.py
@@ -1,0 +1,93 @@
+"""YAML persistence for terrain circuits."""
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from magma_cycling.config.data_repo import get_data_config
+from magma_cycling.terrain.models import TerrainCircuit
+
+logger = logging.getLogger(__name__)
+
+
+def get_terrain_circuits_dir() -> Path:
+    """Return the terrain circuits storage directory.
+
+    Returns:
+        Path to ~/training-logs/data/terrain_circuits/.
+    """
+    config = get_data_config()
+    return config.terrain_circuits_dir
+
+
+def save_circuit(circuit: TerrainCircuit) -> Path:
+    """Save a terrain circuit as YAML.
+
+    Args:
+        circuit: TerrainCircuit to persist.
+
+    Returns:
+        Path to the saved YAML file.
+    """
+    circuits_dir = get_terrain_circuits_dir()
+    circuits_dir.mkdir(parents=True, exist_ok=True)
+
+    filepath = circuits_dir / f"{circuit.circuit_id}.yaml"
+    data = circuit.model_dump(mode="json")
+
+    with open(filepath, "w", encoding="utf-8") as f:
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+
+    logger.info("Saved terrain circuit to %s", filepath)
+    return filepath
+
+
+def load_circuit(circuit_id: str) -> TerrainCircuit | None:
+    """Load a terrain circuit from YAML.
+
+    Args:
+        circuit_id: Circuit ID (e.g. 'TC_i131572602').
+
+    Returns:
+        TerrainCircuit or None if not found.
+    """
+    circuits_dir = get_terrain_circuits_dir()
+    filepath = circuits_dir / f"{circuit_id}.yaml"
+
+    if not filepath.exists():
+        return None
+
+    with open(filepath, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    return TerrainCircuit.model_validate(data)
+
+
+def list_circuits() -> list[dict]:
+    """List all saved terrain circuits.
+
+    Returns:
+        List of dicts with id, name, distance, elevation for each circuit.
+    """
+    circuits_dir = get_terrain_circuits_dir()
+    if not circuits_dir.exists():
+        return []
+
+    results = []
+    for filepath in sorted(circuits_dir.glob("TC_*.yaml")):
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            results.append(
+                {
+                    "id": data.get("circuit_id", filepath.stem),
+                    "name": data.get("name", ""),
+                    "distance_km": data.get("total_distance_km", 0),
+                    "elevation_gain_m": data.get("total_elevation_gain_m", 0),
+                }
+            )
+        except Exception as e:
+            logger.warning("Failed to read %s: %s", filepath, e)
+
+    return results

--- a/tests/test_mcp_terrain.py
+++ b/tests/test_mcp_terrain.py
@@ -1,0 +1,191 @@
+"""Tests for MCP terrain handlers."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.terrain import (
+    handle_adapt_workout_to_terrain,
+    handle_extract_terrain_circuit,
+)
+
+
+def _make_flat_streams(n_km=3):
+    """Generate flat terrain streams for mocking."""
+    n_points = n_km * 100
+    return [
+        {"type": "distance", "data": [i * 10.0 for i in range(n_points)]},
+        {"type": "altitude", "data": [100.0] * n_points},
+    ]
+
+
+def _parse_response(result):
+    """Parse MCP TextContent response to dict."""
+    assert len(result) == 1
+    return json.loads(result[0].text)
+
+
+@pytest.mark.asyncio
+class TestHandleExtractTerrainCircuit:
+    """handle_extract_terrain_circuit tests."""
+
+    async def test_extract_success(self, tmp_path):
+        """Extract circuit from mocked activity streams."""
+        mock_client = MagicMock()
+        mock_client.get_activity.return_value = {"name": "Morning Ride"}
+        mock_client.get_activity_streams.return_value = _make_flat_streams(5)
+        mock_client.get_provider_info.return_value = {
+            "provider": "intervals_icu",
+            "athlete_id": "i42",
+            "status": "ready",
+        }
+
+        with (
+            patch(
+                "magma_cycling.config.create_intervals_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "magma_cycling.terrain.storage.save_circuit",
+                return_value=tmp_path / "TC_i999.yaml",
+            ),
+        ):
+            result = await handle_extract_terrain_circuit({"activity_id": "i999", "save": True})
+
+        data = _parse_response(result)
+        assert data["status"] == "success"
+        assert "circuit" in data
+        assert data["circuit"]["circuit_id"] == "TC_i999"
+        assert "_metadata" in data
+        assert data["_metadata"]["provider"]["provider"] == "intervals_icu"
+
+    async def test_extract_no_save(self):
+        """Extract without saving."""
+        mock_client = MagicMock()
+        mock_client.get_activity.return_value = {"name": "Test"}
+        mock_client.get_activity_streams.return_value = _make_flat_streams(3)
+        mock_client.get_provider_info.return_value = {
+            "provider": "intervals_icu",
+            "athlete_id": "i42",
+            "status": "ready",
+        }
+
+        with patch(
+            "magma_cycling.config.create_intervals_client",
+            return_value=mock_client,
+        ):
+            result = await handle_extract_terrain_circuit({"activity_id": "i100", "save": False})
+
+        data = _parse_response(result)
+        assert data["status"] == "success"
+        assert "_saved_to" not in data
+
+
+@pytest.mark.asyncio
+class TestHandleAdaptWorkoutToTerrain:
+    """handle_adapt_workout_to_terrain tests."""
+
+    async def test_adapt_with_activity_id(self):
+        """Adapt workout using on-the-fly extraction."""
+        mock_client = MagicMock()
+        mock_client.get_activity.return_value = {"name": "Hill Loop"}
+        mock_client.get_activity_streams.return_value = _make_flat_streams(5)
+        mock_client.get_provider_info.return_value = {
+            "provider": "intervals_icu",
+            "athlete_id": "i42",
+            "status": "ready",
+        }
+
+        with patch(
+            "magma_cycling.config.create_intervals_client",
+            return_value=mock_client,
+        ):
+            result = await handle_adapt_workout_to_terrain(
+                {
+                    "activity_id": "i200",
+                    "workout": {"phases": [{"duration_min": 30, "power_pct": 88}]},
+                    "ftp_watts": 260,
+                }
+            )
+
+        data = _parse_response(result)
+        assert data["status"] == "success"
+        assert "adapted_workout" in data
+        adapted = data["adapted_workout"]
+        assert adapted["ftp_watts"] == 260
+        assert len(adapted["segments"]) > 0
+
+    async def test_adapt_with_circuit_id(self):
+        """Adapt workout using a saved circuit."""
+        from magma_cycling.terrain.models import (
+            GradeCategory,
+            TerrainCircuit,
+            TerrainSegment,
+        )
+
+        circuit = TerrainCircuit(
+            circuit_id="TC_test",
+            name="Test",
+            total_distance_km=3.0,
+            total_elevation_gain_m=0,
+            total_elevation_loss_m=0,
+            segments=[
+                TerrainSegment(
+                    km_index=i,
+                    distance_m=1000.0,
+                    elevation_start_m=100,
+                    elevation_end_m=100,
+                    elevation_gain_m=0,
+                    elevation_loss_m=0,
+                    grade_pct=0.0,
+                    grade_category=GradeCategory.plat,
+                )
+                for i in range(3)
+            ],
+        )
+
+        with patch(
+            "magma_cycling.terrain.storage.load_circuit",
+            return_value=circuit,
+        ):
+            result = await handle_adapt_workout_to_terrain(
+                {
+                    "circuit_id": "TC_test",
+                    "workout": "10min@65% + 20min@88%",
+                    "ftp_watts": 250,
+                }
+            )
+
+        data = _parse_response(result)
+        assert data["status"] == "success"
+
+    async def test_error_no_circuit_no_activity(self):
+        """Error when neither circuit_id nor activity_id provided."""
+        result = await handle_adapt_workout_to_terrain(
+            {
+                "workout": {"phases": [{"duration_min": 30, "power_pct": 88}]},
+                "ftp_watts": 260,
+            }
+        )
+
+        data = _parse_response(result)
+        assert "error" in data
+
+    async def test_error_circuit_not_found(self):
+        """Error when circuit_id does not exist."""
+        with patch(
+            "magma_cycling.terrain.storage.load_circuit",
+            return_value=None,
+        ):
+            result = await handle_adapt_workout_to_terrain(
+                {
+                    "circuit_id": "TC_nonexistent",
+                    "workout": {"phases": [{"duration_min": 30, "power_pct": 88}]},
+                    "ftp_watts": 260,
+                }
+            )
+
+        data = _parse_response(result)
+        assert "error" in data
+        assert "non trouve" in data["error"]

--- a/tests/test_terrain_adaptation.py
+++ b/tests/test_terrain_adaptation.py
@@ -1,0 +1,230 @@
+"""Tests for terrain workout adaptation."""
+
+import pytest
+
+from magma_cycling.terrain.adaptation import (
+    POWER_ADJUSTMENTS,
+    _estimate_speed_kmh,
+    _parse_workout_phases,
+    adapt_workout_to_terrain,
+)
+from magma_cycling.terrain.models import (
+    GearObservation,
+    GearProfile,
+    GradeCategory,
+    TerrainCircuit,
+    TerrainSegment,
+)
+
+
+def _make_circuit(
+    n_km: int = 5,
+    grade_pct: float = 0.0,
+    gear_profiles: list | None = None,
+) -> TerrainCircuit:
+    """Helper: build a uniform-grade circuit."""
+    category = GradeCategory.from_grade(grade_pct)
+    segments = [
+        TerrainSegment(
+            km_index=i,
+            distance_m=1000.0,
+            elevation_start_m=100.0 + i * grade_pct * 10,
+            elevation_end_m=100.0 + (i + 1) * grade_pct * 10,
+            elevation_gain_m=max(0, grade_pct * 10),
+            elevation_loss_m=max(0, -grade_pct * 10),
+            grade_pct=grade_pct,
+            grade_category=category,
+        )
+        for i in range(n_km)
+    ]
+    return TerrainCircuit(
+        circuit_id="TC_test",
+        name="Test Circuit",
+        total_distance_km=float(n_km),
+        total_elevation_gain_m=max(0, grade_pct * 10 * n_km),
+        total_elevation_loss_m=max(0, -grade_pct * 10 * n_km),
+        segments=segments,
+        gear_profiles=gear_profiles or [],
+    )
+
+
+class TestParseWorkoutPhases:
+    """_parse_workout_phases tests."""
+
+    def test_dict_with_phases(self):
+        workout = {
+            "phases": [
+                {"duration_min": 10, "power_pct": 65},
+                {"duration_min": 20, "power_pct": 88},
+            ]
+        }
+        phases = _parse_workout_phases(workout)
+        assert len(phases) == 2
+        assert phases[0]["power_pct"] == 65
+        assert phases[1]["duration_min"] == 20
+
+    def test_string_notation(self):
+        phases = _parse_workout_phases("10min@65% + 3x10min@88% + 10min@55%")
+        assert len(phases) == 5  # 1 + 3 + 1
+        assert phases[0]["power_pct"] == 65
+        assert phases[1]["power_pct"] == 88
+        assert phases[4]["power_pct"] == 55
+
+    def test_string_without_reps(self):
+        phases = _parse_workout_phases("15min@70%")
+        assert len(phases) == 1
+        assert phases[0]["duration_min"] == 15
+        assert phases[0]["power_pct"] == 70
+
+
+class TestEstimateSpeed:
+    """Speed estimation tests."""
+
+    def test_flat_reasonable_speed(self):
+        speed = _estimate_speed_kmh(200, 0.0, 70)
+        assert 25 < speed < 40  # Reasonable flat speed at 200W
+
+    def test_uphill_slower(self):
+        speed_flat = _estimate_speed_kmh(200, 0.0, 70)
+        speed_climb = _estimate_speed_kmh(200, 5.0, 70)
+        assert speed_climb < speed_flat
+
+    def test_downhill_faster(self):
+        speed_flat = _estimate_speed_kmh(200, 0.0, 70)
+        speed_down = _estimate_speed_kmh(200, -5.0, 70)
+        assert speed_down > speed_flat
+
+    def test_zero_power(self):
+        speed = _estimate_speed_kmh(0, 0.0, 70)
+        assert speed >= 5.0  # Minimum floor
+
+
+class TestAdaptWorkoutToTerrain:
+    """adapt_workout_to_terrain tests."""
+
+    def test_flat_terrain_no_adjustment(self):
+        """Flat terrain should not adjust power."""
+        circuit = _make_circuit(5, grade_pct=0.0)
+        workout = {"phases": [{"duration_min": 30, "power_pct": 88}]}
+
+        result = adapt_workout_to_terrain(
+            workout, circuit, ftp_watts=260, original_workout_name="SS Test"
+        )
+
+        assert result.workout_name == "SS Test"
+        assert result.circuit_id == "TC_test"
+        for seg in result.segments:
+            assert seg.power_adjustment_pct == 0.0
+            assert seg.adapted_power_pct == 88.0
+
+    def test_climb_reduces_power(self):
+        """Climbing terrain should reduce power."""
+        circuit = _make_circuit(3, grade_pct=3.0)
+        workout = {"phases": [{"duration_min": 30, "power_pct": 88}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260)
+
+        for seg in result.segments:
+            assert seg.power_adjustment_pct == POWER_ADJUSTMENTS[GradeCategory.montee]
+            assert seg.adapted_power_pct < 88.0
+
+    def test_steep_climb_adjustment(self):
+        """Steep climb applies -5% adjustment."""
+        circuit = _make_circuit(2, grade_pct=6.0)
+        workout = {"phases": [{"duration_min": 20, "power_pct": 90}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260)
+
+        for seg in result.segments:
+            assert seg.power_adjustment_pct == -5.0
+            assert seg.adapted_power_pct == 85.0
+
+    def test_descent_reduces_power(self):
+        """Descent applies -10% adjustment."""
+        circuit = _make_circuit(2, grade_pct=-3.0)
+        workout = {"phases": [{"duration_min": 20, "power_pct": 88}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260)
+
+        for seg in result.segments:
+            assert seg.power_adjustment_pct == -10.0
+            assert seg.adapted_power_pct == 78.0
+
+    def test_cadence_positive(self):
+        """Cadence values should be positive for all segments."""
+        circuit = _make_circuit(3, grade_pct=2.0)
+        workout = {"phases": [{"duration_min": 30, "power_pct": 88}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260)
+
+        for seg in result.segments:
+            assert seg.target_cadence_rpm > 0
+            assert seg.cadence_min_rpm <= seg.target_cadence_rpm
+            assert seg.target_cadence_rpm <= seg.cadence_max_rpm
+
+    def test_cadence_range_valid(self):
+        """Cadence min <= target <= max for all segments."""
+        circuit = _make_circuit(5, grade_pct=0.0)
+        workout = {"phases": [{"duration_min": 60, "power_pct": 75}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260)
+
+        for seg in result.segments:
+            assert seg.cadence_min_rpm <= seg.target_cadence_rpm <= seg.cadence_max_rpm
+
+    def test_tss_delta_tracked(self):
+        """Delta TSS is computed when original_tss provided."""
+        circuit = _make_circuit(5, grade_pct=0.0)
+        workout = {"phases": [{"duration_min": 60, "power_pct": 88}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260, original_tss=80)
+
+        # delta_tss should be estimated_tss - original_tss
+        assert result.delta_tss == pytest.approx(result.estimated_tss - 80, abs=0.2)
+
+    def test_gear_recommendations_from_profiles(self):
+        """Gear recommendations come from circuit gear_profiles."""
+        gear = GearObservation(front_teeth=34, rear_teeth=28, ratio=1.214, usage_pct=80.0)
+        profile = GearProfile(
+            grade_category=GradeCategory.montee,
+            primary_gear=gear,
+            avg_cadence_rpm=78.0,
+            avg_power_watts=220.0,
+        )
+        circuit = _make_circuit(3, grade_pct=3.0, gear_profiles=[profile])
+        workout = {"phases": [{"duration_min": 30, "power_pct": 88}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260)
+
+        for seg in result.segments:
+            assert seg.recommended_gear is not None
+            assert seg.recommended_gear.front_teeth == 34
+            assert seg.recommended_gear.rear_teeth == 28
+
+    def test_no_gear_profiles(self):
+        """Without gear profiles, recommended_gear is None."""
+        circuit = _make_circuit(3, grade_pct=0.0)
+        workout = {"phases": [{"duration_min": 30, "power_pct": 88}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260)
+
+        for seg in result.segments:
+            assert seg.recommended_gear is None
+
+    def test_instructions_present(self):
+        """Each segment has a non-empty instruction."""
+        circuit = _make_circuit(3, grade_pct=2.0)
+        workout = {"phases": [{"duration_min": 30, "power_pct": 88}]}
+
+        result = adapt_workout_to_terrain(workout, circuit, ftp_watts=260)
+
+        for seg in result.segments:
+            assert seg.instruction
+            assert "FTP" in seg.instruction
+            assert "rpm" in seg.instruction
+
+    def test_empty_workout(self):
+        """Empty workout produces warning."""
+        circuit = _make_circuit(3)
+        result = adapt_workout_to_terrain({"phases": []}, circuit, ftp_watts=260)
+        assert len(result.warnings) > 0

--- a/tests/test_terrain_extraction.py
+++ b/tests/test_terrain_extraction.py
@@ -1,0 +1,167 @@
+"""Tests for terrain extraction from activity streams."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from magma_cycling.terrain.extraction import (
+    classify_grade,
+    extract_terrain_from_activity,
+    extract_terrain_from_streams,
+)
+from magma_cycling.terrain.models import GradeCategory
+
+
+class TestClassifyGrade:
+    """Direct classify_grade tests."""
+
+    def test_flat(self):
+        assert classify_grade(0.0) == GradeCategory.plat
+
+    def test_climb(self):
+        assert classify_grade(3.0) == GradeCategory.montee
+
+    def test_steep_descent(self):
+        assert classify_grade(-6.0) == GradeCategory.descente_raide
+
+
+def _make_flat_streams(n_km: int = 5) -> list[dict]:
+    """Generate flat terrain streams (altitude constant at 100m)."""
+    n_points = n_km * 100  # 100 points per km
+    distances = [i * 10.0 for i in range(n_points)]  # 10m spacing
+    altitudes = [100.0] * n_points
+    return [
+        {"type": "distance", "data": distances},
+        {"type": "altitude", "data": altitudes},
+    ]
+
+
+def _make_climb_streams(n_km: int = 3, grade_pct: float = 5.0) -> list[dict]:
+    """Generate climbing terrain streams."""
+    n_points = n_km * 100
+    distances = [i * 10.0 for i in range(n_points)]
+    # grade = elevation_change / distance * 100
+    # elevation_change per 10m = grade_pct / 100 * 10 = grade_pct * 0.1
+    elev_per_step = grade_pct * 0.1
+    altitudes = [100.0 + i * elev_per_step for i in range(n_points)]
+    return [
+        {"type": "distance", "data": distances},
+        {"type": "altitude", "data": altitudes},
+    ]
+
+
+def _make_streams_with_gear(n_km: int = 3) -> list[dict]:
+    """Generate streams with gear data (climb on small ring)."""
+    n_points = n_km * 100
+    distances = [i * 10.0 for i in range(n_points)]
+    altitudes = [100.0 + i * 0.3 for i in range(n_points)]  # ~3% grade
+    front_gear = [34] * n_points  # Small chainring
+    rear_gear = [28] * n_points  # Large cog
+    cadence = [80.0] * n_points
+    watts = [200.0] * n_points
+    return [
+        {"type": "distance", "data": distances},
+        {"type": "altitude", "data": altitudes},
+        {"type": "FrontGear", "data": front_gear},
+        {"type": "RearGear", "data": rear_gear},
+        {"type": "cadence", "data": cadence},
+        {"type": "watts", "data": watts},
+    ]
+
+
+class TestExtractTerrainFromStreams:
+    """extract_terrain_from_streams tests."""
+
+    def test_flat_terrain(self):
+        """Flat streams produce flat-category segments."""
+        streams = _make_flat_streams(5)
+        circuit = extract_terrain_from_streams("i100", streams, activity_name="Flat")
+
+        assert circuit.circuit_id == "TC_i100"
+        assert circuit.name == "Flat"
+        assert circuit.source_type == "activity"
+        assert len(circuit.segments) >= 4
+        for seg in circuit.segments:
+            assert seg.grade_category == GradeCategory.plat
+            assert abs(seg.grade_pct) <= 0.5
+
+    def test_climb_terrain(self):
+        """Climbing streams produce montee_raide segments."""
+        streams = _make_climb_streams(3, grade_pct=6.0)
+        circuit = extract_terrain_from_streams("i200", streams)
+
+        assert len(circuit.segments) >= 2
+        for seg in circuit.segments:
+            assert seg.grade_category == GradeCategory.montee_raide
+            assert seg.grade_pct > 4.0
+        assert circuit.total_elevation_gain_m > 0
+
+    def test_no_gear_streams(self):
+        """Without gear streams, gear_profiles is empty."""
+        streams = _make_flat_streams(3)
+        circuit = extract_terrain_from_streams("i300", streams)
+        assert circuit.gear_profiles == []
+
+    def test_with_gear_streams(self):
+        """With gear streams, gear_profiles are populated."""
+        streams = _make_streams_with_gear(3)
+        circuit = extract_terrain_from_streams("i400", streams)
+
+        assert len(circuit.gear_profiles) > 0
+        profile = circuit.gear_profiles[0]
+        assert profile.primary_gear.front_teeth == 34
+        assert profile.primary_gear.rear_teeth == 28
+        assert profile.avg_cadence_rpm > 0
+        assert profile.avg_power_watts > 0
+
+    def test_missing_altitude_raises(self):
+        """Missing altitude stream raises ValueError."""
+        streams = [{"type": "distance", "data": [0, 100, 200]}]
+        with pytest.raises(ValueError, match="altitude"):
+            extract_terrain_from_streams("i500", streams)
+
+    def test_missing_distance_raises(self):
+        """Missing distance stream raises ValueError."""
+        streams = [{"type": "altitude", "data": [100, 101, 102]}]
+        with pytest.raises(ValueError, match="distance"):
+            extract_terrain_from_streams("i600", streams)
+
+    def test_mismatched_lengths_raises(self):
+        """Mismatched stream lengths raise ValueError."""
+        streams = [
+            {"type": "distance", "data": [0, 100, 200]},
+            {"type": "altitude", "data": [100, 101]},
+        ]
+        with pytest.raises(ValueError, match="same length"):
+            extract_terrain_from_streams("i700", streams)
+
+    def test_total_distance(self):
+        """Total distance is computed correctly."""
+        streams = _make_flat_streams(10)
+        circuit = extract_terrain_from_streams("i800", streams)
+        # 10 km of streams, expect close to 10 km total
+        assert 9.0 <= circuit.total_distance_km <= 10.5
+
+    def test_segment_distance(self):
+        """Each segment is approximately 1000m."""
+        streams = _make_flat_streams(5)
+        circuit = extract_terrain_from_streams("i900", streams)
+        for seg in circuit.segments:
+            assert 900 <= seg.distance_m <= 1100
+
+
+class TestExtractTerrainFromActivity:
+    """extract_terrain_from_activity wrapper tests."""
+
+    def test_delegates_to_streams(self):
+        """Wrapper calls client methods and delegates to stream extraction."""
+        mock_client = MagicMock()
+        mock_client.get_activity.return_value = {"name": "Morning Ride"}
+        mock_client.get_activity_streams.return_value = _make_flat_streams(3)
+
+        circuit = extract_terrain_from_activity(mock_client, "i999")
+
+        mock_client.get_activity.assert_called_once_with("i999")
+        mock_client.get_activity_streams.assert_called_once_with("i999")
+        assert circuit.circuit_id == "TC_i999"
+        assert circuit.name == "Morning Ride"

--- a/tests/test_terrain_models.py
+++ b/tests/test_terrain_models.py
@@ -1,0 +1,222 @@
+"""Tests for terrain models."""
+
+import json
+
+import pytest
+
+from magma_cycling.terrain.models import (
+    AdaptedSegment,
+    AdaptedWorkout,
+    GearObservation,
+    GearProfile,
+    GradeCategory,
+    TerrainCircuit,
+    TerrainSegment,
+)
+
+
+class TestGradeCategory:
+    """GradeCategory.from_grade() classification tests."""
+
+    @pytest.mark.parametrize(
+        "grade, expected",
+        [
+            (-10.0, GradeCategory.descente_raide),
+            (-4.1, GradeCategory.descente_raide),
+            (-4.0, GradeCategory.descente),
+            (-2.0, GradeCategory.descente),
+            (-1.5, GradeCategory.faux_plat_descendant),
+            (-1.0, GradeCategory.faux_plat_descendant),
+            (-0.5, GradeCategory.plat),
+            (0.0, GradeCategory.plat),
+            (0.5, GradeCategory.plat),
+            (0.6, GradeCategory.faux_plat_montant),
+            (1.5, GradeCategory.faux_plat_montant),
+            (1.6, GradeCategory.montee),
+            (4.0, GradeCategory.montee),
+            (4.1, GradeCategory.montee_raide),
+            (12.0, GradeCategory.montee_raide),
+        ],
+    )
+    def test_from_grade(self, grade, expected):
+        """Verify grade classification across all 7 categories and boundaries."""
+        assert GradeCategory.from_grade(grade) == expected
+
+    def test_all_categories_reachable(self):
+        """Every category is reachable via from_grade."""
+        grades = [-10, -3, -1, 0, 1, 3, 8]
+        categories = {GradeCategory.from_grade(g) for g in grades}
+        assert categories == set(GradeCategory)
+
+
+class TestGearObservation:
+    """GearObservation validation tests."""
+
+    def test_valid_gear(self):
+        """Valid gear observation with brand-agnostic fields only."""
+        gear = GearObservation(front_teeth=34, rear_teeth=28, ratio=1.214, usage_pct=65.0)
+        assert gear.front_teeth == 34
+        assert gear.rear_teeth == 28
+        assert gear.ratio == 1.214
+        assert gear.usage_pct == 65.0
+
+    def test_no_brand_fields(self):
+        """GearObservation has no brand-specific fields."""
+        fields = set(GearObservation.model_fields.keys())
+        assert fields == {"front_teeth", "rear_teeth", "ratio", "usage_pct"}
+
+    def test_invalid_teeth(self):
+        """Reject zero or negative teeth count."""
+        with pytest.raises(Exception):
+            GearObservation(front_teeth=0, rear_teeth=28, ratio=1.0, usage_pct=50.0)
+
+    def test_invalid_usage_pct(self):
+        """Reject usage outside 0-100 range."""
+        with pytest.raises(Exception):
+            GearObservation(front_teeth=50, rear_teeth=11, ratio=4.5, usage_pct=101.0)
+
+
+class TestTerrainCircuit:
+    """TerrainCircuit roundtrip and validation."""
+
+    @pytest.fixture
+    def sample_circuit(self):
+        """Build a minimal TerrainCircuit."""
+        return TerrainCircuit(
+            circuit_id="TC_i123456",
+            name="Test Circuit",
+            source_type="activity",
+            source_activity_id="i123456",
+            total_distance_km=5.0,
+            total_elevation_gain_m=120.0,
+            total_elevation_loss_m=110.0,
+            segments=[
+                TerrainSegment(
+                    km_index=0,
+                    distance_m=1000.0,
+                    elevation_start_m=100.0,
+                    elevation_end_m=130.0,
+                    elevation_gain_m=30.0,
+                    elevation_loss_m=0.0,
+                    grade_pct=3.0,
+                    grade_category=GradeCategory.montee,
+                ),
+                TerrainSegment(
+                    km_index=1,
+                    distance_m=1000.0,
+                    elevation_start_m=130.0,
+                    elevation_end_m=125.0,
+                    elevation_gain_m=0.0,
+                    elevation_loss_m=5.0,
+                    grade_pct=-0.5,
+                    grade_category=GradeCategory.plat,
+                ),
+            ],
+            gear_profiles=[
+                GearProfile(
+                    grade_category=GradeCategory.montee,
+                    primary_gear=GearObservation(
+                        front_teeth=34, rear_teeth=28, ratio=1.214, usage_pct=70.0
+                    ),
+                    avg_cadence_rpm=78.0,
+                    avg_power_watts=220.0,
+                ),
+            ],
+        )
+
+    def test_json_roundtrip(self, sample_circuit):
+        """Serialize to JSON and back without data loss."""
+        json_str = sample_circuit.model_dump_json()
+        parsed = json.loads(json_str)
+        restored = TerrainCircuit.model_validate(parsed)
+        assert restored == sample_circuit
+
+    def test_source_types(self):
+        """Validate all three source types are accepted."""
+        for src in ("activity", "gpx", "manual"):
+            circuit = TerrainCircuit(
+                circuit_id="TC_test",
+                source_type=src,
+                total_distance_km=1.0,
+                total_elevation_gain_m=0,
+                total_elevation_loss_m=0,
+            )
+            assert circuit.source_type == src
+
+    def test_invalid_source_type(self):
+        """Reject unknown source type."""
+        with pytest.raises(Exception):
+            TerrainCircuit(
+                circuit_id="TC_test",
+                source_type="unknown",
+                total_distance_km=1.0,
+                total_elevation_gain_m=0,
+                total_elevation_loss_m=0,
+            )
+
+
+class TestAdaptedWorkout:
+    """AdaptedWorkout validation tests."""
+
+    def test_basic_adapted_workout(self):
+        """Create a valid adapted workout with segments."""
+        workout = AdaptedWorkout(
+            workout_name="Sweet Spot Terrain",
+            circuit_id="TC_i123456",
+            ftp_watts=260,
+            segments=[
+                AdaptedSegment(
+                    km_index=0,
+                    terrain_grade_pct=3.0,
+                    terrain_category=GradeCategory.montee,
+                    original_power_pct=88.0,
+                    adapted_power_pct=85.4,
+                    power_adjustment_pct=-3.0,
+                    target_cadence_rpm=88,
+                    cadence_min_rpm=83,
+                    cadence_max_rpm=93,
+                    instruction="km 0-1 : Montee 3% — Sweet Spot adapte 85% FTP",
+                ),
+            ],
+            estimated_tss=75.0,
+            original_tss=80.0,
+            delta_tss=-5.0,
+            warnings=["Descente raide km 5: pedalage leger recommande"],
+        )
+        assert workout.ftp_watts == 260
+        assert len(workout.segments) == 1
+        assert workout.segments[0].power_adjustment_pct == -3.0
+        assert workout.delta_tss == -5.0
+
+    def test_adapted_segment_with_gear(self):
+        """AdaptedSegment can include a gear recommendation."""
+        gear = GearObservation(front_teeth=34, rear_teeth=28, ratio=1.214, usage_pct=70.0)
+        seg = AdaptedSegment(
+            km_index=2,
+            terrain_grade_pct=5.5,
+            terrain_category=GradeCategory.montee_raide,
+            original_power_pct=88.0,
+            adapted_power_pct=83.6,
+            power_adjustment_pct=-5.0,
+            target_cadence_rpm=85,
+            cadence_min_rpm=80,
+            cadence_max_rpm=90,
+            recommended_gear=gear,
+        )
+        assert seg.recommended_gear is not None
+        assert seg.recommended_gear.front_teeth == 34
+
+    def test_adapted_segment_without_gear(self):
+        """AdaptedSegment works without gear recommendation."""
+        seg = AdaptedSegment(
+            km_index=0,
+            terrain_grade_pct=0.0,
+            terrain_category=GradeCategory.plat,
+            original_power_pct=88.0,
+            adapted_power_pct=88.0,
+            power_adjustment_pct=0.0,
+            target_cadence_rpm=92,
+            cadence_min_rpm=87,
+            cadence_max_rpm=97,
+        )
+        assert seg.recommended_gear is None


### PR DESCRIPTION
## Summary

- New `terrain/` package: extract terrain profiles from past activities (altitude + distance streams), classify per-km segments by grade category (7 categories from steep descent to steep climb)
- Adapt structured workouts with power adjustment (-15% to 0%), Grappe-based cadence optimization, and gear recommendations from observed activity data
- YAML persistence for reusable terrain circuits in `~/training-logs/data/terrain_circuits/`
- 2 new MCP tools: `extract-terrain-circuit` and `adapt-workout-to-terrain`

## Architecture

```
terrain/
  __init__.py       # docstring
  models.py         # 7 Pydantic v2 models (GradeCategory, TerrainCircuit, AdaptedWorkout...)
  extraction.py     # Streams → TerrainCircuit (per-km, gear profiles)
  adaptation.py     # Workout × Circuit → AdaptedWorkout (power/cadence/gear)
  storage.py        # YAML persistence
```

## Test plan

- [x] 26 model tests (grade classification boundaries, JSON roundtrip, validation)
- [x] 13 extraction tests (flat/climb streams, gear profiles, error cases)
- [x] 18 adaptation tests (power adjustments, cadence biomechanics, gear recommendations)
- [x] 6 MCP handler tests (extract, adapt, error paths)
- [x] Full test suite: 3149 passed, 0 failed
- [x] Pre-commit hooks: all passing
- [ ] MCP manual test: `extract-terrain-circuit` with activity `i131572602`
- [ ] MCP manual test: `adapt-workout-to-terrain` with saved circuit + Sweet Spot workout

🤖 Generated with [Claude Code](https://claude.com/claude-code)