### PR TITLE
refactor(planning): decompose PlanningManager into Facade + 2 Mixins

### DIFF
--- a/magma_cycling/planning/manager/__init__.py
+++ b/magma_cycling/planning/manager/__init__.py
@@ -1,0 +1,1 @@
+"""PlanningManager mixin modules for god class decomposition."""

--- a/magma_cycling/planning/manager/timeline.py
+++ b/magma_cycling/planning/manager/timeline.py
@@ -1,0 +1,118 @@
+"""TimelineMixin — plan timeline generation for PlanningManager."""
+
+from datetime import timedelta
+from typing import Any
+
+
+class TimelineMixin:
+    """Mixin providing plan timeline generation."""
+
+    def get_plan_timeline(self, plan_name: str) -> dict[str, Any]:
+        """
+        Get timeline of deadlines and milestones for a plan.
+
+        Args:
+            plan_name: Name of plan
+
+        Returns:
+            Dictionary with timeline information including:
+                - plan_summary: Basic plan info
+                - deadlines: List of objectives sorted by date
+                - critical_dates: Dates with critical priority objectives
+                - weeks_breakdown: Weekly structure with objectives
+
+        Raises:
+            KeyError: If plan not found
+
+        Example:
+            >>> from magma_cycling.config import AthleteProfile
+            >>> profile = AthleteProfile(age=54, category="master", ftp=220, weight=83.8)
+            >>> from magma_cycling.planning.planning_manager import PlanningManager
+            >>> manager = PlanningManager(athlete_profile=profile)
+            >>> plan = manager.create_training_plan(
+            ...     "Test", date(2026, 1, 1), date(2026, 2, 1), []
+            ... )
+            >>> manager.add_deadline(
+            ...     "Test", date(2026, 1, 15), "Checkpoint",
+            ...     PriorityLevel.MEDIUM
+            ... )
+            <magma_cycling.planning.planning_manager.TrainingObjective object at ...>
+            >>> timeline = manager.get_plan_timeline("Test")
+            >>> len(timeline['deadlines'])
+            1
+        """
+        from magma_cycling.planning.planning_manager import PriorityLevel
+
+        if plan_name not in self.plans:
+            raise KeyError(f"Plan '{plan_name}' not found")
+
+        plan = self.plans[plan_name]
+
+        # Sort objectives by date
+        sorted_objectives = sorted(plan.objectives, key=lambda x: x.target_date)
+
+        # Group objectives by week
+        weeks_breakdown = []
+        current_date = plan.start_date
+        week_num = 1
+
+        while current_date <= plan.end_date:
+            week_end = current_date + timedelta(days=6)
+
+            # Find objectives in this week
+            week_objectives = [
+                obj for obj in sorted_objectives if current_date <= obj.target_date <= week_end
+            ]
+
+            weeks_breakdown.append(
+                {
+                    "week_num": week_num,
+                    "start_date": current_date.isoformat(),
+                    "end_date": week_end.isoformat(),
+                    "objectives": [
+                        {
+                            "name": obj.name,
+                            "date": obj.target_date.isoformat(),
+                            "priority": obj.priority.value,
+                            "type": obj.objective_type.value,
+                        }
+                        for obj in week_objectives
+                    ],
+                }
+            )
+
+            current_date = week_end + timedelta(days=1)
+            week_num += 1
+
+        # Extract critical dates
+        critical_dates = [
+            {
+                "date": obj.target_date.isoformat(),
+                "name": obj.name,
+                "type": obj.objective_type.value,
+            }
+            for obj in sorted_objectives
+            if obj.priority == PriorityLevel.CRITICAL
+        ]
+
+        return {
+            "plan_summary": {
+                "name": plan.name,
+                "start_date": plan.start_date.isoformat(),
+                "end_date": plan.end_date.isoformat(),
+                "duration_weeks": plan.duration_weeks(),
+                "total_objectives": len(plan.objectives),
+            },
+            "deadlines": [
+                {
+                    "name": obj.name,
+                    "date": obj.target_date.isoformat(),
+                    "priority": obj.priority.value,
+                    "type": obj.objective_type.value,
+                    "days_remaining": obj.days_remaining(),
+                }
+                for obj in sorted_objectives
+            ],
+            "critical_dates": critical_dates,
+            "weeks_breakdown": weeks_breakdown,
+        }

--- a/magma_cycling/planning/manager/validation.py
+++ b/magma_cycling/planning/manager/validation.py
@@ -1,0 +1,145 @@
+"""ValidationMixin — plan feasibility validation for PlanningManager."""
+
+import logging
+from typing import Any
+
+from magma_cycling.utils.metrics_advanced import calculate_ramp_rate
+
+logger = logging.getLogger(__name__)
+
+
+class ValidationMixin:
+    """Mixin providing plan feasibility validation."""
+
+    def validate_plan_feasibility(self, plan_name: str, current_ctl: float = 0.0) -> dict[str, Any]:
+        """
+        Validate training plan feasibility against athlete capabilities.
+
+        Checks:
+            - Weekly TSS within athlete limits (max 380 for master 54y)
+            - CTL ramp rate safe (<= 5-7 points/week for master)
+            - Plan duration appropriate (4-12 weeks)
+            - Objectives timeline realistic
+
+        Args:
+            plan_name: Name of plan to validate
+            current_ctl: Current CTL baseline (default 0)
+
+        Returns:
+            Dictionary with validation results:
+                - feasible: Boolean overall feasibility
+                - warnings: List of warning messages
+                - errors: List of error messages (blocking issues)
+                - recommendations: List of recommendations
+
+        Raises:
+            KeyError: If plan not found
+
+        Example:
+            >>> from magma_cycling.config import AthleteProfile
+            >>> profile = AthleteProfile(age=54, category="master", ftp=220, weight=83.8)
+            >>> from magma_cycling.planning.planning_manager import PlanningManager
+            >>> manager = PlanningManager(athlete_profile=profile)
+            >>> plan = manager.create_training_plan(
+            ...     "Test", date(2026, 1, 1), date(2026, 2, 1), [],
+            ...     weekly_tss_targets=[250, 270, 290, 310, 330]
+            ... )
+            >>> result = manager.validate_plan_feasibility("Test", current_ctl=60)
+            >>> result['feasible']
+            True
+        """
+        from magma_cycling.planning.planning_manager import PriorityLevel
+
+        if plan_name not in self.plans:
+            raise KeyError(f"Plan '{plan_name}' not found")
+
+        plan = self.plans[plan_name]
+        warnings = []
+        errors = []
+        recommendations = []
+
+        # Get athlete limits
+        max_weekly_tss = 380 if self.athlete_profile.category == "master" else 450
+        max_ctl_ramp = 7.0 if self.athlete_profile.category == "master" else 10.0
+
+        # Validate weekly TSS targets
+        if plan.weekly_tss_targets:
+            for week_num, tss in enumerate(plan.weekly_tss_targets, 1):
+                if tss > max_weekly_tss:
+                    warnings.append(
+                        f"Week {week_num}: TSS {tss:.0f} exceeds "
+                        f"recommended max {max_weekly_tss:.0f} for "
+                        f"{self.athlete_profile.category} athlete"
+                    )
+
+        # Validate CTL progression if TSS targets provided
+        if plan.weekly_tss_targets and len(plan.weekly_tss_targets) >= 2:
+            # Estimate CTL progression (simplified: TSS/7 ≈ CTL)
+            estimated_start_ctl = current_ctl
+            estimated_end_ctl = current_ctl + sum(plan.weekly_tss_targets) / 7.0
+
+            duration_days = (plan.end_date - plan.start_date).days + 1
+            ramp_rate = calculate_ramp_rate(
+                ctl_previous=estimated_start_ctl,
+                ctl_current=estimated_end_ctl,
+                days=duration_days,
+            )
+
+            if ramp_rate > max_ctl_ramp:
+                errors.append(
+                    f"CTL ramp rate {ramp_rate:.1f} points/week exceeds "
+                    f"safe maximum {max_ctl_ramp:.1f} for "
+                    f"{self.athlete_profile.category} athlete (age "
+                    f"{self.athlete_profile.age})"
+                )
+                recommendations.append(
+                    f"Reduce weekly TSS or extend plan duration to achieve "
+                    f"ramp rate <= {max_ctl_ramp:.1f} points/week"
+                )
+            elif ramp_rate > max_ctl_ramp * 0.8:
+                warnings.append(
+                    f"CTL ramp rate {ramp_rate:.1f} points/week is high "
+                    f"(80%+ of maximum). Monitor recovery carefully."
+                )
+
+        # Validate objectives timeline
+        if plan.objectives:
+            high_priority_count = len(plan.get_objectives_by_priority(PriorityLevel.HIGH))
+            critical_count = len(plan.get_objectives_by_priority(PriorityLevel.CRITICAL))
+
+            if critical_count > 2:
+                warnings.append(
+                    f"Plan has {critical_count} critical objectives. "
+                    f"Consider prioritizing top 2 to avoid overload."
+                )
+
+            if high_priority_count + critical_count > 5:
+                warnings.append(
+                    f"Plan has {high_priority_count + critical_count} high+ "
+                    f"priority objectives. Risk of conflicting priorities."
+                )
+
+        # Overall feasibility
+        feasible = len(errors) == 0
+
+        if feasible and len(warnings) == 0:
+            recommendations.append(
+                "Plan structure looks good. Monitor actual vs planned load weekly."
+            )
+
+        return {
+            "feasible": feasible,
+            "warnings": warnings,
+            "errors": errors,
+            "recommendations": recommendations,
+            "plan_summary": {
+                "name": plan.name,
+                "duration_weeks": plan.duration_weeks(),
+                "total_tss": sum(plan.weekly_tss_targets) if plan.weekly_tss_targets else 0,
+                "avg_weekly_tss": (
+                    sum(plan.weekly_tss_targets) / len(plan.weekly_tss_targets)
+                    if plan.weekly_tss_targets
+                    else 0
+                ),
+            },
+        }

--- a/magma_cycling/planning/planning_manager.py
+++ b/magma_cycling/planning/planning_manager.py
@@ -8,12 +8,13 @@ athlete capabilities (TSS limits, CTL progression rates).
 
 import logging
 from dataclasses import dataclass, field
-from datetime import date, timedelta
+from datetime import date
 from enum import Enum
 from typing import Any
 
 from magma_cycling.config.athlete_profile import AthleteProfile
-from magma_cycling.utils.metrics_advanced import calculate_ramp_rate
+from magma_cycling.planning.manager.timeline import TimelineMixin
+from magma_cycling.planning.manager.validation import ValidationMixin
 
 logger = logging.getLogger(__name__)
 
@@ -239,12 +240,15 @@ class TrainingPlan:
         }
 
 
-class PlanningManager:
+class PlanningManager(TimelineMixin, ValidationMixin):
     """
     Manager for creating and validating training plans.
 
     This class provides methods to create training plans, add deadlines/objectives,
     retrieve timelines, and validate plan feasibility against athlete capabilities.
+
+    Timeline generation is provided by TimelineMixin.
+    Feasibility validation is provided by ValidationMixin.
 
     Example:
         >>> from magma_cycling.config import AthleteProfile
@@ -418,240 +422,3 @@ class PlanningManager:
         )
 
         return objective
-
-    def get_plan_timeline(self, plan_name: str) -> dict[str, Any]:
-        """
-        Get timeline of deadlines and milestones for a plan.
-
-        Args:
-            plan_name: Name of plan
-
-        Returns:
-            Dictionary with timeline information including:
-                - plan_summary: Basic plan info
-                - deadlines: List of objectives sorted by date
-                - critical_dates: Dates with critical priority objectives
-                - weeks_breakdown: Weekly structure with objectives
-
-        Raises:
-            KeyError: If plan not found
-
-        Example:
-            >>> from magma_cycling.config import AthleteProfile
-            >>> profile = AthleteProfile(age=54, category="master", ftp=220, weight=83.8)
-            >>> manager = PlanningManager(athlete_profile=profile)
-            >>> plan = manager.create_training_plan(
-            ...     "Test", date(2026, 1, 1), date(2026, 2, 1), []
-            ... )
-            >>> manager.add_deadline(
-            ...     "Test", date(2026, 1, 15), "Checkpoint",
-            ...     PriorityLevel.MEDIUM
-            ... )
-            <magma_cycling.planning.planning_manager.TrainingObjective object at ...>
-            >>> timeline = manager.get_plan_timeline("Test")
-            >>> len(timeline['deadlines'])
-            1
-        """
-        if plan_name not in self.plans:
-            raise KeyError(f"Plan '{plan_name}' not found")
-
-        plan = self.plans[plan_name]
-
-        # Sort objectives by date
-        sorted_objectives = sorted(plan.objectives, key=lambda x: x.target_date)
-
-        # Group objectives by week
-        weeks_breakdown = []
-        current_date = plan.start_date
-        week_num = 1
-
-        while current_date <= plan.end_date:
-            week_end = current_date + timedelta(days=6)
-
-            # Find objectives in this week
-            week_objectives = [
-                obj for obj in sorted_objectives if current_date <= obj.target_date <= week_end
-            ]
-
-            weeks_breakdown.append(
-                {
-                    "week_num": week_num,
-                    "start_date": current_date.isoformat(),
-                    "end_date": week_end.isoformat(),
-                    "objectives": [
-                        {
-                            "name": obj.name,
-                            "date": obj.target_date.isoformat(),
-                            "priority": obj.priority.value,
-                            "type": obj.objective_type.value,
-                        }
-                        for obj in week_objectives
-                    ],
-                }
-            )
-
-            current_date = week_end + timedelta(days=1)
-            week_num += 1
-
-        # Extract critical dates
-        critical_dates = [
-            {
-                "date": obj.target_date.isoformat(),
-                "name": obj.name,
-                "type": obj.objective_type.value,
-            }
-            for obj in sorted_objectives
-            if obj.priority == PriorityLevel.CRITICAL
-        ]
-
-        return {
-            "plan_summary": {
-                "name": plan.name,
-                "start_date": plan.start_date.isoformat(),
-                "end_date": plan.end_date.isoformat(),
-                "duration_weeks": plan.duration_weeks(),
-                "total_objectives": len(plan.objectives),
-            },
-            "deadlines": [
-                {
-                    "name": obj.name,
-                    "date": obj.target_date.isoformat(),
-                    "priority": obj.priority.value,
-                    "type": obj.objective_type.value,
-                    "days_remaining": obj.days_remaining(),
-                }
-                for obj in sorted_objectives
-            ],
-            "critical_dates": critical_dates,
-            "weeks_breakdown": weeks_breakdown,
-        }
-
-    def validate_plan_feasibility(self, plan_name: str, current_ctl: float = 0.0) -> dict[str, Any]:
-        """
-        Validate training plan feasibility against athlete capabilities.
-
-        Checks:
-            - Weekly TSS within athlete limits (max 380 for master 54y)
-            - CTL ramp rate safe (<= 5-7 points/week for master)
-            - Plan duration appropriate (4-12 weeks)
-            - Objectives timeline realistic
-
-        Args:
-            plan_name: Name of plan to validate
-            current_ctl: Current CTL baseline (default 0)
-
-        Returns:
-            Dictionary with validation results:
-                - feasible: Boolean overall feasibility
-                - warnings: List of warning messages
-                - errors: List of error messages (blocking issues)
-                - recommendations: List of recommendations
-
-        Raises:
-            KeyError: If plan not found
-
-        Example:
-            >>> from magma_cycling.config import AthleteProfile
-            >>> profile = AthleteProfile(age=54, category="master", ftp=220, weight=83.8)
-            >>> manager = PlanningManager(athlete_profile=profile)
-            >>> plan = manager.create_training_plan(
-            ...     "Test", date(2026, 1, 1), date(2026, 2, 1), [],
-            ...     weekly_tss_targets=[250, 270, 290, 310, 330]
-            ... )
-            >>> result = manager.validate_plan_feasibility("Test", current_ctl=60)
-            >>> result['feasible']
-            True
-        """
-        if plan_name not in self.plans:
-            raise KeyError(f"Plan '{plan_name}' not found")
-
-        plan = self.plans[plan_name]
-        warnings = []
-        errors = []
-        recommendations = []
-
-        # Get athlete limits
-        max_weekly_tss = 380 if self.athlete_profile.category == "master" else 450
-        max_ctl_ramp = 7.0 if self.athlete_profile.category == "master" else 10.0
-
-        # Validate weekly TSS targets
-        if plan.weekly_tss_targets:
-            for week_num, tss in enumerate(plan.weekly_tss_targets, 1):
-                if tss > max_weekly_tss:
-                    warnings.append(
-                        f"Week {week_num}: TSS {tss:.0f} exceeds "
-                        f"recommended max {max_weekly_tss:.0f} for "
-                        f"{self.athlete_profile.category} athlete"
-                    )
-
-        # Validate CTL progression if TSS targets provided
-        if plan.weekly_tss_targets and len(plan.weekly_tss_targets) >= 2:
-            # Estimate CTL progression (simplified: TSS/7 ≈ CTL)
-            estimated_start_ctl = current_ctl
-            estimated_end_ctl = current_ctl + sum(plan.weekly_tss_targets) / 7.0
-
-            duration_days = (plan.end_date - plan.start_date).days + 1
-            ramp_rate = calculate_ramp_rate(
-                ctl_previous=estimated_start_ctl,
-                ctl_current=estimated_end_ctl,
-                days=duration_days,
-            )
-
-            if ramp_rate > max_ctl_ramp:
-                errors.append(
-                    f"CTL ramp rate {ramp_rate:.1f} points/week exceeds "
-                    f"safe maximum {max_ctl_ramp:.1f} for "
-                    f"{self.athlete_profile.category} athlete (age "
-                    f"{self.athlete_profile.age})"
-                )
-                recommendations.append(
-                    f"Reduce weekly TSS or extend plan duration to achieve "
-                    f"ramp rate <= {max_ctl_ramp:.1f} points/week"
-                )
-            elif ramp_rate > max_ctl_ramp * 0.8:
-                warnings.append(
-                    f"CTL ramp rate {ramp_rate:.1f} points/week is high "
-                    f"(80%+ of maximum). Monitor recovery carefully."
-                )
-
-        # Validate objectives timeline
-        if plan.objectives:
-            high_priority_count = len(plan.get_objectives_by_priority(PriorityLevel.HIGH))
-            critical_count = len(plan.get_objectives_by_priority(PriorityLevel.CRITICAL))
-
-            if critical_count > 2:
-                warnings.append(
-                    f"Plan has {critical_count} critical objectives. "
-                    f"Consider prioritizing top 2 to avoid overload."
-                )
-
-            if high_priority_count + critical_count > 5:
-                warnings.append(
-                    f"Plan has {high_priority_count + critical_count} high+ "
-                    f"priority objectives. Risk of conflicting priorities."
-                )
-
-        # Overall feasibility
-        feasible = len(errors) == 0
-
-        if feasible and len(warnings) == 0:
-            recommendations.append(
-                "Plan structure looks good. Monitor actual vs planned load weekly."
-            )
-
-        return {
-            "feasible": feasible,
-            "warnings": warnings,
-            "errors": errors,
-            "recommendations": recommendations,
-            "plan_summary": {
-                "name": plan.name,
-                "duration_weeks": plan.duration_weeks(),
-                "total_tss": sum(plan.weekly_tss_targets) if plan.weekly_tss_targets else 0,
-                "avg_weekly_tss": (
-                    sum(plan.weekly_tss_targets) / len(plan.weekly_tss_targets)
-                    if plan.weekly_tss_targets
-                    else 0
-                ),
-            },
-        }


### PR DESCRIPTION
## Summary

- Extract `get_plan_timeline()` into `TimelineMixin` (`manager/timeline.py`)
- Extract `validate_plan_feasibility()` into `ValidationMixin` (`manager/validation.py`)
- Facade retains models (enums + dataclasses) + CRUD (`__init__`, `create_training_plan`, `add_deadline`)
- Local imports for `PriorityLevel` in mixins to avoid circular import

## Test plan

- [x] 21 tests in `test_planning_manager.py` pass (unchanged)
- [x] Full suite 3224 passed, 5 skipped
- [x] All pre-commit hooks pass
- [x] Backward compatibility: all existing imports unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)