### PR TITLE
fix(sync): auto-complete rest sessions + fix session ID suffix regex

### DIFF
--- a/magma_cycling/daily_sync.py
+++ b/magma_cycling/daily_sync.py
@@ -201,6 +201,9 @@ class DailySync(
         if completed_activities:
             self.update_completed_sessions(completed_activities)
 
+        # 1c. Auto-complete rest sessions (TSS=0, duration=0, date passée)
+        self.auto_complete_rest_sessions(check_date)
+
         # 2. Generate AI analyses (if enabled)
         analyses = {}
         if self.enable_ai_analysis and new_activities:

--- a/magma_cycling/workflows/sync/session_updates.py
+++ b/magma_cycling/workflows/sync/session_updates.py
@@ -1,7 +1,7 @@
 """SessionUpdatesMixin — session matching and status updates via Control Tower."""
 
 import re
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 from magma_cycling.config.athlete_profile import AthleteProfile
 from magma_cycling.planning.calendar import TrainingCalendar, WorkoutType
@@ -93,7 +93,7 @@ class SessionUpdatesMixin:
             Example: ("S079", "S079-02")
         """
         # Pattern: S079-02-INT-SweetSpotModere-V001
-        pattern = r"^(S\d{3})-(\d{2})"
+        pattern = r"^(S\d{3})-(\d{2}[a-z]?)"
         match = re.match(pattern, activity_name)
 
         if match:
@@ -281,3 +281,57 @@ class SessionUpdatesMixin:
         print("  ✅ Mise à jour automatique terminée")
 
         return activity_to_session_map
+
+    def auto_complete_rest_sessions(self, check_date: date) -> list[str]:
+        """Auto-complete rest sessions (TSS=0, duration=0) whose date has passed.
+
+        Rest days are accomplished by definition — no activity needed.
+
+        Args:
+            check_date: Current date. Sessions before this date are eligible.
+
+        Returns:
+            List of session IDs that were auto-completed.
+        """
+        from magma_cycling.daily_sync import calculate_current_week_info
+
+        completed_ids: list[str] = []
+
+        # Determine current and previous week
+        current_week_id, _ = calculate_current_week_info(check_date)
+        current_num = int(current_week_id[1:])
+        week_ids = [current_week_id]
+        if current_num > 1:
+            week_ids.append(f"S{current_num - 1:03d}")
+
+        for week_id in week_ids:
+            try:
+                plan = planning_tower.read_week(week_id)
+            except FileNotFoundError:
+                continue
+
+            sessions_to_complete = [
+                s
+                for s in plan.planned_sessions
+                if s.tss_planned == 0
+                and s.duration_min == 0
+                and s.session_date < check_date
+                and s.status == "planned"
+            ]
+
+            if not sessions_to_complete:
+                continue
+
+            session_ids = [s.session_id for s in sessions_to_complete]
+            with planning_tower.modify_week(
+                week_id,
+                requesting_script="daily-sync",
+                reason=f"Auto-complete rest sessions: {', '.join(session_ids)}",
+            ) as mutable_plan:
+                for session in mutable_plan.planned_sessions:
+                    if session.session_id in session_ids:
+                        session.status = "completed"
+                        completed_ids.append(session.session_id)
+                        print(f"  ✅ {session.session_id} (repos) → completed")
+
+        return completed_ids

--- a/tests/workflows/sync/test_session_updates.py
+++ b/tests/workflows/sync/test_session_updates.py
@@ -1,0 +1,274 @@
+"""Tests for SessionUpdatesMixin — regex suffix fix + auto-complete rest sessions."""
+
+import json
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from magma_cycling.planning.control_tower import planning_tower
+from magma_cycling.workflows.sync.session_updates import SessionUpdatesMixin
+
+
+class TestExtractSessionId:
+    """Tests for _extract_session_id regex."""
+
+    def setup_method(self):
+        self.mixin = SessionUpdatesMixin()
+
+    def test_standard_session_id(self):
+        """S079-02 without suffix."""
+        result = self.mixin._extract_session_id("S079-02-INT-SweetSpotModere-V001")
+        assert result == ("S079", "S079-02")
+
+    def test_session_id_with_suffix(self):
+        """S086-06b with letter suffix."""
+        result = self.mixin._extract_session_id("S086-06b-INT-ZwiftFTPTestStandard-V001")
+        assert result == ("S086", "S086-06b")
+
+    def test_session_id_suffix_a(self):
+        """S081-04a with suffix 'a'."""
+        result = self.mixin._extract_session_id("S081-04a-END-EnduranceDouce-V001")
+        assert result == ("S081", "S081-04a")
+
+    def test_no_match(self):
+        """Non-matching activity name returns None."""
+        result = self.mixin._extract_session_id("Morning Ride")
+        assert result is None
+
+    def test_session_id_no_suffix_still_works(self):
+        """Regression: standard IDs without suffix are not broken."""
+        result = self.mixin._extract_session_id("S086-06-END-EnduranceDouce-V001")
+        assert result == ("S086", "S086-06")
+
+
+class TestAutoCompleteRestSessions:
+    """Tests for auto_complete_rest_sessions."""
+
+    @pytest.fixture
+    def mock_tower(self, tmp_path):
+        """Mock Control Tower to use tmp_path."""
+        original_dir = planning_tower.planning_dir
+        original_backup_dir = planning_tower.backup_system.planning_dir
+
+        planning_tower.planning_dir = tmp_path
+        planning_tower.backup_system.planning_dir = tmp_path
+
+        yield tmp_path
+
+        planning_tower.planning_dir = original_dir
+        planning_tower.backup_system.planning_dir = original_backup_dir
+
+    def _write_planning(self, tmp_path, week_id, sessions, start_date="2026-03-23"):
+        """Helper to write a planning JSON file."""
+        # Compute end_date as start + 6 days
+        from datetime import date as d
+        from datetime import timedelta
+
+        sd = d.fromisoformat(start_date)
+        ed = (sd + timedelta(days=6)).isoformat()
+        planning_data = {
+            "week_id": week_id,
+            "start_date": start_date,
+            "end_date": ed,
+            "created_at": "2026-03-01T00:00:00Z",
+            "last_updated": "2026-03-01T00:00:00Z",
+            "version": 1,
+            "athlete_id": "iXXXXXX",
+            "tss_target": 300,
+            "planned_sessions": sessions,
+        }
+        planning_file = tmp_path / f"week_planning_{week_id}.json"
+        with open(planning_file, "w", encoding="utf-8") as f:
+            json.dump(planning_data, f, indent=2)
+        return planning_file
+
+    def test_rest_session_past_date_completed(self, mock_tower):
+        """Rest session (TSS=0, dur=0) with past date → completed."""
+        self._write_planning(
+            mock_tower,
+            "S086",
+            [
+                {
+                    "session_id": "S086-01",
+                    "date": "2026-03-23",
+                    "name": "Repos",
+                    "type": "REC",
+                    "version": "V001",
+                    "tss_planned": 0,
+                    "duration_min": 0,
+                    "description": "",
+                    "status": "planned",
+                },
+            ],
+        )
+
+        mixin = SessionUpdatesMixin()
+        check_date = date(2026, 3, 31)
+
+        with patch(
+            "magma_cycling.daily_sync.calculate_current_week_info",
+            return_value=("S086", date(2026, 3, 23)),
+        ):
+            result = mixin.auto_complete_rest_sessions(check_date)
+
+        assert result == ["S086-01"]
+
+        # Verify persisted
+        from magma_cycling.planning.models import WeeklyPlan
+
+        plan = WeeklyPlan.from_json(mock_tower / "week_planning_S086.json")
+        assert plan.planned_sessions[0].status == "completed"
+
+    def test_rest_session_future_date_stays_planned(self, mock_tower):
+        """Rest session with future date → remains planned."""
+        self._write_planning(
+            mock_tower,
+            "S086",
+            [
+                {
+                    "session_id": "S086-07",
+                    "date": "2026-03-29",
+                    "name": "Repos",
+                    "type": "REC",
+                    "version": "V001",
+                    "tss_planned": 0,
+                    "duration_min": 0,
+                    "description": "",
+                    "status": "planned",
+                },
+            ],
+        )
+
+        mixin = SessionUpdatesMixin()
+        check_date = date(2026, 3, 25)  # Before session date
+
+        with patch(
+            "magma_cycling.daily_sync.calculate_current_week_info",
+            return_value=("S086", date(2026, 3, 23)),
+        ):
+            result = mixin.auto_complete_rest_sessions(check_date)
+
+        assert result == []
+
+        from magma_cycling.planning.models import WeeklyPlan
+
+        plan = WeeklyPlan.from_json(mock_tower / "week_planning_S086.json")
+        assert plan.planned_sessions[0].status == "planned"
+
+    def test_rec_session_with_tss_stays_unchanged(self, mock_tower):
+        """REC session with TSS > 0 is NOT a rest day, stays planned."""
+        self._write_planning(
+            mock_tower,
+            "S086",
+            [
+                {
+                    "session_id": "S086-05",
+                    "date": "2026-03-27",
+                    "name": "RecupActive",
+                    "type": "REC",
+                    "version": "V001",
+                    "tss_planned": 30,
+                    "duration_min": 45,
+                    "description": "Recup active",
+                    "status": "planned",
+                },
+            ],
+        )
+
+        mixin = SessionUpdatesMixin()
+        check_date = date(2026, 3, 31)
+
+        with patch(
+            "magma_cycling.daily_sync.calculate_current_week_info",
+            return_value=("S086", date(2026, 3, 23)),
+        ):
+            result = mixin.auto_complete_rest_sessions(check_date)
+
+        assert result == []
+
+        from magma_cycling.planning.models import WeeklyPlan
+
+        plan = WeeklyPlan.from_json(mock_tower / "week_planning_S086.json")
+        assert plan.planned_sessions[0].status == "planned"
+
+    def test_already_completed_not_touched(self, mock_tower):
+        """Already completed rest session is not re-processed."""
+        self._write_planning(
+            mock_tower,
+            "S086",
+            [
+                {
+                    "session_id": "S086-01",
+                    "date": "2026-03-23",
+                    "name": "Repos",
+                    "type": "REC",
+                    "version": "V001",
+                    "tss_planned": 0,
+                    "duration_min": 0,
+                    "description": "",
+                    "status": "completed",
+                },
+            ],
+        )
+
+        mixin = SessionUpdatesMixin()
+        check_date = date(2026, 3, 31)
+
+        with patch(
+            "magma_cycling.daily_sync.calculate_current_week_info",
+            return_value=("S086", date(2026, 3, 23)),
+        ):
+            result = mixin.auto_complete_rest_sessions(check_date)
+
+        assert result == []
+
+    def test_previous_week_also_checked(self, mock_tower):
+        """Previous week rest sessions are also auto-completed."""
+        self._write_planning(
+            mock_tower,
+            "S085",
+            [
+                {
+                    "session_id": "S085-01",
+                    "date": "2026-03-16",
+                    "name": "Repos",
+                    "type": "REC",
+                    "version": "V001",
+                    "tss_planned": 0,
+                    "duration_min": 0,
+                    "description": "",
+                    "status": "planned",
+                },
+            ],
+            start_date="2026-03-16",
+        )
+        self._write_planning(
+            mock_tower,
+            "S086",
+            [
+                {
+                    "session_id": "S086-03",
+                    "date": "2026-03-25",
+                    "name": "Repos",
+                    "type": "REC",
+                    "version": "V001",
+                    "tss_planned": 0,
+                    "duration_min": 0,
+                    "description": "",
+                    "status": "planned",
+                },
+            ],
+        )
+
+        mixin = SessionUpdatesMixin()
+        check_date = date(2026, 3, 31)
+
+        with patch(
+            "magma_cycling.daily_sync.calculate_current_week_info",
+            return_value=("S086", date(2026, 3, 23)),
+        ):
+            result = mixin.auto_complete_rest_sessions(check_date)
+
+        assert "S086-03" in result
+        assert "S085-01" in result


### PR DESCRIPTION
## Summary

- **Fix regex suffix**: `_extract_session_id()` now captures optional letter suffix (e.g. `S086-06b`) — consistent with Pydantic model pattern
- **Auto-complete rest sessions**: New `auto_complete_rest_sessions()` marks past rest days (TSS=0, duration=0) as completed automatically during daily-sync
- **10 new tests** covering both fixes (regex variants + rest session scenarios)

## Test plan

- [x] `poetry run pytest tests/ -x` — 3234 passed
- [ ] Verify S086-01, S086-03, S086-07 transition to `completed` on next daily-sync
- [ ] Verify S086-06b would match correctly if activities are reprocessed

🤖 Generated with [Claude Code](https://claude.com/claude-code)