### PR TITLE
feat(terrain): add optional name parameter to extract-terrain-circuit

### DIFF
--- a/magma_cycling/_mcp/handlers/terrain.py
+++ b/magma_cycling/_mcp/handlers/terrain.py
@@ -23,6 +23,9 @@ async def handle_extract_terrain_circuit(args: dict) -> list[TextContent]:
 
             circuit = extract_terrain_from_activity(client, activity_id)
 
+            if name := args.get("name"):
+                circuit.name = name
+
             saved_path = None
             if should_save:
                 saved_path = save_circuit(circuit)

--- a/magma_cycling/_mcp/schemas/terrain.py
+++ b/magma_cycling/_mcp/schemas/terrain.py
@@ -25,6 +25,10 @@ def get_tools() -> list[Tool]:
                         "description": ("Sauvegarder le circuit en YAML (defaut: true)"),
                         "default": True,
                     },
+                    "name": {
+                        "type": "string",
+                        "description": "Nom du circuit (optionnel, ecrase le nom auto-genere)",
+                    },
                 },
                 "required": ["activity_id"],
             },

--- a/tests/test_mcp_terrain.py
+++ b/tests/test_mcp_terrain.py
@@ -61,6 +61,35 @@ class TestHandleExtractTerrainCircuit:
         assert "_metadata" in data
         assert data["_metadata"]["provider"]["provider"] == "intervals_icu"
 
+    async def test_extract_with_custom_name(self, tmp_path):
+        """Extract circuit with custom name overriding auto-generated one."""
+        mock_client = MagicMock()
+        mock_client.get_activity.return_value = {"name": "S084-04-END-EnduranceLongue-V001"}
+        mock_client.get_activity_streams.return_value = _make_flat_streams(5)
+        mock_client.get_provider_info.return_value = {
+            "provider": "intervals_icu",
+            "athlete_id": "i42",
+            "status": "ready",
+        }
+
+        with (
+            patch(
+                "magma_cycling.config.create_intervals_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "magma_cycling.terrain.storage.save_circuit",
+                return_value=tmp_path / "TC_i131572602.yaml",
+            ),
+        ):
+            result = await handle_extract_terrain_circuit(
+                {"activity_id": "i131572602", "name": "Boucle Sud Chas-Billom"}
+            )
+
+        data = _parse_response(result)
+        assert data["status"] == "success"
+        assert data["circuit"]["name"] == "Boucle Sud Chas-Billom"
+
     async def test_extract_no_save(self):
         """Extract without saving."""
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary
- Ajout d'un paramètre `name` optionnel au tool MCP `extract-terrain-circuit`
- Permet de nommer un circuit à l'extraction au lieu d'hériter du nom de la session source
- Améliore la lisibilité de `list-terrain-circuits` pour une bibliothèque de circuits à long terme

## Changements
- `schemas/terrain.py` : ajout propriété `name` (string, optionnel)
- `handlers/terrain.py` : écrasement du nom auto-généré si `name` fourni
- `tests/test_mcp_terrain.py` : test avec nom custom vérifiant l'override

## Test plan
- [x] Test unitaire `test_extract_with_custom_name` ajouté
- [x] Suite complète 2982 passed, 0 failed
- [x] Pre-commit 15/15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)