### PR TITLE
fix(terrain): exclude descent segments from compliance

### DIFF
--- a/magma_cycling/config/athlete_context.yaml
+++ b/magma_cycling/config/athlete_context.yaml
@@ -9,6 +9,12 @@ athlete:
     - "Travail terrain (technicien telecom), fatigue physique variable selon chantiers"
     - "Horaires irreguliers impactant regularite entrainement"
     - "Recuperation plus lente (54 ans) - adapter progressivite"
+  bike_setup:
+    groupe: "Shimano Ultegra Di2 R8100 12v"
+    plateaux: [50, 34]
+    cassette: "CS-R8100-12 11-30T"
+    pignons: [11, 12, 13, 14, 15, 17, 19, 21, 24, 27, 30]
+    grand_pignon_limite: 30  # confirme par streams RearGearIndex, usage soutenu sur raidillons ~12%
   system_context: >
     L'athlete utilise un systeme integre avec planification hebdomadaire
     automatisee, suivi sante (sommeil, poids, readiness) et coaching IA

--- a/magma_cycling/terrain/evaluation.py
+++ b/magma_cycling/terrain/evaluation.py
@@ -13,6 +13,13 @@ from magma_cycling.terrain.models import (
     SegmentExecution,
 )
 
+# Descent categories excluded from compliance calculations.
+# Rationale: terrain forces coasting or free-spinning on descents;
+# cadence/gear discipline is not meaningful there.
+_DESCENT_CATEGORIES: frozenset[GradeCategory] = frozenset(
+    {GradeCategory.descente_raide, GradeCategory.descente}
+)
+
 # Grade category labels for French recommendations
 _CATEGORY_LABELS: dict[GradeCategory, str] = {
     GradeCategory.descente_raide: "descente raide",
@@ -225,22 +232,27 @@ def evaluate_outdoor_execution(
             )
             evaluations.append(evaluation)
 
-    # Step 3: Compute summary metrics
+    # Step 3: Compute summary metrics — exclude descent segments
     total = len(evaluations)
-    cadence_ok = sum(1 for e in evaluations if e.cadence_in_range) if total else 0
-    cadence_compliance_pct = round(cadence_ok / total * 100, 1) if total else 100.0
+    counted = [e for e in evaluations if e.terrain_category not in _DESCENT_CATEGORIES]
+    excluded = total - len(counted)
 
-    gear_evaluated = [e for e in evaluations if e.gear_match is not None]
+    cadence_ok = sum(1 for e in counted if e.cadence_in_range) if counted else 0
+    cadence_compliance_pct = round(cadence_ok / len(counted) * 100, 1) if counted else 100.0
+
+    gear_evaluated = [e for e in counted if e.gear_match is not None]
     gear_ok = sum(1 for e in gear_evaluated if e.gear_match)
     gear_compliance_pct = round(gear_ok / len(gear_evaluated) * 100, 1) if gear_evaluated else 100.0
 
     overall_compliance = _compute_overall_compliance(cadence_compliance_pct, gear_compliance_pct)
 
     # Step 4: Generate summary
-    summary = _generate_summary(total, cadence_ok, len(gear_evaluated), gear_ok, overall_compliance)
+    summary = _generate_summary(
+        len(counted), cadence_ok, len(gear_evaluated), gear_ok, overall_compliance, excluded
+    )
 
-    # Step 5: Generate recommendations
-    recommendations = _generate_recommendations(evaluations)
+    # Step 5: Generate recommendations (only from counted segments)
+    recommendations = _generate_recommendations(counted)
 
     return ExecutionEvaluation(
         activity_id=activity_id or adapted_workout.workout_name,
@@ -249,6 +261,7 @@ def evaluate_outdoor_execution(
         ftp_watts=ftp_watts,
         segment_evaluations=evaluations,
         segments_evaluated=total,
+        segments_excluded=excluded,
         cadence_compliance_pct=cadence_compliance_pct,
         gear_compliance_pct=gear_compliance_pct,
         overall_compliance=overall_compliance,
@@ -437,15 +450,17 @@ def _generate_summary(
     gear_evaluated: int,
     gear_ok: int,
     overall: str,
+    excluded: int = 0,
 ) -> str:
     """Generate a French summary of the evaluation.
 
     Args:
-        total: Total segments evaluated.
+        total: Total counted segments (excluding descents).
         cadence_ok: Segments with cadence in range.
         gear_evaluated: Segments where gear was evaluated.
         gear_ok: Segments with correct gear.
         overall: Overall compliance level.
+        excluded: Number of descent segments excluded from compliance.
 
     Returns:
         Human-readable summary in French.
@@ -461,6 +476,8 @@ def _generate_summary(
     parts = [
         f"Evaluation terrain: {cadence_ok}/{total} segments conformes en cadence",
     ]
+    if excluded > 0:
+        parts.append(f"{excluded} segment(s) de descente exclus")
     if gear_evaluated > 0:
         parts.append(f"{gear_ok}/{gear_evaluated} conformes en braquet")
     else:

--- a/magma_cycling/terrain/models.py
+++ b/magma_cycling/terrain/models.py
@@ -176,6 +176,11 @@ class ExecutionEvaluation(BaseModel):
     segment_evaluations: list[SegmentEvaluation] = Field(default_factory=list)
     # Summary metrics
     segments_evaluated: int = Field(..., ge=0)
+    segments_excluded: int = Field(
+        default=0,
+        ge=0,
+        description="Segments excluded from compliance (descent segments)",
+    )
     cadence_compliance_pct: float = Field(
         ..., ge=0, le=100, description="Pct of segments with cadence in range"
     )

--- a/tests/test_terrain_evaluation.py
+++ b/tests/test_terrain_evaluation.py
@@ -605,3 +605,218 @@ class TestEvaluateOutdoorExecution:
 
         recs_text = " ".join(result.recommendations)
         assert "braquet" in recs_text.lower()
+
+    def test_descent_segments_excluded_from_compliance(self):
+        """Descent segments are evaluated but excluded from compliance %."""
+        n_km = 5
+        points_per_km = 100
+        n_points = n_km * points_per_km
+        step_m = 1000.0 / points_per_km
+
+        distance = [i * step_m for i in range(n_points)]
+        watts_data = [200.0] * n_points
+        # All 5 km at cadence 90 (in range for flat, but we make descent
+        # segments have cadence 50 — far from target — to prove they
+        # don't affect compliance)
+        cadence_data = [90.0] * (3 * points_per_km) + [50.0] * (  # km 0-2: flat, in range
+            2 * points_per_km
+        )  # km 3-4: descent, way off
+
+        streams = [
+            {"type": "distance", "data": distance},
+            {"type": "watts", "data": watts_data},
+            {"type": "cadence", "data": cadence_data},
+        ]
+
+        segments = [
+            # 3 flat segments — cadence 90 in [85,95] → compliant
+            *[
+                _make_adapted_segment(
+                    km_index=i,
+                    grade_pct=0.0,
+                    category=GradeCategory.plat,
+                    target_cadence=90,
+                    cadence_min=85,
+                    cadence_max=95,
+                )
+                for i in range(3)
+            ],
+            # 2 descent segments — cadence 50 far from target but excluded
+            *[
+                _make_adapted_segment(
+                    km_index=i,
+                    grade_pct=-6.0,
+                    category=GradeCategory.descente_raide,
+                    target_cadence=90,
+                    cadence_min=85,
+                    cadence_max=95,
+                )
+                for i in range(3, 5)
+            ],
+        ]
+        workout = _make_adapted_workout(segments=segments)
+
+        result = evaluate_outdoor_execution(streams, workout)
+
+        # All 5 segments are evaluated and present in detail
+        assert result.segments_evaluated == 5
+        assert len(result.segment_evaluations) == 5
+        # But only 3 flat segments count for compliance
+        assert result.segments_excluded == 2
+        # 3/3 flat segments have cadence in range → 100%
+        assert result.cadence_compliance_pct == 100.0
+        assert result.overall_compliance == "excellent"
+        # Summary mentions excluded segments
+        assert "descente exclus" in result.summary
+
+    def test_descent_hors_cible_does_not_lower_verdict(self):
+        """A ride with perfect flat + bad descent stays excellent."""
+        n_km = 4
+        points_per_km = 100
+        n_points = n_km * points_per_km
+        step_m = 1000.0 / points_per_km
+
+        distance = [i * step_m for i in range(n_points)]
+        watts_data = [200.0] * n_points
+        # km 0-1: flat at 90 rpm (good), km 2-3: descent at 110 rpm (hors_cible)
+        cadence_data = [90.0] * (2 * points_per_km) + [110.0] * (2 * points_per_km)
+
+        streams = [
+            {"type": "distance", "data": distance},
+            {"type": "watts", "data": watts_data},
+            {"type": "cadence", "data": cadence_data},
+        ]
+
+        segments = [
+            _make_adapted_segment(
+                km_index=0,
+                grade_pct=0.0,
+                category=GradeCategory.plat,
+                target_cadence=90,
+                cadence_min=85,
+                cadence_max=95,
+            ),
+            _make_adapted_segment(
+                km_index=1,
+                grade_pct=0.0,
+                category=GradeCategory.plat,
+                target_cadence=90,
+                cadence_min=85,
+                cadence_max=95,
+            ),
+            _make_adapted_segment(
+                km_index=2,
+                grade_pct=-5.0,
+                category=GradeCategory.descente_raide,
+                target_cadence=75,
+                cadence_min=70,
+                cadence_max=80,
+            ),
+            _make_adapted_segment(
+                km_index=3,
+                grade_pct=-2.0,
+                category=GradeCategory.descente,
+                target_cadence=80,
+                cadence_min=75,
+                cadence_max=85,
+            ),
+        ]
+        workout = _make_adapted_workout(segments=segments)
+
+        result = evaluate_outdoor_execution(streams, workout)
+
+        assert result.segments_evaluated == 4
+        assert result.segments_excluded == 2
+        # Only flat segments count: 2/2 compliant → excellent
+        assert result.cadence_compliance_pct == 100.0
+        assert result.overall_compliance == "excellent"
+
+    def test_descent_recommendations_not_generated(self):
+        """No cadence recommendation generated for descent failures."""
+        n_km = 3
+        points_per_km = 100
+        n_points = n_km * points_per_km
+        step_m = 1000.0 / points_per_km
+
+        distance = [i * step_m for i in range(n_points)]
+        watts_data = [200.0] * n_points
+        # km 0: flat OK, km 1-2: descent with bad cadence
+        cadence_data = [90.0] * points_per_km + [50.0] * (2 * points_per_km)
+
+        streams = [
+            {"type": "distance", "data": distance},
+            {"type": "watts", "data": watts_data},
+            {"type": "cadence", "data": cadence_data},
+        ]
+
+        segments = [
+            _make_adapted_segment(
+                km_index=0,
+                grade_pct=0.0,
+                category=GradeCategory.plat,
+                target_cadence=90,
+                cadence_min=85,
+                cadence_max=95,
+            ),
+            _make_adapted_segment(
+                km_index=1,
+                grade_pct=-5.0,
+                category=GradeCategory.descente_raide,
+                target_cadence=80,
+                cadence_min=75,
+                cadence_max=85,
+            ),
+            _make_adapted_segment(
+                km_index=2,
+                grade_pct=-2.0,
+                category=GradeCategory.descente,
+                target_cadence=80,
+                cadence_min=75,
+                cadence_max=85,
+            ),
+        ]
+        workout = _make_adapted_workout(segments=segments)
+
+        result = evaluate_outdoor_execution(streams, workout)
+
+        # No recommendations — the flat segment is compliant,
+        # and descent failures are not counted
+        assert len(result.recommendations) == 0
+
+    def test_all_descent_segments_100pct(self):
+        """A ride with only descent segments gives 100% compliance."""
+        n_km = 3
+        points_per_km = 100
+        n_points = n_km * points_per_km
+        step_m = 1000.0 / points_per_km
+
+        distance = [i * step_m for i in range(n_points)]
+        watts_data = [100.0] * n_points
+        cadence_data = [50.0] * n_points  # Low cadence, doesn't matter
+
+        streams = [
+            {"type": "distance", "data": distance},
+            {"type": "watts", "data": watts_data},
+            {"type": "cadence", "data": cadence_data},
+        ]
+
+        segments = [
+            _make_adapted_segment(
+                km_index=i,
+                grade_pct=-6.0,
+                category=GradeCategory.descente_raide,
+                target_cadence=80,
+                cadence_min=75,
+                cadence_max=85,
+            )
+            for i in range(3)
+        ]
+        workout = _make_adapted_workout(segments=segments)
+
+        result = evaluate_outdoor_execution(streams, workout)
+
+        assert result.segments_evaluated == 3
+        assert result.segments_excluded == 3
+        # No counted segments → defaults to 100%
+        assert result.cadence_compliance_pct == 100.0
+        assert result.overall_compliance == "excellent"


### PR DESCRIPTION
## Summary

- Descent segments (`descente_raide`, `descente`) are now excluded from cadence/gear compliance percentages and recommendations — terrain forces coasting or free-spinning on descents, evaluating discipline there penalizes correct behavior
- Segments remain in `segment_evaluations` detail for informational purposes
- New `segments_excluded` field in `ExecutionEvaluation` for traceability
- Summary message mentions excluded descent segments
- Adds `bike_setup` section to `athlete_context.yaml` (Ultegra Di2 R8100, cassette CS-R8100-12 11-30T confirmed from real stream data)

## Rationale

Identified by Claude Desktop: on a hilly course with 20% descent km, a cyclist coasting at 100 rpm on descents (correct behavior) could see their compliance drop from "excellent" to "bon" because descent segments were counted equally in the compliance calculation.

## Test plan

- [x] 4 new tests covering descent exclusion scenarios
- [x] `test_descent_segments_excluded_from_compliance` — 3 flat + 2 descent segments, only flat count
- [x] `test_descent_hors_cible_does_not_lower_verdict` — perfect flat + bad descent stays excellent
- [x] `test_descent_recommendations_not_generated` — no recs for excluded descent failures
- [x] `test_all_descent_segments_100pct` — all-descent ride defaults to 100%
- [x] All 26 evaluation tests pass, all 12 MCP terrain tests pass
- [x] Full suite: 3181 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)