### PR TITLE
feat(prompt): enrich coach analysis with intervals and local TSS

### DIFF
--- a/magma_cycling/workflows/prompt/data_formatting.py
+++ b/magma_cycling/workflows/prompt/data_formatting.py
@@ -146,6 +146,34 @@ class DataFormattingMixin:
 
         return formatted
 
+    def format_intervals_data(self, intervals: list[dict]) -> list[dict] | None:
+        """Formate les intervalles d'activité pour le prompt."""
+        if not intervals:
+            return None
+
+        def _round(val, decimals=0):
+            if val is None:
+                return None
+            return round(val, decimals)
+
+        formatted = []
+        for iv in intervals:
+            formatted.append(
+                {
+                    "type": iv.get("type", "UNKNOWN"),
+                    "label": iv.get("label", ""),
+                    "duration_secs": iv.get("elapsed_time", 0),
+                    "avg_watts": _round(iv.get("average_watts")),
+                    "np": _round(iv.get("weighted_average_watts")),
+                    "avg_cadence": _round(iv.get("average_cadence")),
+                    "avg_hr": _round(iv.get("average_heartrate")),
+                    "max_hr": _round(iv.get("max_heartrate")),
+                    "decoupling": _round(iv.get("decoupling"), 1),
+                    "avg_lr_balance": _round(iv.get("avg_lr_balance"), 1),
+                }
+            )
+        return formatted
+
     def format_athlete_feedback(self, feedback):
         """Format le feedback pour inclusion dans le prompt."""
         if not feedback:

--- a/magma_cycling/workflows/prompt/prompt_assembly.py
+++ b/magma_cycling/workflows/prompt/prompt_assembly.py
@@ -26,12 +26,26 @@ class PromptAssemblyMixin:
         periodization_context=None,
         session_prescription=None,
         overtime_analysis=None,
+        activity_intervals=None,
+        tss_planned_local=None,
     ):
         """Generate le prompt complet pour analyse IA.
 
         Args:
+            activity_data: Formatted activity dict from format_activity_data().
+            wellness_pre: Pre-workout wellness dict or None.
+            wellness_post: Post-workout wellness dict or None.
+            athlete_context: Athlete context string or None.
+            recent_workouts: Recent workouts string or None.
+            athlete_feedback: Athlete feedback dict or None.
+            planned_workout: Planned workout event dict or None.
+            cycling_concepts: Cycling concepts string or None.
+            periodization_context: Periodization context dict or None.
+            session_prescription: Session prescription text or None.
             overtime_analysis: Optional dict with overtime metrics from
                 decoupling recalculation (decoupling_prescribed, overtime_analysis).
+            activity_intervals: Raw intervals from get_activity_intervals() or None.
+            tss_planned_local: TSS from local planning JSON or None.
         """
         # Formater les données
 
@@ -139,7 +153,16 @@ Certaines métriques (puissance, découplage) peuvent être manquantes ou incomp
 - FC max : {self.safe_format_metric(max_hr, '.0f', 'bpm')}
 - Découplage cardiovasculaire : {decoupling_str}{overtime_str}
 - Température : {temperature_str}
+"""
+        # Build intervals table if available
+        intervals_section = ""
+        if activity_intervals:
+            formatted_intervals = self.format_intervals_data(activity_intervals)
+            if formatted_intervals:
+                intervals_section = self._build_intervals_section(formatted_intervals)
 
+        prompt += intervals_section
+        prompt += f"""
 ### Métriques Post-séance
 - CTL : {w_post['ctl']:.0f}
 - ATL : {w_post['atl']:.0f}
@@ -201,6 +224,16 @@ ci-dessus. Identifier les écarts entre intention et réalisation.
 - IF : {planned['intensity_planned']:.2f} prévue → {act['intensity']:.2f} réalisée ({act['intensity'] - planned['intensity_planned']:+.2f})
 - Puissance moy. : {planned['avg_watts_planned']:.0f}W prévue → {act['avg_power']:.0f}W réalisée ({act['avg_power'] - planned['avg_watts_planned']:+.0f}W)
 - NP : {planned['np_planned']:.0f}W prévue → {act['np']:.0f}W réalisée ({act['np'] - planned['np_planned']:+.0f}W)
+"""
+            # Add local TSS planned if available and different from Intervals.icu
+            tss_source_note = ""
+            if tss_planned_local is not None:
+                tss_source_note = (
+                    f"\n- **TSS planifié (planning local)** : {tss_planned_local}"
+                    " (source de vérité pour la comparaison)"
+                )
+
+            prompt += f"""{tss_source_note}
 
 **Consigne d'analyse** : Évaluer l'adhérence au plan et identifier les écarts significatifs (>10% en durée/TSS, >5% en IF).
 
@@ -275,6 +308,8 @@ En tant qu'assistant coach, analyse cette séance avec un regard factuel et tech
 4. Identifier patterns (Sweet-Spot, Endurance, VO2, etc.)
 5. **Intégrer le feedback athlète** (section "Feedback Athlète") s'il est présent - ressenti général (1-5, 1=Excellent 5=Mauvais) et notes textuelles (avec système de fallback: description activité en priorité, wellness comments si vide)
 6. Recommandations concrètes basées sur les données ET le ressenti
+7. Comparer TSS réalisé au TSS planifié **local** (pas au TSS Intervals.icu qui peut être mis à jour post-sync) si disponible
+8. **Découplage** : utiliser UNIQUEMENT la valeur fournie dans "Exécution". Valeur négative = bonne efficacité. Ne jamais recalculer ou estimer
 
 **Gestion des données manquantes (activités Strava) :**
 - Si puissance = 0W : Indiquer "_Données non disponibles (source Strava)_"
@@ -344,6 +379,36 @@ Date : {act['date']}
 Génère maintenant l'entrée d'analyse.
 """
         return prompt
+
+    def _build_intervals_section(self, intervals: list[dict]) -> str:
+        """Construit la section intervalles pour le prompt."""
+        lines = [
+            "\n### Données par Intervalles\n",
+            "| # | Type | Durée | Avg W | NP | Cadence | Avg HR | Max HR "
+            "| Découplage | Balance G/D |",
+            "|---|------|-------|-------|----|---------|--------|--------"
+            "|------------|-------------|",
+        ]
+        for i, iv in enumerate(intervals, 1):
+            dur_min = iv["duration_secs"] // 60 if iv["duration_secs"] else 0
+            dur_sec = iv["duration_secs"] % 60 if iv["duration_secs"] else 0
+            dur_str = f"{dur_min}m{dur_sec:02d}s" if dur_sec else f"{dur_min}min"
+
+            def fmt(val, suffix=""):
+                return f"{val}{suffix}" if val is not None else "-"
+
+            lr = iv.get("avg_lr_balance")
+            lr_str = f"{lr:.1f}/{100 - lr:.1f}" if lr is not None else "-"
+
+            lines.append(
+                f"| {i} | {iv['type']} | {dur_str} | "
+                f"{fmt(iv['avg_watts'], 'W')} | {fmt(iv['np'], 'W')} | "
+                f"{fmt(iv['avg_cadence'], 'rpm')} | {fmt(iv['avg_hr'], 'bpm')} | "
+                f"{fmt(iv['max_hr'], 'bpm')} | {fmt(iv['decoupling'], '%')} | "
+                f"{lr_str} |"
+            )
+        lines.append("")
+        return "\n".join(lines)
 
     def _build_environment_section(self, act, planned):
         """Construit la section environnement indoor/outdoor pour le prompt."""

--- a/magma_cycling/workflows/sync/ai_analysis.py
+++ b/magma_cycling/workflows/sync/ai_analysis.py
@@ -148,8 +148,9 @@ class AIAnalysisMixin:
             except Exception:
                 pass  # No planned workout available
 
-            # Get session prescription from local planning JSON
+            # Get session prescription and tss_planned from local planning JSON
             session_prescription = None
+            tss_planned_local = None
             if "-" in activity_name:
                 parts = activity_name.split("-")
                 if len(parts) >= 2 and parts[0].startswith("S") and len(parts[0]) == 4:
@@ -160,9 +161,17 @@ class AIAnalysisMixin:
                         for s in plan.planned_sessions:
                             if s.session_id == _session_id:
                                 session_prescription = s.description
+                                tss_planned_local = s.tss_planned
                                 break
                     except Exception:
                         pass  # Planning not found — skip
+
+            # Fetch activity intervals (WORK/RECOVERY blocks)
+            activity_intervals = None
+            try:
+                activity_intervals = self.client.get_activity_intervals(activity_id)
+            except Exception:
+                pass  # Activité sans intervalles — analyse dégradée
 
             # Generate complete prompt
             prompt = self.prompt_generator.generate_prompt(
@@ -176,6 +185,8 @@ class AIAnalysisMixin:
                 cycling_concepts=None,
                 periodization_context=periodization_context,
                 session_prescription=session_prescription,
+                activity_intervals=activity_intervals,
+                tss_planned_local=tss_planned_local,
             )
 
             # Build system_prompt for AI framing


### PR DESCRIPTION
## Summary

- Inject WORK/RECOVERY interval data (power, NP, cadence, HR, decoupling, L/R balance) into the AI coach prompt as a markdown table
- Add `tss_planned_local` from planning JSON as source of truth for TSS comparison, distinct from Intervals.icu TSS
- Add explicit LLM instructions: never recalculate decoupling, compare against local TSS
- Round interval floats for prompt readability (82.8rpm → 83rpm, 3.82% → 3.8%)
- Fix NP field name: `weighted_average_watts` (real API) not `icu_weighted_avg_watts`

## Context

The AI coach analysis had 3 issues:
1. **No interval data** — LLM only saw aggregated metrics, couldn't evaluate block-by-block
2. **Wrong TSS comparison** — compared to Intervals.icu TSS (52 vs 52) instead of local planning (38), hiding a +37% overload on S086-04
3. **Decoupling hallucination risk** — no explicit instruction to use the raw value

## Files changed

| File | Change |
|---|---|
| `workflows/sync/ai_analysis.py` | Fetch intervals + tss_planned_local, pass to prompt |
| `workflows/prompt/data_formatting.py` | New `format_intervals_data()` with rounding |
| `workflows/prompt/prompt_assembly.py` | Intervals table section, TSS local note, decoupling instructions |

## Test plan

- [x] 3224 tests pass, 0 regression
- [x] Validated on real activity i135002815 (S086-04): 9 intervals rendered, TSS delta +14 visible
- [x] Pre-commit hooks pass (black, ruff, isort, pydocstyle)
- [ ] Validate via Claude Desktop MCP prompt on next activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)