### PR TITLE
fix(mcp): call auto_complete_rest_sessions in backfill handler

### DIFF
--- a/magma_cycling/_mcp/handlers/remote_sync.py
+++ b/magma_cycling/_mcp/handlers/remote_sync.py
@@ -380,6 +380,11 @@ async def handle_backfill_activities(args: dict) -> list[TextContent]:
 
         activity_to_session_map = sync.update_completed_sessions(activities)
 
+        # Auto-complete rest sessions (TSS=0, duration=0, date passée)
+        from datetime import date
+
+        sync.auto_complete_rest_sessions(date.today())
+
         updated = {}
         already_completed = {}
         unmatched = []


### PR DESCRIPTION
## Summary

- Add `auto_complete_rest_sessions()` call in `remote_sync.py` backfill-activities handler
- Ensures rest sessions (TSS=0, duration=0) are auto-completed when sync is triggered via MCP, not just via daily-sync CLI

## Test plan

- [x] `poetry run pytest tests/ -x` — 3234 passed
- [ ] Run backfill-activities via MCP and verify S086-01, S086-03, S086-07 → completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)