### PR TITLE
feat(planning): reconcile TSS local vs remote at upload time

### DIFF
--- a/magma_cycling/_mcp/handlers/remote_sync.py
+++ b/magma_cycling/_mcp/handlers/remote_sync.py
@@ -182,6 +182,11 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
 
             created_count = 0
             updated_count = 0
+            tss_pairs = []
+            tss_reconciliation_summary = None
+
+            # Build local TSS lookup from plan sessions
+            local_tss_map = {s.session_id: s.tss_planned for s in sessions_to_process}
 
             if not dry_run:
                 for item in to_create:
@@ -214,6 +219,16 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
 
                             created_count += 1
 
+                            # Collect TSS pair from create response
+                            remote_tss = created.get("icu_training_load")
+                            tss_pairs.append(
+                                {
+                                    "session_id": item["session_id"],
+                                    "local_tss": local_tss_map.get(item["session_id"], 0),
+                                    "remote_tss": remote_tss,
+                                }
+                            )
+
                     except Exception as e:
                         errors.append(f"Error creating {item['session_id']}: {str(e)}")
 
@@ -222,11 +237,60 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
                         updated = client.update_event(item["intervals_id"], item["event_data"])
                         if updated:
                             updated_count += 1
+
+                            # Collect TSS pair from update response
+                            if isinstance(updated, dict):
+                                remote_tss = updated.get("icu_training_load")
+                                tss_pairs.append(
+                                    {
+                                        "session_id": item["session_id"],
+                                        "local_tss": local_tss_map.get(item["session_id"], 0),
+                                        "remote_tss": remote_tss,
+                                    }
+                                )
                         else:
                             errors.append(f"Failed to update {item['session_id']}")
 
                     except Exception as e:
                         errors.append(f"Error updating {item['session_id']}: {str(e)}")
+
+                # TSS reconciliation after all creates/updates
+                if tss_pairs:
+                    from magma_cycling.utils.tss_reconciliation import reconcile_week_tss
+
+                    recon = reconcile_week_tss(tss_pairs)
+                    updated_results = [r for r in recon["results"] if r.action == "updated"]
+
+                    if updated_results:
+                        with planning_tower.modify_week(
+                            week_id,
+                            requesting_script="mcp-server",
+                            reason="MCP: TSS reconciliation from remote icu_training_load",
+                        ) as plan:
+                            for r in updated_results:
+                                for session in plan.planned_sessions:
+                                    if session.session_id == r.session_id:
+                                        session.tss_planned = r.reconciled_tss
+                                        break
+
+                    tss_reconciliation_summary = {
+                        "sessions_updated": recon["sessions_updated"],
+                        "sessions_skipped": recon["sessions_skipped"],
+                        "tss_local_total": recon["tss_local_total"],
+                        "tss_remote_total": recon["tss_remote_total"],
+                        "tss_reconciled_total": recon["tss_reconciled_total"],
+                        "details": [
+                            {
+                                "session_id": r.session_id,
+                                "local_tss": r.local_tss,
+                                "remote_tss": r.remote_tss,
+                                "reconciled_tss": r.reconciled_tss,
+                                "delta": r.delta,
+                                "action": r.action,
+                            }
+                            for r in recon["results"]
+                        ],
+                    }
 
         if errors:
             status = "partial_success"
@@ -266,6 +330,9 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
             "errors": errors if errors else None,
             "message": f"Sync {'preview' if dry_run else 'completed'} for {week_id}",
         }
+
+        if not dry_run and tss_reconciliation_summary:
+            result["tss_reconciliation"] = tss_reconciliation_summary
 
         return mcp_response(result, provider_info=_provider_info)
 

--- a/magma_cycling/utils/tss_reconciliation.py
+++ b/magma_cycling/utils/tss_reconciliation.py
@@ -1,0 +1,120 @@
+"""TSS reconciliation between local planning and remote platform values."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TssReconciliationResult:
+    """Result of TSS reconciliation for a single session."""
+
+    session_id: str
+    local_tss: int
+    remote_tss: int | None
+    reconciled_tss: int
+    delta: int  # remote - local (signed)
+    action: str  # "updated" | "skipped" | "skipped_rest"
+    reason: str
+
+
+def reconcile_session_tss(
+    session_id: str,
+    local_tss: int,
+    remote_tss: int | None,
+    *,
+    threshold_abs: int = 5,
+    threshold_pct: float = 0.10,
+) -> TssReconciliationResult:
+    """Reconcile TSS for a single session.
+
+    Remote-wins strategy with threshold: adopt remote if delta exceeds
+    max(threshold_abs, local * threshold_pct). Skip if remote is None/0
+    (rest day) or delta within tolerance (LLM rounding).
+
+    Args:
+        session_id: Session identifier (e.g. "S087-01").
+        local_tss: TSS from local planning (LLM header).
+        remote_tss: TSS from remote platform (icu_training_load), None for rest days.
+        threshold_abs: Absolute threshold in TSS (default 5).
+        threshold_pct: Percentage threshold of local TSS (default 10%).
+
+    Returns:
+        TssReconciliationResult with reconciled value and action taken.
+    """
+    if remote_tss is None or remote_tss == 0:
+        return TssReconciliationResult(
+            session_id=session_id,
+            local_tss=local_tss,
+            remote_tss=remote_tss,
+            reconciled_tss=local_tss,
+            delta=0,
+            action="skipped_rest",
+            reason="Remote TSS absent or zero (rest day)",
+        )
+
+    delta = remote_tss - local_tss
+    threshold = max(threshold_abs, int(local_tss * threshold_pct))
+
+    if abs(delta) <= threshold:
+        return TssReconciliationResult(
+            session_id=session_id,
+            local_tss=local_tss,
+            remote_tss=remote_tss,
+            reconciled_tss=local_tss,
+            delta=delta,
+            action="skipped",
+            reason=f"Delta {delta} within threshold {threshold}",
+        )
+
+    # Remote wins — clamp to [0, 500] for Pydantic model safety
+    reconciled = max(0, min(500, remote_tss))
+    return TssReconciliationResult(
+        session_id=session_id,
+        local_tss=local_tss,
+        remote_tss=remote_tss,
+        reconciled_tss=reconciled,
+        delta=delta,
+        action="updated",
+        reason=f"Delta {delta} exceeds threshold {threshold}",
+    )
+
+
+def reconcile_week_tss(
+    sessions: list[dict],
+    **kwargs,
+) -> dict:
+    """Reconcile TSS for an entire week.
+
+    Args:
+        sessions: List of dicts with keys {session_id, local_tss, remote_tss}.
+        **kwargs: Forwarded to reconcile_session_tss (threshold_abs, threshold_pct).
+
+    Returns:
+        Dict with keys: results, tss_local_total, tss_remote_total,
+        tss_reconciled_total, sessions_updated, sessions_skipped.
+    """
+    results = []
+    for s in sessions:
+        result = reconcile_session_tss(
+            session_id=s["session_id"],
+            local_tss=s["local_tss"],
+            remote_tss=s.get("remote_tss"),
+            **kwargs,
+        )
+        results.append(result)
+
+    tss_local_total = sum(r.local_tss for r in results)
+    tss_remote_total = sum(r.remote_tss or 0 for r in results)
+    tss_reconciled_total = sum(r.reconciled_tss for r in results)
+    sessions_updated = sum(1 for r in results if r.action == "updated")
+    sessions_skipped = sum(1 for r in results if r.action in ("skipped", "skipped_rest"))
+
+    return {
+        "results": results,
+        "tss_local_total": tss_local_total,
+        "tss_remote_total": tss_remote_total,
+        "tss_reconciled_total": tss_reconciled_total,
+        "sessions_updated": sessions_updated,
+        "sessions_skipped": sessions_skipped,
+    }

--- a/magma_cycling/workflows/eow/upload.py
+++ b/magma_cycling/workflows/eow/upload.py
@@ -195,6 +195,50 @@ class UploadMixin:
 
             print(f"     ✓ {len(workouts_sorted)} workouts uploadés")
 
+            # TSS reconciliation: compare local (LLM header) vs remote (icu_training_load)
+            from magma_cycling.utils.tss_reconciliation import reconcile_week_tss
+
+            tss_pairs = []
+            for ws in workouts_sorted:
+                wname = ws.get("name", "")
+                meta = workout_metadata.get(wname, {})
+                local_tss = meta.get("tss_planned", 0)
+                remote_tss = ws.get("icu_training_load")
+                # Extract session_id from workout name (e.g. S081-01)
+                sid_match = re.match(r"(S\d+-\d+)", wname)
+                sid = sid_match.group(1) if sid_match else wname
+                tss_pairs.append(
+                    {"session_id": sid, "local_tss": local_tss, "remote_tss": remote_tss}
+                )
+
+            if tss_pairs:
+                recon = reconcile_week_tss(tss_pairs)
+                updated_results = [r for r in recon["results"] if r.action == "updated"]
+
+                if updated_results:
+                    print(
+                        f"\n  🔄 TSS reconciliation: "
+                        f"{recon['sessions_updated']}/{len(tss_pairs)} sessions updated"
+                    )
+                    for r in updated_results:
+                        pct = (r.delta / r.local_tss * 100) if r.local_tss else 0
+                        print(
+                            f"     {r.session_id}: {r.local_tss} → {r.reconciled_tss} "
+                            f"({r.delta:+d}, {pct:+.1f}%)"
+                        )
+                    print(
+                        f"  Weekly TSS: {recon['tss_local_total']} (local) → "
+                        f"{recon['tss_reconciled_total']} (reconciled)"
+                    )
+
+                # Apply reconciled TSS back to workout_metadata
+                for r in recon["results"]:
+                    if r.action == "updated":
+                        for wname, meta in workout_metadata.items():
+                            if wname.startswith(f"{r.session_id}-"):
+                                meta["tss_planned"] = r.reconciled_tss
+                                break
+
             # Build planning data structure
             planning_data = {
                 "week_id": self.week_next,

--- a/tests/test_tss_reconciliation.py
+++ b/tests/test_tss_reconciliation.py
@@ -1,0 +1,130 @@
+"""Tests for TSS reconciliation between local and remote values."""
+
+from magma_cycling.utils.tss_reconciliation import (
+    TssReconciliationResult,
+    reconcile_session_tss,
+    reconcile_week_tss,
+)
+
+
+class TestReconcileSessionTss:
+    """Unit tests for reconcile_session_tss."""
+
+    def test_remote_wins_above_threshold(self):
+        """Remote TSS adopted when delta exceeds threshold."""
+        r = reconcile_session_tss("S087-01", local_tss=72, remote_tss=85)
+        assert r.reconciled_tss == 85
+        assert r.action == "updated"
+        assert r.delta == 13
+        assert r.local_tss == 72
+        assert r.remote_tss == 85
+
+    def test_within_abs_threshold_skipped(self):
+        """Delta within absolute threshold (5 TSS) is skipped."""
+        r = reconcile_session_tss("S087-02", local_tss=72, remote_tss=74)
+        assert r.reconciled_tss == 72  # local kept
+        assert r.action == "skipped"
+        assert r.delta == 2
+
+    def test_within_pct_threshold_skipped(self):
+        """Delta within percentage threshold (10%) is skipped."""
+        # local=100, remote=108, delta=8 < threshold=max(5, 10)=10
+        r = reconcile_session_tss("S087-03", local_tss=100, remote_tss=108)
+        assert r.reconciled_tss == 100
+        assert r.action == "skipped"
+        assert r.delta == 8
+
+    def test_remote_none_skipped_rest(self):
+        """Remote None treated as rest day."""
+        r = reconcile_session_tss("S087-04", local_tss=0, remote_tss=None)
+        assert r.action == "skipped_rest"
+        assert r.reconciled_tss == 0
+        assert r.delta == 0
+
+    def test_remote_zero_skipped_rest(self):
+        """Remote 0 treated as rest day."""
+        r = reconcile_session_tss("S087-05", local_tss=0, remote_tss=0)
+        assert r.action == "skipped_rest"
+        assert r.reconciled_tss == 0
+
+    def test_negative_delta(self):
+        """Remote lower than local — still adopted if above threshold."""
+        r = reconcile_session_tss("S087-06", local_tss=85, remote_tss=72)
+        assert r.reconciled_tss == 72
+        assert r.action == "updated"
+        assert r.delta == -13
+
+    def test_clamp_upper_bound(self):
+        """Remote TSS above 500 is clamped."""
+        r = reconcile_session_tss("S087-07", local_tss=400, remote_tss=600)
+        assert r.reconciled_tss == 500
+        assert r.action == "updated"
+
+    def test_result_is_frozen_dataclass(self):
+        """Result is immutable."""
+        r = reconcile_session_tss("S087-01", local_tss=72, remote_tss=85)
+        assert isinstance(r, TssReconciliationResult)
+
+    def test_custom_thresholds(self):
+        """Custom thresholds override defaults."""
+        # With default: delta=8, threshold=max(5,7.2)=7 → updated
+        r_default = reconcile_session_tss("S087-08", local_tss=72, remote_tss=80)
+        assert r_default.action == "updated"
+
+        # With higher threshold: delta=8, threshold=max(10,7.2)=10 → skipped
+        r_custom = reconcile_session_tss("S087-08", local_tss=72, remote_tss=80, threshold_abs=10)
+        assert r_custom.action == "skipped"
+
+
+class TestReconcileWeekTss:
+    """Unit tests for reconcile_week_tss."""
+
+    def test_week_totals(self):
+        """Verify weekly totals with mixed sessions including rest days."""
+        sessions = [
+            {"session_id": "S087-01", "local_tss": 72, "remote_tss": 85},  # updated
+            {"session_id": "S087-02", "local_tss": 0, "remote_tss": None},  # rest
+            {"session_id": "S087-03", "local_tss": 45, "remote_tss": 43},  # skipped (delta=2)
+            {"session_id": "S087-04", "local_tss": 0, "remote_tss": 0},  # rest
+            {"session_id": "S087-05", "local_tss": 100, "remote_tss": 120},  # updated
+        ]
+        result = reconcile_week_tss(sessions)
+
+        assert result["tss_local_total"] == 217  # 72+0+45+0+100
+        assert result["tss_remote_total"] == 248  # 85+0+43+0+120
+        # reconciled: 85+0+45+0+120 = 250
+        assert result["tss_reconciled_total"] == 250
+        assert result["sessions_updated"] == 2
+        assert result["sessions_skipped"] == 3  # 1 skipped + 2 rest
+
+    def test_mixed_skip_and_update(self):
+        """Verify counters for mixed skip/update."""
+        sessions = [
+            {"session_id": "S087-01", "local_tss": 72, "remote_tss": 85},  # updated (+13)
+            {"session_id": "S087-02", "local_tss": 50, "remote_tss": 52},  # skipped (delta=2)
+            {"session_id": "S087-03", "local_tss": 80, "remote_tss": 65},  # updated (-15)
+        ]
+        result = reconcile_week_tss(sessions)
+
+        assert result["sessions_updated"] == 2
+        assert result["sessions_skipped"] == 1
+        assert len(result["results"]) == 3
+
+    def test_empty_sessions(self):
+        """Empty session list returns zero totals."""
+        result = reconcile_week_tss([])
+        assert result["tss_local_total"] == 0
+        assert result["tss_reconciled_total"] == 0
+        assert result["sessions_updated"] == 0
+        assert result["sessions_skipped"] == 0
+        assert result["results"] == []
+
+    def test_all_rest_days(self):
+        """All rest days produce zero updates."""
+        sessions = [
+            {"session_id": "S087-01", "local_tss": 0, "remote_tss": None},
+            {"session_id": "S087-02", "local_tss": 0, "remote_tss": 0},
+        ]
+        result = reconcile_week_tss(sessions)
+        assert result["sessions_updated"] == 0
+        assert result["sessions_skipped"] == 2

--- a/tests/workflows/eow/test_upload.py
+++ b/tests/workflows/eow/test_upload.py
@@ -501,3 +501,118 @@ class TestStep5bSavePlanningJson:
 
         plan = WeeklyPlan.from_json(planning_dir / "week_planning_S081.json")
         assert len(plan.planned_sessions) == 0
+
+
+class TestStep5bTssReconciliation:
+    """Tests for TSS reconciliation integration in _step5b_save_planning_json."""
+
+    @patch("magma_cycling.workflows.eow.upload.audit_log")
+    @patch("magma_cycling.config.get_intervals_config")
+    @patch("magma_cycling.api.intervals_client.IntervalsClient")
+    def test_eow_applies_reconciled_tss(self, mock_client_cls, mock_config, mock_audit, tmp_path):
+        """Verify that divergent icu_training_load causes TSS reconciliation."""
+        f = tmp_path / "S081_workouts.txt"
+        f.write_text(VALID_WORKOUTS_CONTENT)
+
+        config = MagicMock()
+        config.athlete_id = "iXXXXXX"
+        config.api_key = "fake_key"
+        mock_config.return_value = config
+
+        # Remote has different icu_training_load values
+        mock_client = MagicMock()
+        mock_client.get_events.return_value = [
+            {
+                "id": 100,
+                "name": "S081-01-END-RepriseLundi-V001",
+                "category": "WORKOUT",
+                "start_date_local": "2026-03-16T08:00:00",
+                "icu_training_load": 60,  # local=45, delta=15 → updated
+            },
+            {
+                "id": 200,
+                "name": "S081-03-INT-Intervalles-V001",
+                "category": "WORKOUT",
+                "start_date_local": "2026-03-18T08:00:00",
+                "icu_training_load": 82,  # local=80, delta=2 → skipped
+            },
+        ]
+        mock_client_cls.return_value = mock_client
+
+        planning_dir = tmp_path / "planning"
+        planning_dir.mkdir()
+
+        wf = StubEowWorkflow(
+            workouts_file=f,
+            week_next="S081",
+            next_start_date=date(2026, 3, 16),
+            next_end_date=date(2026, 3, 22),
+            planning_dir=planning_dir,
+        )
+        wf._step5b_save_planning_json()
+
+        from magma_cycling.planning.models import WeeklyPlan
+
+        plan = WeeklyPlan.from_json(planning_dir / "week_planning_S081.json")
+
+        # S081-01: local=45, remote=60, delta=15 > max(5, 4.5)=5 → reconciled to 60
+        s1 = next(s for s in plan.planned_sessions if s.session_id == "S081-01")
+        assert s1.tss_planned == 60
+
+        # S081-03: local=80, remote=82, delta=2 < max(5, 8)=8 → kept at 80
+        s3 = next(s for s in plan.planned_sessions if s.session_id == "S081-03")
+        assert s3.tss_planned == 80
+
+        # Total: 60 + 80 = 140
+        assert plan.tss_target == 140
+
+    @patch("magma_cycling.workflows.eow.upload.audit_log")
+    @patch("magma_cycling.config.get_intervals_config")
+    @patch("magma_cycling.api.intervals_client.IntervalsClient")
+    def test_eow_no_reconciliation_when_no_remote_tss(
+        self, mock_client_cls, mock_config, mock_audit, tmp_path
+    ):
+        """No reconciliation when events lack icu_training_load."""
+        f = tmp_path / "S081_workouts.txt"
+        f.write_text(VALID_WORKOUTS_CONTENT)
+
+        config = MagicMock()
+        config.athlete_id = "iXXXXXX"
+        config.api_key = "fake_key"
+        mock_config.return_value = config
+
+        # No icu_training_load in events
+        mock_client = MagicMock()
+        mock_client.get_events.return_value = [
+            {
+                "id": 100,
+                "name": "S081-01-END-RepriseLundi-V001",
+                "category": "WORKOUT",
+                "start_date_local": "2026-03-16T08:00:00",
+            },
+            {
+                "id": 200,
+                "name": "S081-03-INT-Intervalles-V001",
+                "category": "WORKOUT",
+                "start_date_local": "2026-03-18T08:00:00",
+            },
+        ]
+        mock_client_cls.return_value = mock_client
+
+        planning_dir = tmp_path / "planning"
+        planning_dir.mkdir()
+
+        wf = StubEowWorkflow(
+            workouts_file=f,
+            week_next="S081",
+            next_start_date=date(2026, 3, 16),
+            next_end_date=date(2026, 3, 22),
+            planning_dir=planning_dir,
+        )
+        wf._step5b_save_planning_json()
+
+        from magma_cycling.planning.models import WeeklyPlan
+
+        plan = WeeklyPlan.from_json(planning_dir / "week_planning_S081.json")
+        # Original values kept: 45 + 80 = 125
+        assert plan.tss_target == 125


### PR DESCRIPTION
## Summary

- **New module** `utils/tss_reconciliation.py`: pure reconciliation logic (remote-wins with threshold `max(5 TSS, 10% local)`)
- **EOW pipeline** (`workflows/eow/upload.py`): reconciles TSS from `icu_training_load` after `get_events()`, before building planning JSON
- **MCP sync** (`_mcp/handlers/remote_sync.py`): collects TSS pairs from create/update API responses, reconciles and applies via `modify_week()`, adds `tss_reconciliation` block to MCP response

Fixes masked load divergence where LLM header TSS diverges from Intervals.icu block-calculated TSS (cf. S086-04: +37% hidden overload).

## Test plan

- [x] 13 unit tests for `reconcile_session_tss` and `reconcile_week_tss`
- [x] 2 integration tests for EOW pipeline TSS reconciliation
- [x] Full test suite: 3281 passed, 5 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)