### PR TITLE
fix(intelligence): reduce prompt noise from 158K to ~30K chars

### DIFF
--- a/magma_cycling/intelligence/training_intelligence.py
+++ b/magma_cycling/intelligence/training_intelligence.py
@@ -351,9 +351,10 @@ class TrainingIntelligence:
                 break
 
         if existing_id:
-            # Update existing learning
+            # Update existing learning (deduplicate evidence)
             learning = self.learnings[existing_id]
-            learning.evidence.extend(evidence)
+            existing_evidence = set(learning.evidence)
+            learning.evidence.extend(e for e in evidence if e not in existing_evidence)
 
             # Auto-promote confidence based on evidence count
             evidence_count = len(learning.evidence)
@@ -495,9 +496,16 @@ class TrainingIntelligence:
             ...     evidence=["S024-05: 6.2h sleep, VO2 RPE 9"]
             ... )
         """
-        timestamp = int(datetime.now().timestamp())
-
-        adaptation_id = f"{protocol_name}_{adaptation_type}_{timestamp}"
+        # Upsert: find existing PROPOSED adaptation with same key
+        existing_id = None
+        for aid, adapt in self.adaptations.items():
+            if (
+                adapt.protocol_name == protocol_name
+                and adapt.adaptation_type == adaptation_type
+                and adapt.status == "PROPOSED"
+            ):
+                existing_id = aid
+                break
 
         # Determine confidence from evidence count
         evidence_count = len(evidence)
@@ -509,6 +517,22 @@ class TrainingIntelligence:
             confidence = ConfidenceLevel.MEDIUM
         else:
             confidence = ConfidenceLevel.LOW
+
+        if existing_id:
+            # Update existing adaptation in place
+            adaptation = self.adaptations[existing_id]
+            adaptation.current_rule = current_rule
+            adaptation.proposed_rule = proposed_rule
+            adaptation.justification = justification
+            adaptation.evidence = evidence
+            adaptation.confidence = confidence
+            return adaptation
+
+        # Create new adaptation (ensure unique ID)
+        timestamp = int(datetime.now().timestamp())
+        adaptation_id = f"{protocol_name}_{adaptation_type}_{timestamp}"
+        if adaptation_id in self.adaptations:
+            adaptation_id = f"{protocol_name}_{adaptation_type}_{timestamp}_1"
 
         adaptation = ProtocolAdaptation(
             id=adaptation_id,
@@ -524,6 +548,38 @@ class TrainingIntelligence:
 
         self.adaptations[adaptation_id] = adaptation
         return adaptation
+
+    def expire_stale_adaptations(self, max_age_days: int = 14) -> int:
+        """Expire PROPOSED adaptations older than max_age_days.
+
+        Extracts timestamp from adaptation ID (format: protocol_type_TIMESTAMP)
+        and marks as EXPIRED if older than max_age_days.
+
+        Args:
+            max_age_days: Maximum age in days before expiration (default: 14)
+
+        Returns:
+            Number of adaptations expired
+        """
+        now = datetime.now()
+        expired_count = 0
+
+        for adaptation in self.adaptations.values():
+            if adaptation.status != "PROPOSED":
+                continue
+
+            # Extract timestamp from ID (last segment after last '_')
+            try:
+                ts_str = adaptation.id.rsplit("_", 1)[-1]
+                ts = datetime.fromtimestamp(int(ts_str))
+                age_days = (now - ts).total_seconds() / 86400
+                if age_days > max_age_days:
+                    adaptation.status = "EXPIRED"
+                    expired_count += 1
+            except (ValueError, IndexError, OSError):
+                continue
+
+        return expired_count
 
     def get_daily_insights(self, context: dict[str, Any]) -> dict[str, Any]:
         """Get daily insights based on current context and accumulated intelligence.

--- a/magma_cycling/scripts/pid_daily_evaluation.py
+++ b/magma_cycling/scripts/pid_daily_evaluation.py
@@ -204,6 +204,12 @@ class PIDDailyEvaluator(
         # Save
         self.save_intelligence()
 
+        # Expire stale adaptations
+        expired = self.intelligence.expire_stale_adaptations()
+        if expired > 0:
+            print(f"   🗑️  {expired} adaptation(s) expirée(s)")
+            self.save_intelligence()
+
         print(f"\n{'=' * 70}")
         print("✨ Daily Evaluation Complete")
         print(f"{'=' * 70}")

--- a/magma_cycling/workflows/planner/context_loading.py
+++ b/magma_cycling/workflows/planner/context_loading.py
@@ -4,6 +4,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 
 class ContextLoadingMixin:
@@ -215,11 +216,8 @@ class ContextLoadingMixin:
         try:
             if intelligence_file.exists():
                 intelligence_data = json.loads(intelligence_file.read_text(encoding="utf-8"))
-                # Format as readable text for AI
-                context["intelligence"] = json.dumps(
-                    intelligence_data, indent=2, ensure_ascii=False
-                )
-                print("  ✅ intelligence.json", file=sys.stderr)
+                context["intelligence"] = _summarize_intelligence(intelligence_data)
+                print("  ✅ intelligence.json (résumé)", file=sys.stderr)
             else:
                 print("  ⚠️ Non trouvé : intelligence.json", file=sys.stderr)
                 context["intelligence"] = "[Aucune recommandation d'adaptation disponible]"
@@ -296,3 +294,83 @@ class ContextLoadingMixin:
         except Exception as e:
             print(f"  ⚠️ Erreur chargement analyses : {e}", file=sys.stderr)
             return ""
+
+
+def _summarize_intelligence(data: dict[str, Any]) -> str:
+    """Summarize intelligence data for prompt injection.
+
+    Filters and compresses intelligence to reduce prompt size:
+    - Learnings: keep confidence >= medium, deduplicate evidence, max 5 items
+    - Adaptations: keep only PROPOSED, 1 per protocol_name (most recent)
+    - Patterns: pass through as-is
+    """
+    sections = []
+
+    # --- Learnings: confidence >= medium, max 5 evidence ---
+    learnings = data.get("learnings", {})
+    kept_learnings = []
+    for lid, learning in learnings.items():
+        conf = learning.get("confidence", "low")
+        if conf in ("medium", "high", "validated"):
+            evidence = learning.get("evidence", [])
+            unique_evidence = list(dict.fromkeys(evidence))  # deduplicate, preserve order
+            total = len(unique_evidence)
+            summary = {
+                "id": lid,
+                "category": learning.get("category"),
+                "description": learning.get("description"),
+                "confidence": conf,
+                "impact": learning.get("impact"),
+                "evidence": unique_evidence[:5],
+            }
+            if total > 5:
+                summary["evidence_total"] = total
+            kept_learnings.append(summary)
+
+    if kept_learnings:
+        sections.append(f"## Learnings ({len(kept_learnings)} sur {len(learnings)})\n")
+        sections.append(json.dumps(kept_learnings, indent=2, ensure_ascii=False))
+
+    # --- Adaptations: PROPOSED only, 1 per protocol_name (most recent) ---
+    adaptations = data.get("adaptations", {})
+    best_by_protocol: dict[str, tuple[int, str, dict]] = {}
+    for aid, adapt in adaptations.items():
+        if adapt.get("status") != "PROPOSED":
+            continue
+        protocol = adapt.get("protocol_name", "")
+        # Extract timestamp from ID (last segment)
+        try:
+            ts = int(aid.rsplit("_", 1)[-1])
+        except (ValueError, IndexError):
+            ts = 0
+        if protocol not in best_by_protocol or ts > best_by_protocol[protocol][0]:
+            best_by_protocol[protocol] = (ts, aid, adapt)
+
+    if best_by_protocol:
+        kept_adaptations = []
+        for _ts, aid, adapt in best_by_protocol.values():
+            kept_adaptations.append(
+                {
+                    "id": aid,
+                    "protocol_name": adapt.get("protocol_name"),
+                    "adaptation_type": adapt.get("adaptation_type"),
+                    "proposed_rule": adapt.get("proposed_rule"),
+                    "justification": adapt.get("justification"),
+                    "confidence": adapt.get("confidence"),
+                }
+            )
+        sections.append(
+            f"\n## Adaptations PROPOSED ({len(kept_adaptations)} sur {len(adaptations)})\n"
+        )
+        sections.append(json.dumps(kept_adaptations, indent=2, ensure_ascii=False))
+
+    # --- Patterns: pass through ---
+    patterns = data.get("patterns", {})
+    if patterns:
+        sections.append(f"\n## Patterns ({len(patterns)})\n")
+        sections.append(json.dumps(list(patterns.values()), indent=2, ensure_ascii=False))
+
+    if not sections:
+        return "[Aucune recommandation d'adaptation disponible]"
+
+    return "\n".join(sections)

--- a/tests/intelligence/test_training_intelligence.py
+++ b/tests/intelligence/test_training_intelligence.py
@@ -600,3 +600,227 @@ def test_load_empty_intelligence(tmp_path):
     assert len(loaded.learnings) == 0
     assert len(loaded.patterns) == 0
     assert len(loaded.adaptations) == 0
+
+
+# ============================================================================
+# TESTS EVIDENCE DEDUPLICATION (2)
+# ============================================================================
+
+
+def test_add_learning_deduplicates_evidence():
+    """Test that duplicate evidence is not added when reinforcing a learning."""
+    intelligence = TrainingIntelligence()
+
+    intelligence.add_learning(
+        category="sweet-spot",
+        description="88% FTP sustainable",
+        evidence=["S024-04: Success", "S024-06: Success"],
+        level=AnalysisLevel.DAILY,
+    )
+
+    # Re-add with one duplicate and one new
+    learning = intelligence.add_learning(
+        category="sweet-spot",
+        description="88% FTP sustainable",
+        evidence=["S024-04: Success", "S024-08: New"],
+        level=AnalysisLevel.DAILY,
+    )
+
+    assert len(learning.evidence) == 3
+    assert learning.evidence == ["S024-04: Success", "S024-06: Success", "S024-08: New"]
+
+
+def test_add_learning_all_duplicates_no_growth():
+    """Test that all-duplicate evidence does not grow the list."""
+    intelligence = TrainingIntelligence()
+
+    intelligence.add_learning(
+        category="test",
+        description="test desc",
+        evidence=["E1", "E2"],
+        level=AnalysisLevel.DAILY,
+    )
+
+    learning = intelligence.add_learning(
+        category="test",
+        description="test desc",
+        evidence=["E1", "E2"],
+        level=AnalysisLevel.DAILY,
+    )
+
+    assert len(learning.evidence) == 2
+
+
+# ============================================================================
+# TESTS ADAPTATION UPSERT (3)
+# ============================================================================
+
+
+def test_propose_adaptation_upsert_existing():
+    """Test that proposing same protocol+type updates existing adaptation."""
+    intelligence = TrainingIntelligence()
+
+    adapt1 = intelligence.propose_adaptation(
+        protocol_name="ftp_test_cycle",
+        adaptation_type="ADD",
+        current_rule="Old rule v1",
+        proposed_rule="Proposed v1",
+        justification="Justification v1",
+        evidence=["E1"],
+    )
+
+    adapt2 = intelligence.propose_adaptation(
+        protocol_name="ftp_test_cycle",
+        adaptation_type="ADD",
+        current_rule="Old rule v2",
+        proposed_rule="Proposed v2",
+        justification="Justification v2",
+        evidence=["E2", "E3"],
+    )
+
+    # Should be same adaptation, updated in place
+    assert adapt1.id == adapt2.id
+    assert len(intelligence.adaptations) == 1
+    assert adapt2.proposed_rule == "Proposed v2"
+    assert adapt2.justification == "Justification v2"
+    assert adapt2.evidence == ["E2", "E3"]
+
+
+def test_propose_adaptation_different_type_creates_new():
+    """Test that different adaptation_type creates a new adaptation."""
+    intelligence = TrainingIntelligence()
+
+    intelligence.propose_adaptation(
+        protocol_name="ftp_test_cycle",
+        adaptation_type="ADD",
+        current_rule="Rule",
+        proposed_rule="New",
+        justification="Just",
+        evidence=["E1"],
+    )
+
+    intelligence.propose_adaptation(
+        protocol_name="ftp_test_cycle",
+        adaptation_type="MODIFY",
+        current_rule="Rule",
+        proposed_rule="Modified",
+        justification="Just",
+        evidence=["E1"],
+    )
+
+    assert len(intelligence.adaptations) == 2
+
+
+def test_propose_adaptation_no_upsert_non_proposed():
+    """Test that non-PROPOSED adaptations are not upserted."""
+    intelligence = TrainingIntelligence()
+
+    adapt1 = intelligence.propose_adaptation(
+        protocol_name="test",
+        adaptation_type="ADD",
+        current_rule="Rule",
+        proposed_rule="New",
+        justification="Just",
+        evidence=["E1"],
+    )
+
+    # Manually change status to VALIDATED
+    adapt1.status = "VALIDATED"
+
+    # Should create a new one since the existing is VALIDATED
+    adapt2 = intelligence.propose_adaptation(
+        protocol_name="test",
+        adaptation_type="ADD",
+        current_rule="Rule v2",
+        proposed_rule="New v2",
+        justification="Just v2",
+        evidence=["E2"],
+    )
+
+    assert adapt1.id != adapt2.id
+    assert len(intelligence.adaptations) == 2
+
+
+# ============================================================================
+# TESTS EXPIRE STALE ADAPTATIONS (3)
+# ============================================================================
+
+
+def test_expire_stale_adaptations_old():
+    """Test that old PROPOSED adaptations get expired."""
+    intelligence = TrainingIntelligence()
+
+    # Create adaptation with old timestamp (30 days ago)
+    import time
+
+    old_ts = int(time.time()) - (30 * 86400)
+    adaptation = ProtocolAdaptation(
+        id=f"test_ADD_{old_ts}",
+        protocol_name="test",
+        adaptation_type="ADD",
+        current_rule="Old",
+        proposed_rule="New",
+        justification="Just",
+        evidence=["E1"],
+        confidence=ConfidenceLevel.LOW,
+        status="PROPOSED",
+    )
+    intelligence.adaptations[adaptation.id] = adaptation
+
+    expired = intelligence.expire_stale_adaptations(max_age_days=14)
+
+    assert expired == 1
+    assert adaptation.status == "EXPIRED"
+
+
+def test_expire_stale_adaptations_recent_kept():
+    """Test that recent PROPOSED adaptations are not expired."""
+    intelligence = TrainingIntelligence()
+
+    # Create adaptation with current timestamp
+    import time
+
+    recent_ts = int(time.time())
+    adaptation = ProtocolAdaptation(
+        id=f"test_ADD_{recent_ts}",
+        protocol_name="test",
+        adaptation_type="ADD",
+        current_rule="Old",
+        proposed_rule="New",
+        justification="Just",
+        evidence=["E1"],
+        confidence=ConfidenceLevel.LOW,
+        status="PROPOSED",
+    )
+    intelligence.adaptations[adaptation.id] = adaptation
+
+    expired = intelligence.expire_stale_adaptations(max_age_days=14)
+
+    assert expired == 0
+    assert adaptation.status == "PROPOSED"
+
+
+def test_expire_stale_adaptations_skips_non_proposed():
+    """Test that non-PROPOSED adaptations are not expired."""
+    intelligence = TrainingIntelligence()
+
+    import time
+
+    old_ts = int(time.time()) - (30 * 86400)
+    adaptation = ProtocolAdaptation(
+        id=f"test_ADD_{old_ts}",
+        protocol_name="test",
+        adaptation_type="ADD",
+        current_rule="Old",
+        proposed_rule="New",
+        justification="Just",
+        evidence=["E1"],
+        confidence=ConfidenceLevel.LOW,
+        status="VALIDATED",
+    )
+    intelligence.adaptations[adaptation.id] = adaptation
+
+    expired = intelligence.expire_stale_adaptations(max_age_days=14)
+
+    assert expired == 0
+    assert adaptation.status == "VALIDATED"

--- a/tests/workflows/test_summarize_intelligence.py
+++ b/tests/workflows/test_summarize_intelligence.py
@@ -1,0 +1,128 @@
+"""Tests for _summarize_intelligence in context_loading."""
+
+import json
+
+from magma_cycling.workflows.planner.context_loading import _summarize_intelligence
+
+
+def test_summarize_filters_low_confidence_learnings():
+    """Test that low confidence learnings are excluded."""
+    data = {
+        "learnings": {
+            "low_1": {
+                "category": "test",
+                "description": "Low conf",
+                "confidence": "low",
+                "impact": "LOW",
+                "evidence": ["E1"],
+            },
+            "med_1": {
+                "category": "test2",
+                "description": "Med conf",
+                "confidence": "medium",
+                "impact": "MEDIUM",
+                "evidence": ["E1", "E2", "E3"],
+            },
+        },
+        "adaptations": {},
+        "patterns": {},
+    }
+
+    result = _summarize_intelligence(data)
+
+    assert "Med conf" in result
+    assert "Low conf" not in result
+    assert "1 sur 2" in result
+
+
+def test_summarize_deduplicates_and_limits_evidence():
+    """Test that evidence is deduplicated and limited to 5."""
+    data = {
+        "learnings": {
+            "test_1": {
+                "category": "test",
+                "description": "Test",
+                "confidence": "high",
+                "impact": "HIGH",
+                "evidence": ["E1", "E2", "E1", "E3", "E2", "E4", "E5", "E6", "E7"],
+            },
+        },
+        "adaptations": {},
+        "patterns": {},
+    }
+
+    result = _summarize_intelligence(data)
+    parsed = json.loads(result.split("\n", 1)[1])
+
+    learning = parsed[0]
+    # 9 items → 7 unique → show 5 + evidence_total
+    assert len(learning["evidence"]) == 5
+    assert learning["evidence_total"] == 7
+
+
+def test_summarize_keeps_one_adaptation_per_protocol():
+    """Test that only most recent PROPOSED adaptation per protocol is kept."""
+    data = {
+        "learnings": {},
+        "adaptations": {
+            "ftp_ADD_1000": {
+                "protocol_name": "ftp_test_cycle",
+                "adaptation_type": "ADD",
+                "proposed_rule": "Old proposal",
+                "justification": "Old",
+                "confidence": "low",
+                "status": "PROPOSED",
+            },
+            "ftp_ADD_2000": {
+                "protocol_name": "ftp_test_cycle",
+                "adaptation_type": "ADD",
+                "proposed_rule": "Recent proposal",
+                "justification": "Recent",
+                "confidence": "low",
+                "status": "PROPOSED",
+            },
+            "ftp_ADD_3000": {
+                "protocol_name": "ftp_test_cycle",
+                "adaptation_type": "ADD",
+                "proposed_rule": "Most recent",
+                "justification": "Latest",
+                "confidence": "low",
+                "status": "EXPIRED",
+            },
+        },
+        "patterns": {},
+    }
+
+    result = _summarize_intelligence(data)
+
+    assert "Recent proposal" in result
+    assert "Old proposal" not in result
+    assert "Most recent" not in result  # EXPIRED, excluded
+    assert "1 sur 3" in result
+
+
+def test_summarize_empty_data():
+    """Test that empty intelligence returns placeholder."""
+    data = {"learnings": {}, "adaptations": {}, "patterns": {}}
+    result = _summarize_intelligence(data)
+    assert result == "[Aucune recommandation d'adaptation disponible]"
+
+
+def test_summarize_patterns_passed_through():
+    """Test that patterns are included as-is."""
+    data = {
+        "learnings": {},
+        "adaptations": {},
+        "patterns": {
+            "p1": {
+                "name": "sleep_debt",
+                "trigger_conditions": {"sleep": "<6h"},
+                "observed_outcome": "Failure",
+                "frequency": 5,
+            }
+        },
+    }
+
+    result = _summarize_intelligence(data)
+    assert "sleep_debt" in result
+    assert "Patterns (1)" in result


### PR DESCRIPTION
## Summary

- Deduplicate evidence in `add_learning()` to prevent accumulation (904→401 items)
- Upsert PROPOSED adaptations by `(protocol_name, adaptation_type)` instead of creating duplicates (111→1)
- Add `expire_stale_adaptations()` for PROPOSED older than 14 days
- Add `_summarize_intelligence()` filter in prompt injection: confidence ≥ medium, max 5 evidence, 1 adaptation per protocol
- Clean existing `intelligence.json` (158K→59K bytes)

| Metric | Before | After |
|---|---|---|
| Intelligence in prompt | 158K chars | ~30K chars |
| Evidence items | 904 | 401 |
| Adaptations | 111 identical | 1 per protocol |
| intelligence.json | 158K bytes | 59K bytes |

## Test plan

- [x] 13 new tests (dedup×2, upsert×3, expiration×3, summarize×5)
- [x] Full suite: 3194 passed, 0 failed
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)