### PR TITLE
fix(mcp): prevent weekly-planner silent overwrite + fix VV001 version bug

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -140,6 +140,7 @@ async def handle_weekly_planner(args: dict) -> list[TextContent]:
     week_id = args["week_id"]
     start_date_str = args["start_date"]
     provider = args.get("provider", "clipboard")
+    force = args.get("force", False)
 
     start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
 
@@ -147,7 +148,30 @@ async def handle_weekly_planner(args: dict) -> list[TextContent]:
     with suppress_stdout_stderr():
         planner = WeeklyPlanner(week_number=week_id, start_date=start_date, project_root=Path.cwd())
 
-        # Collect metrics
+    # --- Guard: reject overwrite unless force=True ---
+    existing_file = planner.planning_dir / f"week_planning_{week_id}.json"
+    if existing_file.exists():
+        if not force:
+            return mcp_response(
+                {
+                    "error": "planning_exists",
+                    "week_id": week_id,
+                    "existing_file": str(existing_file),
+                    "message": (
+                        f"Planning {week_id} already exists. "
+                        "Use force=true to overwrite (a backup will be created first)."
+                    ),
+                }
+            )
+        # force=True → backup before overwrite
+        from magma_cycling.planning.control_tower import planning_tower
+
+        with suppress_stdout_stderr():
+            planning_tower.backup_system.backup_week_files(week_id)
+        logger.info("Backup created for %s before forced overwrite", week_id)
+
+    # Collect metrics
+    with suppress_stdout_stderr():
         planner.current_metrics = planner.collect_current_metrics()
         planner.previous_week_bilan = planner.load_previous_week_bilan()
         planner.context_files = planner.load_context_files()

--- a/magma_cycling/_mcp/schemas/planning.py
+++ b/magma_cycling/_mcp/schemas/planning.py
@@ -34,6 +34,11 @@ def get_tools() -> list[Tool]:
                         ],
                         "default": "clipboard",
                     },
+                    "force": {
+                        "type": "boolean",
+                        "description": "Force overwrite if a planning already exists for this week (creates backup first). Default false — will reject if planning exists.",
+                        "default": False,
+                    },
                 },
                 "required": ["week_id", "start_date"],
             },

--- a/magma_cycling/planning/control_tower.py
+++ b/magma_cycling/planning/control_tower.py
@@ -440,7 +440,7 @@ class PlanningControlTower:
                 "session_date": event_date,
                 "name": session_name,
                 "session_type": session_type,
-                "version": f"V{version}",
+                "version": version,
                 "intervals_id": intervals_id,
                 "status": status,
                 "description": description,

--- a/magma_cycling/planning/models.py
+++ b/magma_cycling/planning/models.py
@@ -110,6 +110,15 @@ class Session(BaseModel):
         alias="type", description="Session type (END, INT, REC, CAD, VO2, etc.)"
     )  # Use alias to avoid 'type' keyword conflict
     version: str = Field(default="V001", pattern=r"^V\d{3}$", description="Session version")
+
+    @field_validator("version", mode="before")
+    @classmethod
+    def normalize_version(cls, v: str) -> str:
+        """Strip duplicate V prefix (VV001 → V001)."""
+        if isinstance(v, str) and v.startswith("VV"):
+            return v[1:]
+        return v
+
     tss_planned: int = Field(ge=0, le=500, description="Planned Training Stress Score")
     duration_min: int = Field(ge=0, le=600, description="Planned duration in minutes")
     description: str = Field(default="", description="Workout description")

--- a/tests/_mcp/test_weekly_planner_prompt_exposure.py
+++ b/tests/_mcp/test_weekly_planner_prompt_exposure.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import tempfile
 from contextlib import nullcontext
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,6 +26,7 @@ def _patch_planner():
     """Patch WeeklyPlanner to avoid real API/filesystem calls."""
     mock_cls = MagicMock()
     instance = mock_cls.return_value
+    instance.planning_dir = Path(tempfile.mkdtemp())
     instance.collect_current_metrics.return_value = {}
     instance.load_previous_week_bilan.return_value = ""
     instance.load_context_files.return_value = {}

--- a/tests/planning/test_control_tower.py
+++ b/tests/planning/test_control_tower.py
@@ -1,0 +1,24 @@
+"""Tests for PlanningControlTower — sync_from_remote version handling."""
+
+from magma_cycling.planning.models import WORKOUT_NAME_REGEX
+
+
+class TestSyncFromRemoteVersion:
+    """Test that sync_from_remote does not double the V prefix."""
+
+    def test_sync_from_remote_version_no_double_V(self):
+        """Regex group(4) already captures 'V001'; building the dict must NOT add another V."""
+        event_name = "S087-01-END-EnduranceDouce-V001"
+        match = WORKOUT_NAME_REGEX.search(event_name)
+        assert match is not None
+
+        version = match.group(4)
+        assert version == "V001", f"Regex should capture 'V001', got {version!r}"
+
+        # Simulate the FIXED line (was: f"V{version}" → "VV001")
+        built_version = version  # correct
+        assert built_version == "V001"
+
+        # Demonstrate the old bug
+        old_built_version = f"V{version}"
+        assert old_built_version == "VV001", "Old code would have produced VV001"

--- a/tests/planning/test_models.py
+++ b/tests/planning/test_models.py
@@ -1,0 +1,43 @@
+"""Tests for planning models — version normalization."""
+
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from magma_cycling.planning.models import Session
+
+
+class TestVersionNormalization:
+    """Test version field_validator normalizes double-V prefix."""
+
+    def _make_session(self, version: str) -> Session:
+        return Session(
+            session_id="S087-01",
+            session_date=date(2026, 4, 6),
+            name="EnduranceDouce",
+            session_type="END",
+            tss_planned=50,
+            duration_min=60,
+            version=version,
+        )
+
+    def test_version_normalization_VV001(self):
+        """VV001 (double-V bug) is silently fixed to V001."""
+        session = self._make_session("VV001")
+        assert session.version == "V001"
+
+    def test_version_valid_V001(self):
+        """V001 remains V001 — no mutation."""
+        session = self._make_session("V001")
+        assert session.version == "V001"
+
+    def test_version_V002_unchanged(self):
+        """V002 remains V002."""
+        session = self._make_session("V002")
+        assert session.version == "V002"
+
+    def test_version_invalid_rejected(self):
+        """Invalid version pattern is rejected by pydantic."""
+        with pytest.raises(ValidationError):
+            self._make_session("X001")

--- a/tests/test_mcp_weekly_planner_direct.py
+++ b/tests/test_mcp_weekly_planner_direct.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import tempfile
 from datetime import date
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -193,8 +195,7 @@ def _make_mock_planner():
     """Create a mock WeeklyPlanner with required attributes."""
     planner = MagicMock()
     planner.current_metrics = {"ftp": 250, "weight": 75}
-    planner.planning_dir = MagicMock()
-    planner.planning_dir.__truediv__ = MagicMock(return_value=MagicMock())
+    planner.planning_dir = Path(tempfile.mkdtemp())
     return planner
 
 
@@ -211,11 +212,6 @@ class TestHandleWeeklyPlannerDirect:
         planner.generate_planning_prompt.return_value = "fake prompt"
         mock_planner_cls.return_value = planner
         mock_call_ai.return_value = fake_ai_response
-
-        # Mock workouts_file path
-        mock_file = MagicMock()
-        planner.planning_dir.__truediv__.return_value = mock_file
-        mock_file.__str__ = MagicMock(return_value="/tmp/S083_workouts.txt")
 
         result = _run_async(
             handle_weekly_planner(
@@ -275,9 +271,6 @@ class TestHandleWeeklyPlannerDirect:
         mock_planner_cls.return_value = planner
         mock_call_ai.return_value = "Just some text without workout delimiters"
 
-        mock_file = MagicMock()
-        planner.planning_dir.__truediv__.return_value = mock_file
-
         result = _run_async(
             handle_weekly_planner(
                 {
@@ -315,10 +308,6 @@ class TestHandleWeeklyPlannerDirect:
         mock_planner_cls.return_value = planner
         mock_call_ai.return_value = partial_response
 
-        mock_file = MagicMock()
-        planner.planning_dir.__truediv__.return_value = mock_file
-        mock_file.__str__ = MagicMock(return_value="/tmp/S083_workouts.txt")
-
         result = _run_async(
             handle_weekly_planner(
                 {
@@ -348,10 +337,6 @@ class TestHandleWeeklyPlannerDirect:
         mock_planner_cls.return_value = planner
         mock_call_ai.return_value = fake_ai_response
 
-        mock_file = MagicMock()
-        planner.planning_dir.__truediv__.return_value = mock_file
-        mock_file.__str__ = MagicMock(return_value="/tmp/S083_workouts.txt")
-
         _run_async(
             handle_weekly_planner(
                 {
@@ -363,7 +348,9 @@ class TestHandleWeeklyPlannerDirect:
         )
 
         # Verify file was written with raw AI response
-        mock_file.write_text.assert_called_once_with(fake_ai_response, encoding="utf-8")
+        workouts_file = planner.planning_dir / "S083_workouts.txt"
+        assert workouts_file.exists()
+        assert workouts_file.read_text(encoding="utf-8") == fake_ai_response
 
     @patch("magma_cycling._mcp.handlers.planning._call_ai_provider")
     @patch("magma_cycling.weekly_planner.WeeklyPlanner")
@@ -375,10 +362,6 @@ class TestHandleWeeklyPlannerDirect:
         planner.generate_planning_prompt.return_value = "fake prompt"
         mock_planner_cls.return_value = planner
         mock_call_ai.return_value = fake_ai_response
-
-        mock_file = MagicMock()
-        planner.planning_dir.__truediv__.return_value = mock_file
-        mock_file.__str__ = MagicMock(return_value="/tmp/S083_workouts.txt")
 
         _run_async(
             handle_weekly_planner(

--- a/tests/test_weekly_planner_guard.py
+++ b/tests/test_weekly_planner_guard.py
@@ -1,0 +1,112 @@
+"""Tests for weekly-planner overwrite guard (Bug #3 — S087)."""
+
+import json
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.planning import handle_weekly_planner
+
+
+def _extract_result(response):
+    """Extract the JSON result from MCP TextContent response."""
+    return json.loads(response[0].text)
+
+
+@contextmanager
+def _noop_suppress():
+    """No-op replacement for suppress_stdout_stderr."""
+    yield
+
+
+@pytest.fixture
+def mock_planner(tmp_path):
+    """Create a mock WeeklyPlanner with a temp planning_dir."""
+    planner = MagicMock()
+    planner.planning_dir = tmp_path
+    planner.current_metrics = {}
+    planner.previous_week_bilan = None
+    planner.context_files = {}
+    planner.generate_planning_prompt.return_value = "test prompt"
+    planner.collect_current_metrics.return_value = {}
+    planner.load_previous_week_bilan.return_value = None
+    planner.load_context_files.return_value = {}
+    return planner
+
+
+class TestWeeklyPlannerGuard:
+    """Test the overwrite protection guard."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_overwrite_without_force(self, mock_planner, tmp_path):
+        """Existing planning + no force → error with suggestion."""
+        existing = tmp_path / "week_planning_S087.json"
+        existing.write_text("{}", encoding="utf-8")
+
+        with (
+            patch(
+                "magma_cycling.weekly_planner.WeeklyPlanner",
+                return_value=mock_planner,
+            ),
+            patch(
+                "magma_cycling._mcp.handlers.planning.suppress_stdout_stderr",
+                _noop_suppress,
+            ),
+        ):
+            response = await handle_weekly_planner({"week_id": "S087", "start_date": "2026-03-30"})
+
+        result = _extract_result(response)
+        assert result["error"] == "planning_exists"
+        assert "force=true" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_allows_overwrite_with_force(self, mock_planner, tmp_path):
+        """Existing planning + force=True → backup created + continues."""
+        existing = tmp_path / "week_planning_S087.json"
+        existing.write_text("{}", encoding="utf-8")
+
+        mock_backup = MagicMock()
+        mock_tower = MagicMock()
+        mock_tower.backup_system.backup_week_files = mock_backup
+
+        with (
+            patch(
+                "magma_cycling.weekly_planner.WeeklyPlanner",
+                return_value=mock_planner,
+            ),
+            patch(
+                "magma_cycling._mcp.handlers.planning.suppress_stdout_stderr",
+                _noop_suppress,
+            ),
+            patch(
+                "magma_cycling.planning.control_tower.planning_tower",
+                mock_tower,
+            ),
+        ):
+            response = await handle_weekly_planner(
+                {"week_id": "S087", "start_date": "2026-03-30", "force": True}
+            )
+
+        result = _extract_result(response)
+        assert "error" not in result or result.get("error") != "planning_exists"
+        mock_backup.assert_called_once_with("S087")
+
+    @pytest.mark.asyncio
+    async def test_creates_new_without_force(self, mock_planner, tmp_path):
+        """No existing planning + no force → proceeds normally."""
+        with (
+            patch(
+                "magma_cycling.weekly_planner.WeeklyPlanner",
+                return_value=mock_planner,
+            ),
+            patch(
+                "magma_cycling._mcp.handlers.planning.suppress_stdout_stderr",
+                _noop_suppress,
+            ),
+        ):
+            response = await handle_weekly_planner({"week_id": "S087", "start_date": "2026-03-30"})
+
+        result = _extract_result(response)
+        assert result.get("error") != "planning_exists"
+        assert result["week_id"] == "S087"


### PR DESCRIPTION
## Summary
- **Bug #3 (CRITICAL)**: `weekly-planner` now rejects overwrite when planning file exists unless `force=true` is passed (creates backup first)
- **Bug #4 (HIGH)**: `sync_from_remote` no longer doubles the V prefix (`f"V{version}"` where version=`"V001"` → `"VV001"`). Added defensive `field_validator` on `Session.version` to normalize `VV→V`
- Adapted 2 existing test files for compatibility with the new overwrite guard

## Test plan
- [x] 3 new tests for overwrite guard (`test_weekly_planner_guard.py`)
- [x] 4 new tests for version normalization (`test_models.py`)
- [x] 1 new test for regex version parsing (`test_control_tower.py`)
- [x] Full test suite: 3289 passed, 5 skipped, 0 failed

Incident: S087 session 02/04/2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)