### PR TITLE
feat(mcp): add validate-local-remote-sync tool

### DIFF
--- a/magma_cycling/_mcp/handlers/analysis.py
+++ b/magma_cycling/_mcp/handlers/analysis.py
@@ -22,6 +22,7 @@ __all__ = [
     "handle_restore_week_from_backup",
     "handle_analyze_training_patterns",
     "handle_get_coach_analysis",
+    "handle_validate_local_remote_sync",
 ]
 
 
@@ -917,3 +918,217 @@ async def handle_get_coach_analysis(args: dict) -> list[TextContent]:
 
     except Exception as e:
         return mcp_response({"error": f"Failed to retrieve coach analysis: {str(e)}"})
+
+
+# ---------------------------------------------------------------------------
+# Local ↔ Remote sync validator
+# ---------------------------------------------------------------------------
+
+
+def _parse_event_name(name: str) -> dict | None:
+    """Parse an Intervals.icu event name using WORKOUT_NAME_REGEX.
+
+    Returns dict with session_id, session_type, workout_name, version
+    or None if the name doesn't match.
+    """
+    from magma_cycling.planning.models import WORKOUT_NAME_REGEX
+
+    match = WORKOUT_NAME_REGEX.search(name)
+    if not match:
+        return None
+    return {
+        "session_id": match.group(1),
+        "session_type": match.group(2),
+        "workout_name": match.group(3),
+        "version": match.group(4),
+    }
+
+
+async def handle_validate_local_remote_sync(args: dict) -> list[TextContent]:
+    """Compare local planning vs remote Intervals.icu events to detect drift."""
+    from magma_cycling._mcp._utils import SYNCABLE_STATUSES
+    from magma_cycling.config import create_intervals_client
+    from magma_cycling.planning.control_tower import planning_tower
+    from magma_cycling.utils.event_sync import calculate_description_hash
+
+    week_id = args["week_id"]
+    include_description_check = args.get("include_description_check", False)
+
+    try:
+        with suppress_stdout_stderr():
+            plan = planning_tower.read_week(week_id)
+
+            client = create_intervals_client()
+            remote_events = client.get_events(
+                oldest=str(plan.start_date),
+                newest=str(plan.end_date),
+            )
+
+            # Index remote WORKOUT events by id
+            remote_by_id: dict[int, dict] = {}
+            remote_workouts: list[dict] = []
+            for event in remote_events:
+                if event.get("category") == "WORKOUT":
+                    eid = event.get("id")
+                    if eid is not None:
+                        remote_by_id[eid] = event
+                        remote_workouts.append(event)
+
+            discrepancies: list[dict] = []
+            linked_remote_ids: set[int] = set()
+
+            # Check each session that has an intervals_id
+            for session in plan.planned_sessions:
+                if session.intervals_id is None:
+                    continue
+
+                linked_remote_ids.add(session.intervals_id)
+                remote_event = remote_by_id.get(session.intervals_id)
+
+                if remote_event is None:
+                    discrepancies.append(
+                        {
+                            "session_id": session.session_id,
+                            "intervals_id": session.intervals_id,
+                            "type": "REMOTE_MISSING",
+                            "local": session.session_id,
+                            "remote": None,
+                            "severity": "HIGH",
+                        }
+                    )
+                    continue
+
+                # Parse the remote event name
+                parsed = _parse_event_name(remote_event.get("name", ""))
+                if parsed is None:
+                    # Unparseable remote name — skip structured checks
+                    continue
+
+                # 1. SESSION_ID_MISMATCH (detects swaps)
+                if parsed["session_id"] != session.session_id:
+                    discrepancies.append(
+                        {
+                            "session_id": session.session_id,
+                            "intervals_id": session.intervals_id,
+                            "type": "SESSION_ID_MISMATCH",
+                            "local": session.session_id,
+                            "remote": parsed["session_id"],
+                            "severity": "HIGH",
+                        }
+                    )
+
+                # 2. NAME_MISMATCH
+                if parsed["workout_name"] != session.name:
+                    discrepancies.append(
+                        {
+                            "session_id": session.session_id,
+                            "intervals_id": session.intervals_id,
+                            "type": "NAME_MISMATCH",
+                            "local": session.name,
+                            "remote": parsed["workout_name"],
+                            "severity": "HIGH",
+                        }
+                    )
+
+                # 3. TYPE_MISMATCH
+                if parsed["session_type"] != session.session_type:
+                    discrepancies.append(
+                        {
+                            "session_id": session.session_id,
+                            "intervals_id": session.intervals_id,
+                            "type": "TYPE_MISMATCH",
+                            "local": session.session_type,
+                            "remote": parsed["session_type"],
+                            "severity": "HIGH",
+                        }
+                    )
+
+                # 4. DATE_MISMATCH
+                remote_date_str = remote_event.get("start_date_local", "")[:10]
+                if remote_date_str and remote_date_str != str(session.session_date):
+                    discrepancies.append(
+                        {
+                            "session_id": session.session_id,
+                            "intervals_id": session.intervals_id,
+                            "type": "DATE_MISMATCH",
+                            "local": str(session.session_date),
+                            "remote": remote_date_str,
+                            "severity": "HIGH",
+                        }
+                    )
+
+                # 5. DESCRIPTION_MISMATCH (opt-in, off by default)
+                if include_description_check:
+                    remote_desc = remote_event.get("description", "") or ""
+                    local_desc = session.description or ""
+                    if local_desc and remote_desc:
+                        local_hash = calculate_description_hash(local_desc)
+                        remote_hash = calculate_description_hash(remote_desc)
+                        if local_hash != remote_hash:
+                            discrepancies.append(
+                                {
+                                    "session_id": session.session_id,
+                                    "intervals_id": session.intervals_id,
+                                    "type": "DESCRIPTION_MISMATCH",
+                                    "local": local_hash,
+                                    "remote": remote_hash,
+                                    "severity": "LOW",
+                                }
+                            )
+
+            # Orphaned remote: WORKOUT events not linked to any local session
+            orphaned_remote = []
+            for event in remote_workouts:
+                eid = event.get("id")
+                if eid not in linked_remote_ids:
+                    parsed = _parse_event_name(event.get("name", ""))
+                    orphaned_remote.append(
+                        {
+                            "intervals_id": eid,
+                            "name": event.get("name", ""),
+                            "date": event.get("start_date_local", "")[:10],
+                            "parsed": parsed,
+                        }
+                    )
+
+            # Unlinked local: sessions that should be synced but have no intervals_id
+            unlinked_local = []
+            for session in plan.planned_sessions:
+                if session.intervals_id is None and session.status in SYNCABLE_STATUSES:
+                    unlinked_local.append(
+                        {
+                            "session_id": session.session_id,
+                            "name": session.name,
+                            "status": session.status,
+                            "date": str(session.session_date),
+                        }
+                    )
+
+            sessions_checked = sum(1 for s in plan.planned_sessions if s.intervals_id is not None)
+            status = "DRIFT_DETECTED" if discrepancies or orphaned_remote else "IN_SYNC"
+
+            result = {
+                "week_id": week_id,
+                "status": status,
+                "sessions_checked": sessions_checked,
+                "discrepancies": discrepancies,
+                "orphaned_remote": orphaned_remote,
+                "unlinked_local": unlinked_local,
+            }
+
+        return mcp_response(result)
+
+    except FileNotFoundError:
+        return mcp_response(
+            {
+                "error": f"Planning not found for {week_id}",
+                "week_id": week_id,
+            }
+        )
+    except Exception as e:
+        return mcp_response(
+            {
+                "error": f"Sync validation error: {str(e)}",
+                "week_id": week_id,
+            }
+        )

--- a/magma_cycling/_mcp/schemas/analysis.py
+++ b/magma_cycling/_mcp/schemas/analysis.py
@@ -142,6 +142,26 @@ def get_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="validate-local-remote-sync",
+            description="Compare local planning sessions vs Intervals.icu remote events to detect sync drift (name/type/date mismatches, swaps, orphans). Description check off by default (structural noise).",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "week_id": {
+                        "type": "string",
+                        "description": "Week ID (e.g., S087)",
+                        "pattern": "^S\\d{3}$",
+                    },
+                    "include_description_check": {
+                        "type": "boolean",
+                        "description": "Include DESCRIPTION_MISMATCH checks (default: false, opt-in for debug)",
+                        "default": False,
+                    },
+                },
+                "required": ["week_id"],
+            },
+        ),
+        Tool(
             name="get-coach-analysis",
             description="Retrieve past coach AI analysis from workouts-history.md by activity ID, session ID, or date",
             inputSchema={

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -42,6 +42,7 @@ from magma_cycling._mcp.handlers.analysis import (  # noqa: F401
     handle_get_recommendations,
     handle_get_training_statistics,
     handle_restore_week_from_backup,
+    handle_validate_local_remote_sync,
     handle_validate_week_consistency,
 )
 from magma_cycling._mcp.handlers.athlete import (  # noqa: F401
@@ -205,6 +206,7 @@ TOOL_HANDLERS = {
     "restore-week-from-backup": handle_restore_week_from_backup,
     "analyze-training-patterns": handle_analyze_training_patterns,
     "get-coach-analysis": handle_get_coach_analysis,
+    "validate-local-remote-sync": handle_validate_local_remote_sync,
     # Admin (2)
     "reload-server": handle_reload_server,
     "system-info": handle_system_info,

--- a/tests/test_mcp_sync_validator.py
+++ b/tests/test_mcp_sync_validator.py
@@ -1,0 +1,500 @@
+"""Tests for validate-local-remote-sync MCP tool."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.analysis import (
+    _parse_event_name,
+    handle_validate_local_remote_sync,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: _parse_event_name
+# ---------------------------------------------------------------------------
+
+
+class TestParseEventName:
+    """Unit tests for _parse_event_name helper."""
+
+    def test_standard_name(self):
+        result = _parse_event_name("S087-01-REC-RecoveryActive-V001")
+        assert result == {
+            "session_id": "S087-01",
+            "session_type": "REC",
+            "workout_name": "RecoveryActive",
+            "version": "V001",
+        }
+
+    def test_double_session_suffix(self):
+        result = _parse_event_name("S081-06a-INT-TempoSoutenu-V001")
+        assert result == {
+            "session_id": "S081-06a",
+            "session_type": "INT",
+            "workout_name": "TempoSoutenu",
+            "version": "V001",
+        }
+
+    def test_cancelled_prefix(self):
+        result = _parse_event_name("[ANNULÉE] S087-04-INT-SweetSpot-V001")
+        assert result is not None
+        assert result["session_id"] == "S087-04"
+        assert result["session_type"] == "INT"
+        assert result["workout_name"] == "SweetSpot"
+
+    def test_no_match(self):
+        assert _parse_event_name("Random Note Title") is None
+        assert _parse_event_name("") is None
+
+    def test_partial_match(self):
+        assert _parse_event_name("S087-01-REC") is None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_session(
+    session_id="S087-01",
+    name="RecoveryActive",
+    session_type="REC",
+    session_date=date(2026, 3, 30),
+    intervals_id=101,
+    status="uploaded",
+    description="Easy spin",
+):
+    """Create a mock Session object."""
+    s = MagicMock()
+    s.session_id = session_id
+    s.name = name
+    s.session_type = session_type
+    s.session_date = session_date
+    s.intervals_id = intervals_id
+    s.status = status
+    s.description = description
+    return s
+
+
+def _make_event(
+    eid=101,
+    name="S087-01-REC-RecoveryActive-V001",
+    start_date="2026-03-30T08:00:00",
+    description="Easy spin",
+    category="WORKOUT",
+):
+    """Create a mock remote event dict."""
+    return {
+        "id": eid,
+        "name": name,
+        "start_date_local": start_date,
+        "description": description,
+        "category": category,
+    }
+
+
+def _extract_result(response):
+    """Extract the JSON result from an MCP response."""
+    return json.loads(response[0].text)
+
+
+# ---------------------------------------------------------------------------
+# Handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateLocalRemoteSync:
+    """Tests for handle_validate_local_remote_sync."""
+
+    @pytest.mark.asyncio
+    async def test_in_sync(self):
+        """All sessions match remote — IN_SYNC."""
+        session = _make_session()
+        event = _make_event()
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "IN_SYNC"
+        assert result["sessions_checked"] == 1
+        assert result["discrepancies"] == []
+        assert result["orphaned_remote"] == []
+
+    @pytest.mark.asyncio
+    async def test_name_mismatch(self):
+        """Local name differs from remote parsed name."""
+        session = _make_session(name="SweetSpotProgressif")
+        event = _make_event(name="S087-01-REC-RecoveryActive-V001")
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "DRIFT_DETECTED"
+        names = [d["type"] for d in result["discrepancies"]]
+        assert "NAME_MISMATCH" in names
+
+    @pytest.mark.asyncio
+    async def test_type_mismatch(self):
+        """Local type differs from remote parsed type."""
+        session = _make_session(session_type="INT")
+        event = _make_event(name="S087-01-REC-RecoveryActive-V001")
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "DRIFT_DETECTED"
+        types = [d["type"] for d in result["discrepancies"]]
+        assert "TYPE_MISMATCH" in types
+
+    @pytest.mark.asyncio
+    async def test_date_mismatch(self):
+        """Local date differs from remote date."""
+        session = _make_session(session_date=date(2026, 3, 30))
+        event = _make_event(start_date="2026-03-31T08:00:00")
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "DRIFT_DETECTED"
+        types = [d["type"] for d in result["discrepancies"]]
+        assert "DATE_MISMATCH" in types
+
+    @pytest.mark.asyncio
+    async def test_session_id_mismatch_detects_swap(self):
+        """Session ID in remote name differs from local — detects swap."""
+        session = _make_session(session_id="S087-01")
+        event = _make_event(name="S087-03-REC-RecoveryActive-V001")
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "DRIFT_DETECTED"
+        swap = [d for d in result["discrepancies"] if d["type"] == "SESSION_ID_MISMATCH"]
+        assert len(swap) == 1
+        assert swap[0]["local"] == "S087-01"
+        assert swap[0]["remote"] == "S087-03"
+
+    @pytest.mark.asyncio
+    async def test_description_mismatch_skipped_by_default(self):
+        """Description check is off by default — no DESCRIPTION_MISMATCH."""
+        session = _make_session(description="Local description v2")
+        event = _make_event(description="Remote description v1")
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "IN_SYNC"
+        desc = [d for d in result["discrepancies"] if d["type"] == "DESCRIPTION_MISMATCH"]
+        assert len(desc) == 0
+
+    @pytest.mark.asyncio
+    async def test_description_mismatch_opt_in(self):
+        """Description check enabled via include_description_check=true."""
+        session = _make_session(description="Local description v2")
+        event = _make_event(description="Remote description v1")
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(
+                await handle_validate_local_remote_sync(
+                    {
+                        "week_id": "S087",
+                        "include_description_check": True,
+                    }
+                )
+            )
+
+        desc = [d for d in result["discrepancies"] if d["type"] == "DESCRIPTION_MISMATCH"]
+        assert len(desc) == 1
+        assert desc[0]["severity"] == "LOW"
+
+    @pytest.mark.asyncio
+    async def test_remote_missing(self):
+        """Local session points to intervals_id that doesn't exist remotely."""
+        session = _make_session(intervals_id=999)
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = []
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "DRIFT_DETECTED"
+        missing = [d for d in result["discrepancies"] if d["type"] == "REMOTE_MISSING"]
+        assert len(missing) == 1
+        assert missing[0]["intervals_id"] == 999
+
+    @pytest.mark.asyncio
+    async def test_orphaned_remote(self):
+        """Remote WORKOUT event not linked to any local session."""
+        session = _make_session(intervals_id=101)
+        event_linked = _make_event(eid=101)
+        event_orphan = _make_event(
+            eid=202,
+            name="S087-05-END-EnduranceDouce-V001",
+            start_date="2026-04-01T08:00:00",
+        )
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event_linked, event_orphan]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "DRIFT_DETECTED"
+        assert len(result["orphaned_remote"]) == 1
+        assert result["orphaned_remote"][0]["intervals_id"] == 202
+
+    @pytest.mark.asyncio
+    async def test_unlinked_local(self):
+        """Local session is syncable but has no intervals_id."""
+        session_linked = _make_session(intervals_id=101)
+        session_unlinked = _make_session(
+            session_id="S087-02",
+            name="Tempo",
+            intervals_id=None,
+            status="planned",
+        )
+        event = _make_event(eid=101)
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session_linked, session_unlinked]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert len(result["unlinked_local"]) == 1
+        assert result["unlinked_local"][0]["session_id"] == "S087-02"
+
+    @pytest.mark.asyncio
+    async def test_planning_not_found(self):
+        """Returns error when planning file doesn't exist."""
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.read_week.side_effect = FileNotFoundError("not found")
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S999"}))
+
+        assert "error" in result
+        assert "not found" in result["error"].lower() or "Planning" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_api_error(self):
+        """Returns error when Intervals.icu API fails."""
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = []
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.side_effect = Exception("API timeout")
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert "error" in result
+        assert "API timeout" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_note_events_ignored(self):
+        """NOTE events should not appear as orphaned_remote."""
+        session = _make_session(intervals_id=101)
+        event = _make_event(eid=101)
+        note_event = {
+            "id": 300,
+            "name": "Rest day note",
+            "category": "NOTE",
+            "start_date_local": "2026-04-01T00:00:00",
+        }
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [event, note_event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["status"] == "IN_SYNC"
+        assert result["orphaned_remote"] == []
+
+    @pytest.mark.asyncio
+    async def test_completed_session_without_intervals_id_not_unlinked(self):
+        """Completed sessions without intervals_id are not reported as unlinked."""
+        session = _make_session(intervals_id=None, status="completed")
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = []
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert result["unlinked_local"] == []
+
+    @pytest.mark.asyncio
+    async def test_metadata_present(self):
+        """Response includes _metadata."""
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = []
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = []
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        assert "_metadata" in result
+        assert "response_date" in result["_metadata"]


### PR DESCRIPTION
## Summary
- New MCP tool `validate-local-remote-sync` comparing local planning vs Intervals.icu remote events
- Detects: SESSION_ID_MISMATCH (swaps), NAME/TYPE/DATE_MISMATCH, REMOTE_MISSING, orphaned remote, unlinked local
- Description check opt-in (`include_description_check: false` by default) to avoid structural noise
- 20 tests covering all checks, edge cases, and error handling

## Test plan
- [x] `poetry run pytest tests/test_mcp_sync_validator.py -x -v` — 20 passed
- [x] `poetry run pytest tests/ -x` — 3254 passed
- [x] Live validation: swap S087-04↔S087-05 → IN_SYNC, swap back → IN_SYNC
- [x] Pre-commit hooks pass (black, ruff, isort, pydocstyle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)