### PR TITLE
fix(mcp): expose API decoupling in get-activity-details

### DIFF
--- a/magma_cycling/_mcp/handlers/remote_activities.py
+++ b/magma_cycling/_mcp/handlers/remote_activities.py
@@ -91,6 +91,11 @@ async def handle_get_activity_details(args: dict) -> list[TextContent]:
                 except Exception:
                     pass
 
+            # decoupling_api: Intervals.icu server-side (portion active only)
+            # cardiovascular_decoupling: local split-half NP/HR (biased if warmup >15min)
+            # Prefer decoupling_api for sessions with significant warmup/cooldown
+            decoupling_api = activity.get("decoupling")
+
             result = {
                 "id": activity.get("id"),
                 "name": activity.get("name"),
@@ -106,6 +111,7 @@ async def handle_get_activity_details(args: dict) -> list[TextContent]:
                 "average_heartrate": activity.get("average_heartrate"),
                 "average_cadence": activity.get("average_cadence"),
                 "cardiovascular_decoupling": cardiovascular_decoupling,
+                "decoupling_api": decoupling_api,
                 "description": activity.get("description", ""),
                 "paired_event_id": activity.get("paired_event_id"),
             }


### PR DESCRIPTION
## Summary

- Add `decoupling_api` field from Intervals.icu API alongside existing `cardiovascular_decoupling` in `get-activity-details` MCP handler
- Document the methodological difference: API calculates on active portion, local split-half includes warmup/cooldown

## Context

On S086-04 (activation pre-test with 19min warmup):
- `cardiovascular_decoupling` (local) = **-5.6%** — artefact from warmup dominating first half
- `decoupling_api` (Intervals.icu) = **8.82%** — calculated on active portion only

Claude Desktop only saw -5.6%, while the prompt coach used 8.82%. Now both values are exposed for reconciliation.

## No breaking change

`cardiovascular_decoupling` remains unchanged. New field is additive only.

## Test plan

- [x] 10 existing `activity_details` tests pass unchanged
- [x] 3224 total tests pass, 0 regression
- [x] Verified on i135002815: `decoupling_api` = 8.82

🤖 Generated with [Claude Code](https://claude.com/claude-code)