### PR TITLE
feat(mcp): sync rest days as NOTE instead of WORKOUT

### DIFF
--- a/magma_cycling/_mcp/handlers/analysis.py
+++ b/magma_cycling/_mcp/handlers/analysis.py
@@ -964,15 +964,16 @@ async def handle_validate_local_remote_sync(args: dict) -> list[TextContent]:
                 newest=str(plan.end_date),
             )
 
-            # Index remote WORKOUT events by id
+            # Index all remote events by id (for intervals_id lookup)
             remote_by_id: dict[int, dict] = {}
+            # Keep WORKOUT-only list for orphan detection
             remote_workouts: list[dict] = []
             for event in remote_events:
+                eid = event.get("id")
+                if eid is not None:
+                    remote_by_id[eid] = event
                 if event.get("category") == "WORKOUT":
-                    eid = event.get("id")
-                    if eid is not None:
-                        remote_by_id[eid] = event
-                        remote_workouts.append(event)
+                    remote_workouts.append(event)
 
             discrepancies: list[dict] = []
             linked_remote_ids: set[int] = set()

--- a/magma_cycling/_mcp/handlers/remote_sync.py
+++ b/magma_cycling/_mcp/handlers/remote_sync.py
@@ -77,34 +77,48 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
                 )
                 full_description = workout_descriptions.get(intervals_name, session.description)
 
-                event_data = {
-                    "category": "WORKOUT",
-                    "type": "VirtualRide",
-                    "name": intervals_name,
-                    "description": full_description,
-                    "start_date_local": f"{session.session_date}T{start_time}",
-                }
+                is_rest_day = (
+                    session.session_type == "REC"
+                    and session.tss_planned == 0
+                    and session.duration_min == 0
+                )
 
-                if (
-                    session.duration_min
-                    and session.duration_min > 0
-                    and full_description
-                    and full_description.strip()
-                ):
-                    from magma_cycling.intervals_format_validator import (
-                        IntervalsFormatValidator,
-                    )
+                if is_rest_day:
+                    event_data = {
+                        "category": "NOTE",
+                        "name": intervals_name,
+                        "description": session.description or "Jour de repos complet",
+                        "start_date_local": f"{session.session_date}T06:00:00",
+                    }
+                else:
+                    event_data = {
+                        "category": "WORKOUT",
+                        "type": "VirtualRide",
+                        "name": intervals_name,
+                        "description": full_description,
+                        "start_date_local": f"{session.session_date}T{start_time}",
+                    }
 
-                    validator = IntervalsFormatValidator()
-                    is_valid, val_errors, _val_warnings = validator.validate_workout(
-                        full_description
-                    )
-                    if not is_valid:
-                        errors.append(
-                            f"Session {session.session_id}: workout validation failed — {val_errors}. "
-                            f"Fix with validate-workout tool, then retry sync."
+                    if (
+                        session.duration_min
+                        and session.duration_min > 0
+                        and full_description
+                        and full_description.strip()
+                    ):
+                        from magma_cycling.intervals_format_validator import (
+                            IntervalsFormatValidator,
                         )
-                        continue
+
+                        validator = IntervalsFormatValidator()
+                        is_valid, val_errors, _val_warnings = validator.validate_workout(
+                            full_description
+                        )
+                        if not is_valid:
+                            errors.append(
+                                f"Session {session.session_id}: workout validation failed — {val_errors}. "
+                                f"Fix with validate-workout tool, then retry sync."
+                            )
+                            continue
 
                 existing_event = None
                 if session.intervals_id and session.intervals_id in remote_workouts:

--- a/tests/_mcp/handlers/test_remote_sync.py
+++ b/tests/_mcp/handlers/test_remote_sync.py
@@ -1,0 +1,175 @@
+"""Tests for rest day NOTE sync in _mcp/handlers/remote_sync.py."""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.remote_sync import handle_sync_week_to_calendar
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MOCK_PROVIDER_INFO = {"provider": "intervals_icu", "athlete_id": "iXXXXXX", "status": "ready"}
+
+
+def _make_session(
+    session_id="S099-07",
+    name="ReposComplet",
+    session_type="REC",
+    tss_planned=0,
+    duration_min=0,
+    session_date=date(2026, 4, 5),
+    description="Repos complet",
+    status="planned",
+    intervals_id=None,
+    version="V001",
+):
+    """Create a mock PlannedSession."""
+    s = MagicMock()
+    s.session_id = session_id
+    s.name = name
+    s.session_type = session_type
+    s.tss_planned = tss_planned
+    s.duration_min = duration_min
+    s.session_date = session_date
+    s.description = description
+    s.status = status
+    s.intervals_id = intervals_id
+    s.version = version
+    return s
+
+
+def _make_plan(sessions, start_date=date(2026, 3, 30), end_date=date(2026, 4, 5)):
+    """Create a mock WeeklyPlan."""
+    plan = MagicMock()
+    plan.start_date = start_date
+    plan.end_date = end_date
+    plan.planned_sessions = sessions
+    return plan
+
+
+@contextmanager
+def _patch_sync(plan, client, workout_descriptions=None):
+    """Patch planning_tower, intervals_client, and workout descriptions."""
+    with (
+        patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+        patch("magma_cycling.config.create_intervals_client") as mock_factory,
+        patch(
+            "magma_cycling._mcp.handlers.remote_sync.load_workout_descriptions",
+            return_value=workout_descriptions or {},
+        ),
+    ):
+        mock_tower.read_week.return_value = plan
+        mock_factory.return_value = client
+        yield mock_tower
+
+
+def _make_client(create_return=None):
+    """Create a mock IntervalsClient."""
+    client = MagicMock()
+    client.get_events.return_value = []
+    client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+    client.create_event.return_value = create_return or {"id": 777}
+    return client
+
+
+def _extract(response):
+    """Extract JSON from MCP response."""
+    return json.loads(response[0].text)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRestDayCreatesNote:
+    """Rest day sessions (REC, TSS=0, duration=0) → NOTE event."""
+
+    @pytest.mark.asyncio
+    async def test_rest_day_creates_note(self):
+        """A rest day session should produce category=NOTE without type=VirtualRide."""
+        session = _make_session()
+        plan = _make_plan([session])
+        client = _make_client()
+
+        with _patch_sync(plan, client):
+            result = _extract(await handle_sync_week_to_calendar({"week_id": "S099"}))
+
+        assert result["summary"]["to_create"] == 1
+        # Verify the event_data passed to create_event
+        call_args = client.create_event.call_args[0][0]
+        assert call_args["category"] == "NOTE"
+        assert "type" not in call_args
+        assert call_args["start_date_local"] == "2026-04-05T06:00:00"
+
+    @pytest.mark.asyncio
+    async def test_rest_day_writeback_intervals_id(self):
+        """The intervals_id from the created NOTE should be written back to local planning."""
+        session = _make_session()
+        plan = _make_plan([session])
+        client = _make_client(create_return={"id": 888})
+
+        with _patch_sync(plan, client) as mock_tower:
+            # Setup modify_week context manager
+            modify_plan = MagicMock()
+            modify_plan.planned_sessions = [_make_session(intervals_id=None)]
+
+            @contextmanager
+            def _modify_cm(*args, **kwargs):
+                yield modify_plan
+
+            mock_tower.modify_week.side_effect = _modify_cm
+
+            result = _extract(await handle_sync_week_to_calendar({"week_id": "S099"}))
+
+        assert result["summary"]["created"] == 1
+        # Verify modify_week was called to write back the id
+        mock_tower.modify_week.assert_called_once()
+        assert modify_plan.planned_sessions[0].intervals_id == 888
+
+    @pytest.mark.asyncio
+    async def test_active_recovery_creates_workout(self):
+        """A REC session with TSS>0 and duration>0 should remain a WORKOUT."""
+        session = _make_session(
+            session_id="S099-01",
+            name="RecoveryActive",
+            tss_planned=30,
+            duration_min=45,
+            description="- 45m 55% 85rpm",
+        )
+        plan = _make_plan([session])
+        client = _make_client()
+
+        with _patch_sync(plan, client):
+            result = _extract(await handle_sync_week_to_calendar({"week_id": "S099"}))
+
+        assert result["summary"]["to_create"] == 1
+        call_args = client.create_event.call_args[0][0]
+        assert call_args["category"] == "WORKOUT"
+        assert call_args["type"] == "VirtualRide"
+
+    @pytest.mark.asyncio
+    async def test_rest_day_skips_validation(self):
+        """Rest day should not trigger IntervalsFormatValidator."""
+        session = _make_session()
+        plan = _make_plan([session])
+        client = _make_client()
+
+        with (
+            _patch_sync(plan, client),
+            patch(
+                "magma_cycling.intervals_format_validator.IntervalsFormatValidator"
+            ) as mock_validator_cls,
+        ):
+            result = _extract(await handle_sync_week_to_calendar({"week_id": "S099"}))
+
+        # Validator should never be instantiated for rest days
+        mock_validator_cls.assert_not_called()
+        assert result["summary"]["errors"] == 0

--- a/tests/test_mcp_sync_validator.py
+++ b/tests/test_mcp_sync_validator.py
@@ -478,6 +478,44 @@ class TestValidateLocalRemoteSync:
         assert result["unlinked_local"] == []
 
     @pytest.mark.asyncio
+    async def test_rest_day_note_not_remote_missing(self):
+        """A rest day synced as NOTE should not trigger REMOTE_MISSING."""
+        session = _make_session(
+            session_id="S087-07",
+            name="ReposComplet",
+            session_type="REC",
+            intervals_id=500,
+            status="uploaded",
+        )
+        # The remote event is a NOTE (not a WORKOUT)
+        note_event = _make_event(
+            eid=500,
+            name="S087-07-REC-ReposComplet-V001",
+            category="NOTE",
+        )
+
+        plan = MagicMock()
+        plan.start_date = date(2026, 3, 30)
+        plan.end_date = date(2026, 4, 5)
+        plan.planned_sessions = [session]
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.config.create_intervals_client") as mock_client_factory,
+        ):
+            mock_tower.read_week.return_value = plan
+            mock_client = MagicMock()
+            mock_client.get_events.return_value = [note_event]
+            mock_client_factory.return_value = mock_client
+
+            result = _extract_result(await handle_validate_local_remote_sync({"week_id": "S087"}))
+
+        # No REMOTE_MISSING — the NOTE event is found in remote_by_id
+        missing = [d for d in result["discrepancies"] if d["type"] == "REMOTE_MISSING"]
+        assert len(missing) == 0
+        assert result["status"] == "IN_SYNC"
+
+    @pytest.mark.asyncio
     async def test_metadata_present(self):
         """Response includes _metadata."""
         plan = MagicMock()


### PR DESCRIPTION
## Summary

- Rest day sessions (REC, TSS=0, duration=0) are now synced as **NOTE** events on Intervals.icu instead of WORKOUT — eliminates the misleading ❌ 0% compliance display
- Sync validator (`validate-local-remote-sync`) indexes all event categories in `remote_by_id`, preventing false `REMOTE_MISSING` for NOTE-linked sessions
- WORKOUT-only filter preserved for orphan detection (no behavior change there)

## Test plan

- [x] `test_rest_day_creates_note` — REC/TSS=0/dur=0 → category=NOTE, no VirtualRide type
- [x] `test_rest_day_writeback_intervals_id` — NOTE id written back to local planning
- [x] `test_active_recovery_creates_workout` — REC/TSS=30/dur=45 → still WORKOUT
- [x] `test_rest_day_skips_validation` — no IntervalsFormatValidator call
- [x] `test_rest_day_note_not_remote_missing` — NOTE event found in validator, no false drift
- [x] Full suite: 3259 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)