### PR TITLE
feat(health): push wellness to calendar after enrich-session-health

### DIFF
--- a/magma_cycling/_mcp/handlers/health.py
+++ b/magma_cycling/_mcp/handlers/health.py
@@ -632,4 +632,21 @@ async def handle_enrich_session_health(args: dict) -> list[TextContent]:
                 "status": "success",
             }
 
+        # Push health data to calendar wellness (outside Control Tower lock)
+        sync_to_calendar = args.get("sync_to_calendar", True)
+        if sync_to_calendar and health_metrics:
+            try:
+                sync_result = sync_health_to_calendar(
+                    start_date=session_date,
+                    end_date=session_date,
+                    data_types=["sleep", "weight"],
+                )
+                result["calendar_sync"] = {
+                    "synced": bool(sync_result.get("synced_dates")),
+                    "synced_dates": sync_result.get("synced_dates", []),
+                    "errors": sync_result.get("errors", []),
+                }
+            except Exception as e:
+                result["calendar_sync"] = {"synced": False, "error": str(e)}
+
     return mcp_response(result, provider_info=provider_info)

--- a/magma_cycling/_mcp/schemas/health.py
+++ b/magma_cycling/_mcp/schemas/health.py
@@ -163,6 +163,11 @@ def get_tools() -> list[Tool]:
                         "description": "Add training readiness evaluation (default: true)",
                         "default": True,
                     },
+                    "sync_to_calendar": {
+                        "type": "boolean",
+                        "description": "Push health data to training calendar wellness (default: true)",
+                        "default": True,
+                    },
                 },
                 "required": ["week_id", "session_id"],
             },

--- a/tests/test_mcp_new_handlers.py
+++ b/tests/test_mcp_new_handlers.py
@@ -1696,3 +1696,144 @@ class TestHandleEnrichSessionHealth:
         data = json.loads(result[0].text)
         assert data["status"] == "error"
         assert "not found" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_enrich_session_syncs_to_calendar(self, mock_tower):
+        """Default sync_to_calendar=True triggers sync_health_to_calendar."""
+        from magma_cycling.mcp_server import handle_enrich_session_health
+        from magma_cycling.models.withings_models import SleepData, WeightMeasurement
+
+        mock_provider = _mock_health_provider()
+        mock_provider.get_sleep_range.return_value = [
+            SleepData(
+                date=date(2026, 2, 25),
+                start_datetime=datetime(2026, 2, 24, 23, 0),
+                end_datetime=datetime(2026, 2, 25, 6, 30),
+                total_sleep_hours=7.5,
+                sleep_score=82,
+                deep_sleep_minutes=90,
+                wakeup_count=1,
+            ),
+        ]
+        mock_provider.get_body_composition.return_value = WeightMeasurement(
+            date=date(2026, 2, 25),
+            datetime=datetime(2026, 2, 25, 8, 0),
+            weight_kg=84.2,
+        )
+        mock_provider.get_readiness.return_value = None
+
+        mock_sync = Mock(return_value={"synced_dates": ["2026-02-25"], "errors": []})
+
+        with (
+            patch(TOWER_PATCH, mock_tower),
+            patch(HEALTH_PROVIDER_PATCH, return_value=mock_provider),
+            patch(
+                "magma_cycling._mcp.handlers.health.sync_health_to_calendar",
+                mock_sync,
+            ),
+        ):
+            result = await handle_enrich_session_health(
+                {"week_id": "S082", "session_id": "S082-03"}
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["calendar_sync"]["synced"] is True
+        assert "2026-02-25" in data["calendar_sync"]["synced_dates"]
+        mock_sync.assert_called_once_with(
+            start_date=date(2026, 2, 25),
+            end_date=date(2026, 2, 25),
+            data_types=["sleep", "weight"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_enrich_session_skip_calendar_sync(self, mock_tower):
+        """sync_to_calendar=False skips calendar push."""
+        from magma_cycling.mcp_server import handle_enrich_session_health
+        from magma_cycling.models.withings_models import SleepData, WeightMeasurement
+
+        mock_provider = _mock_health_provider()
+        mock_provider.get_sleep_range.return_value = [
+            SleepData(
+                date=date(2026, 2, 25),
+                start_datetime=datetime(2026, 2, 24, 23, 0),
+                end_datetime=datetime(2026, 2, 25, 6, 30),
+                total_sleep_hours=7.5,
+                sleep_score=82,
+                deep_sleep_minutes=90,
+                wakeup_count=1,
+            ),
+        ]
+        mock_provider.get_body_composition.return_value = WeightMeasurement(
+            date=date(2026, 2, 25),
+            datetime=datetime(2026, 2, 25, 8, 0),
+            weight_kg=84.2,
+        )
+        mock_provider.get_readiness.return_value = None
+
+        mock_sync = Mock()
+
+        with (
+            patch(TOWER_PATCH, mock_tower),
+            patch(HEALTH_PROVIDER_PATCH, return_value=mock_provider),
+            patch(
+                "magma_cycling._mcp.handlers.health.sync_health_to_calendar",
+                mock_sync,
+            ),
+        ):
+            result = await handle_enrich_session_health(
+                {
+                    "week_id": "S082",
+                    "session_id": "S082-03",
+                    "sync_to_calendar": False,
+                }
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert "calendar_sync" not in data
+        mock_sync.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enrich_session_calendar_sync_error_non_blocking(self, mock_tower):
+        """Calendar sync failure does not block enrichment success."""
+        from magma_cycling.mcp_server import handle_enrich_session_health
+        from magma_cycling.models.withings_models import SleepData, WeightMeasurement
+
+        mock_provider = _mock_health_provider()
+        mock_provider.get_sleep_range.return_value = [
+            SleepData(
+                date=date(2026, 2, 25),
+                start_datetime=datetime(2026, 2, 24, 23, 0),
+                end_datetime=datetime(2026, 2, 25, 6, 30),
+                total_sleep_hours=7.5,
+                sleep_score=82,
+                deep_sleep_minutes=90,
+                wakeup_count=1,
+            ),
+        ]
+        mock_provider.get_body_composition.return_value = WeightMeasurement(
+            date=date(2026, 2, 25),
+            datetime=datetime(2026, 2, 25, 8, 0),
+            weight_kg=84.2,
+        )
+        mock_provider.get_readiness.return_value = None
+
+        mock_sync = Mock(side_effect=ConnectionError("API unreachable"))
+
+        with (
+            patch(TOWER_PATCH, mock_tower),
+            patch(HEALTH_PROVIDER_PATCH, return_value=mock_provider),
+            patch(
+                "magma_cycling._mcp.handlers.health.sync_health_to_calendar",
+                mock_sync,
+            ),
+        ):
+            result = await handle_enrich_session_health(
+                {"week_id": "S082", "session_id": "S082-03"}
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["calendar_sync"]["synced"] is False
+        assert "API unreachable" in data["calendar_sync"]["error"]


### PR DESCRIPTION
## Summary

- Add `sync_to_calendar` parameter (default `true`) to `enrich-session-health` MCP tool
- After local session enrichment, automatically push sleep + weight data to Intervals.icu wellness via `sync_health_to_calendar()`
- Non-blocking: sync errors are captured in `calendar_sync.error` without affecting enrichment `status: success`

## Details

| Fichier | Modification |
|---|---|
| `_mcp/schemas/health.py` | Ajout paramètre `sync_to_calendar` (boolean, default true) |
| `_mcp/handlers/health.py` | Appel `sync_health_to_calendar()` hors du lock Control Tower |
| `tests/test_mcp_new_handlers.py` | 3 tests: sync par défaut, skip avec `false`, erreur non-bloquante |

## Test plan

- [x] `pytest tests/test_mcp_new_handlers.py::TestHandleEnrichSessionHealth -v` — 5/5 passed
- [x] `pytest tests/ -x` — 3197 passed, 0 failures
- [ ] Test MCP depuis Claude Desktop: `enrich-session-health` → vérifier `calendar_sync.synced: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)