### PR TITLE
fix(planning): recalculate duration_min from workout blocks

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -86,6 +86,13 @@ def _parse_ai_workouts(raw_text: str, start_date: date) -> list[dict]:
         if dur_match:
             duration = int(dur_match.group(1))
 
+        # Recalculate from blocks (source of truth)
+        from magma_cycling.workout_parser import calculate_workout_duration
+
+        calculated = calculate_workout_duration(content_stripped)
+        if calculated is not None:
+            duration = calculated
+
         workouts.append(
             {
                 "session_id": session_id,
@@ -733,6 +740,16 @@ async def handle_modify_session_details(args: dict) -> list[TextContent]:
                             session.session_type = session_type
                         if description:
                             session.description = description
+                            # Auto-recalculate duration from blocks if not explicitly provided
+                            if duration_min is None:
+                                from magma_cycling.workout_parser import (
+                                    calculate_workout_duration,
+                                )
+
+                                calculated = calculate_workout_duration(description)
+                                if calculated is not None:
+                                    session.duration_min = calculated
+                                    modifications.append(f"duration={calculated}min (auto)")
                         if tss_planned is not None:
                             session.tss_planned = tss_planned
                         if duration_min is not None:

--- a/magma_cycling/workflows/eow/upload.py
+++ b/magma_cycling/workflows/eow/upload.py
@@ -163,6 +163,17 @@ class UploadMixin:
                     "tss_planned": tss,
                 }
 
+            # Recalculate durations from blocks (source of truth)
+            from magma_cycling.workout_parser import calculate_workout_duration
+
+            body_pattern = r"=== WORKOUT (S\d+-\d+-\w+-\w+-V\d+) ===\n(.*?)\n=== FIN WORKOUT ==="
+            for body_match in re.finditer(body_pattern, workouts_text, re.DOTALL):
+                wid = body_match.group(1)
+                if wid in workout_metadata:
+                    calculated = calculate_workout_duration(body_match.group(2).strip())
+                    if calculated is not None:
+                        workout_metadata[wid]["duration_min"] = calculated
+
             print(f"     ✓ {len(workout_metadata)} workouts parsés")
 
             # Get uploaded events from Intervals.icu

--- a/magma_cycling/workout_parser.py
+++ b/magma_cycling/workout_parser.py
@@ -168,6 +168,18 @@ def parse_workout_text(text: str) -> list[WorkoutBlock]:
     return blocks
 
 
+def calculate_workout_duration(description: str) -> int | None:
+    """Calculate total workout duration from structured blocks.
+
+    Returns total minutes if blocks were parsed, None otherwise (rest day, unparseable).
+    """
+    blocks = parse_workout_text(description)
+    if not blocks:
+        return None
+    total_seconds = sum(b.duration_seconds for b in blocks)
+    return total_seconds // 60
+
+
 def classify_interval_type(block: WorkoutBlock, main_blocks: list[WorkoutBlock]) -> str:
     """Classify a block as WORK or RECOVERY.
 

--- a/tests/_mcp/handlers/test_planning_duration.py
+++ b/tests/_mcp/handlers/test_planning_duration.py
@@ -1,0 +1,114 @@
+"""Tests for duration recalculation from workout blocks."""
+
+import json
+from datetime import UTC, date, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.planning import _parse_ai_workouts
+
+
+class TestParseAiWorkoutsRecalculatesDuration:
+    """Test that _parse_ai_workouts recalculates duration from blocks."""
+
+    def test_blocks_override_header_duration(self):
+        """Header says 90min but blocks total 75min → duration_min == 75."""
+        raw_text = """\
+=== WORKOUT S087-03-SST-SweetSpotProgressif-V001 ===
+SweetSpot Progressif (90min, 72 TSS)
+
+Warmup
+- 10m ramp 50-65% 85rpm
+- 5m 65% 90rpm
+
+Main set
+- 40m 88-92% 90rpm
+- 5m 62% 85rpm
+
+Cooldown
+- 10m ramp 65-50% 85rpm
+- 5m 50% 80rpm
+=== FIN WORKOUT ==="""
+
+        start_date = date(2026, 3, 30)
+        workouts = _parse_ai_workouts(raw_text, start_date)
+
+        assert len(workouts) == 1
+        assert workouts[0]["duration_min"] == 75  # blocks: 10+5+40+5+10+5
+        assert workouts[0]["tss_planned"] == 72  # TSS still from header
+
+
+class TestModifySessionAutoCalculatesDuration:
+    """Test that modify-session-details auto-calculates duration from blocks."""
+
+    @pytest.mark.asyncio
+    async def test_auto_calculates_duration_from_description(self):
+        """Description with structured blocks → auto-calculated duration."""
+        from magma_cycling._mcp.handlers.planning import handle_modify_session_details
+        from magma_cycling.planning.models import Session, WeeklyPlan
+
+        # Build a mock plan with one session
+        session = Session(
+            session_id="S087-03",
+            date=date(2026, 4, 2),
+            name="SweetSpotProgressif",
+            type="SST",
+            version="V001",
+            tss_planned=72,
+            duration_min=90,
+            description="Old description",
+            status="planned",
+        )
+        mock_plan = WeeklyPlan(
+            week_id="S087",
+            start_date=date(2026, 3, 30),
+            end_date=date(2026, 4, 5),
+            tss_target=350,
+            planned_sessions=[session],
+            created_at=datetime.now(UTC),
+            last_updated=datetime.now(UTC),
+            version=1,
+            athlete_id="i000000",
+        )
+
+        new_description = """\
+SweetSpot Progressif (90min, 72 TSS)
+
+Warmup
+- 10m ramp 50-65% 85rpm
+- 5m 65% 90rpm
+
+Main set
+- 40m 88-92% 90rpm
+- 5m 62% 85rpm
+
+Cooldown
+- 10m ramp 65-50% 85rpm
+- 5m 50% 80rpm"""
+
+        # Mock the context manager from planning_tower.modify_week
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_plan)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.modify_week.return_value = mock_cm
+
+            result = await handle_modify_session_details(
+                {
+                    "week_id": "S087",
+                    "session_id": "S087-03",
+                    "description": new_description,
+                    # No duration_min provided → should auto-calculate
+                }
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert "duration=75min (auto)" in data["modifications"]
+
+        # Verify the session was actually modified
+        modified = mock_plan.planned_sessions[0]
+        assert modified.description == new_description
+        assert modified.duration_min == 75

--- a/tests/test_workout_parser.py
+++ b/tests/test_workout_parser.py
@@ -5,6 +5,7 @@ import pytest
 from magma_cycling.workout_parser import (
     Phase,
     WorkoutBlock,
+    calculate_workout_duration,
     classify_interval_type,
     compute_intervals,
     parse_workout_text,
@@ -254,3 +255,74 @@ class TestComputeIntervals:
         assert intervals[1].type == "WORK"
         assert intervals[2].type == "RECOVERY"
         assert intervals[3].type == "WORK"
+
+
+class TestCalculateWorkoutDuration:
+    """Tests for calculate_workout_duration()."""
+
+    def test_simple_workout(self):
+        """Blocs 10+3+45+10=68 → retourne 68."""
+        text = """\
+Endurance Base (68min, 48 TSS)
+
+Warmup
+- 10m ramp 50-65% 85rpm
+- 3m 65% 90rpm
+
+Main set
+- 45m 68-72% 88rpm
+
+Cooldown
+- 10m ramp 65-50% 85rpm
+"""
+        assert calculate_workout_duration(text) == 68
+
+    def test_repeated_blocks(self):
+        """Main set 3x → expansion correcte."""
+        text = """\
+Variations Cadence (40min, 32 TSS)
+
+Warmup
+- 5m ramp 50-65% 85rpm
+
+Main set 3x
+- 3m 70% 95rpm
+- 2m 70% 80rpm
+- 3m 70% 105rpm
+- 2m 65% 85rpm
+
+Cooldown
+- 5m ramp 65-50% 85rpm
+"""
+        # 5 + 3*(3+2+3+2) + 5 = 5 + 30 + 5 = 40
+        assert calculate_workout_duration(text) == 40
+
+    def test_rest_day_returns_none(self):
+        """Texte REPOS → None."""
+        text = "REPOS\n\nSéance reportée à samedi."
+        assert calculate_workout_duration(text) is None
+
+    def test_unparseable_returns_none(self):
+        """Texte libre sans blocs structurés → None."""
+        text = "Sortie libre en endurance, rouler au feeling."
+        assert calculate_workout_duration(text) is None
+
+    def test_header_ignored_blocks_used(self):
+        """Header dit 90min, blocs totalisent 75min → retourne 75."""
+        text = """\
+SweetSpot Progressif (90min, 72 TSS)
+
+Warmup
+- 10m ramp 50-65% 85rpm
+- 5m 65% 90rpm
+
+Main set
+- 40m 88-92% 90rpm
+- 5m 62% 85rpm
+
+Cooldown
+- 10m ramp 65-50% 85rpm
+- 5m 50% 80rpm
+"""
+        # 10+5+40+5+10+5 = 75 (header says 90)
+        assert calculate_workout_duration(text) == 75


### PR DESCRIPTION
## Summary

- Add `calculate_workout_duration()` in `workout_parser.py` — sums parsed block durations as source of truth
- Fix `_parse_ai_workouts` to override header duration with block-calculated duration
- Fix `modify-session-details` to auto-calculate duration when description is updated without explicit `duration_min`
- Fix EOW upload pipeline to recalculate durations from full workout bodies
- Falls back to header value for rest days and unparseable text

**Root cause**: LLM generates header `(Xmin, Y TSS)` and structured blocks independently. System extracted duration from header only, while Intervals.icu parses blocks → local/remote divergence (e.g. S087-03: 130% adherence instead of ~107%).

## Test plan

- [x] 5 unit tests for `calculate_workout_duration()` (simple, repeated, rest, unparseable, header-vs-blocks)
- [x] 2 integration tests (parse_ai_workouts override + modify-session auto-calc)
- [x] Full suite: 3266 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)