### PR TITLE
feat(terrain): add list-terrain-circuits MCP tool

### DIFF
--- a/magma_cycling/_mcp/handlers/terrain.py
+++ b/magma_cycling/_mcp/handlers/terrain.py
@@ -105,3 +105,23 @@ async def handle_adapt_workout_to_terrain(args: dict) -> list[TextContent]:
 
     except Exception as e:
         return mcp_response({"error": f"Adaptation failed: {e}"})
+
+
+async def handle_list_terrain_circuits(args: dict) -> list[TextContent]:
+    """List all saved terrain circuits."""
+    try:
+        with suppress_stdout_stderr():
+            from magma_cycling.terrain.storage import list_circuits
+
+            circuits = list_circuits()
+
+        return mcp_response(
+            {
+                "status": "success",
+                "count": len(circuits),
+                "circuits": circuits,
+            }
+        )
+
+    except Exception as e:
+        return mcp_response({"error": f"List circuits failed: {e}"})

--- a/magma_cycling/_mcp/schemas/terrain.py
+++ b/magma_cycling/_mcp/schemas/terrain.py
@@ -92,4 +92,16 @@ def get_tools() -> list[Tool]:
                 "required": ["workout", "ftp_watts"],
             },
         ),
+        Tool(
+            name="list-terrain-circuits",
+            description=(
+                "Liste les circuits terrain sauvegardes. "
+                "Retourne id, nom, distance et denivele de chaque circuit."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
     ]

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -104,6 +104,7 @@ from magma_cycling._mcp.handlers.sessions import (  # noqa: F401
 from magma_cycling._mcp.handlers.terrain import (  # noqa: F401
     handle_adapt_workout_to_terrain,
     handle_extract_terrain_circuit,
+    handle_list_terrain_circuits,
 )
 from magma_cycling._mcp.handlers.workouts import (  # noqa: F401
     handle_get_workout,
@@ -220,8 +221,9 @@ TOOL_HANDLERS = {
     # Rest / Recovery (2)
     "pre-session-check": handle_pre_session_check,
     "patch-coach-analysis": handle_patch_coach_analysis,
-    # Terrain (2)
+    # Terrain (3)
     "extract-terrain-circuit": handle_extract_terrain_circuit,
+    "list-terrain-circuits": handle_list_terrain_circuits,
     "adapt-workout-to-terrain": handle_adapt_workout_to_terrain,
 }
 

--- a/tests/test_mcp_terrain.py
+++ b/tests/test_mcp_terrain.py
@@ -8,6 +8,7 @@ import pytest
 from magma_cycling._mcp.handlers.terrain import (
     handle_adapt_workout_to_terrain,
     handle_extract_terrain_circuit,
+    handle_list_terrain_circuits,
 )
 
 
@@ -189,3 +190,49 @@ class TestHandleAdaptWorkoutToTerrain:
         data = _parse_response(result)
         assert "error" in data
         assert "non trouve" in data["error"]
+
+
+@pytest.mark.asyncio
+class TestHandleListTerrainCircuits:
+    """handle_list_terrain_circuits tests."""
+
+    async def test_list_empty(self):
+        """Empty list when no circuits saved."""
+        with patch(
+            "magma_cycling.terrain.storage.list_circuits",
+            return_value=[],
+        ):
+            result = await handle_list_terrain_circuits({})
+
+        data = _parse_response(result)
+        assert data["status"] == "success"
+        assert data["count"] == 0
+        assert data["circuits"] == []
+
+    async def test_list_with_circuits(self):
+        """List returns saved circuits."""
+        mock_circuits = [
+            {
+                "id": "TC_i131572602",
+                "name": "Boucle Sud",
+                "distance_km": 77.4,
+                "elevation_gain_m": 486,
+            },
+            {
+                "id": "TC_i999",
+                "name": "Col Test",
+                "distance_km": 12.0,
+                "elevation_gain_m": 650,
+            },
+        ]
+        with patch(
+            "magma_cycling.terrain.storage.list_circuits",
+            return_value=mock_circuits,
+        ):
+            result = await handle_list_terrain_circuits({})
+
+        data = _parse_response(result)
+        assert data["status"] == "success"
+        assert data["count"] == 2
+        assert data["circuits"][0]["id"] == "TC_i131572602"
+        assert data["circuits"][1]["distance_km"] == 12.0


### PR DESCRIPTION
## Summary

- New MCP tool `list-terrain-circuits` exposing `storage.list_circuits()`
- Returns id, name, distance_km, elevation_gain_m for each saved circuit
- No parameters required
- Terrain tools are now 3: extract, adapt, list

## Test plan

- [x] 2 new tests: empty list + list with circuits
- [x] Live test: returns TC_i131572602 (77.4 km, D+486m)
- [x] Full suite: 3151 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)