### PR TITLE
fix: sanitize description dashes for Intervals.icu (BT-008)

### DIFF
--- a/magma_cycling/workflows/planner/templates/peaks_methodology.md
+++ b/magma_cycling/workflows/planner/templates/peaks_methodology.md
@@ -279,6 +279,7 @@ Cooldown
 - Format texte pur Intervals.icu uniquement
 - Chaque workout séparé par `=== WORKOUT ... ===` et `=== FIN WORKOUT ===`
 - Directement copiable dans Intervals.icu Workout Builder
+- **TIRETS** : les lignes commençant par `-` sont interprétées comme des intervalles par Intervals.icu. N'utiliser `-` QUE pour les instructions d'intervalles (Warmup, Main set, Cooldown). Pour les notes textuelles (Points clés, consignes), utiliser `•` comme préfixe
 
 ### Convention de Nommage
 
@@ -377,9 +378,9 @@ Pour chaque séance, spécifie :
 [Structure Intervals.icu]
 
 **Points clés** :
-- [Consigne technique 1]
-- [Consigne technique 2]
-- [Hydratation si nécessaire]
+• [Consigne technique 1]
+• [Consigne technique 2]
+• [Hydratation si nécessaire]
 
 **Placement semaine** : [Justification]
 ```

--- a/magma_cycling/workflows/uploader/upload.py
+++ b/magma_cycling/workflows/uploader/upload.py
@@ -1,5 +1,6 @@
 """Upload mixin for WorkoutUploader."""
 
+import re
 from datetime import datetime, timedelta
 
 from magma_cycling.utils.event_sync import (
@@ -42,6 +43,57 @@ def _find_matching_event(
     return None
 
 
+# Regex pour détecter une ligne d'instruction d'intervalle Intervals.icu
+# Pattern : - {durée}{unité} {intensité}% {cadence}rpm  (avec variantes ramp, plages)
+_INTERVAL_LINE_RE = re.compile(r"^-\s+\d+[msh]\s+")  # tiret + durée (10m, 30s, 1h)
+
+
+def sanitize_description(description: str) -> str:
+    """Remplace les tirets non-intervalle par des bullets dans la description.
+
+    Intervals.icu interprète toute ligne commençant par '-' comme un bloc
+    d'intervalle structuré. Les lignes textuelles (Points clés, notes) qui
+    utilisent des tirets comme puces de liste génèrent des barres parasites
+    sur le graphique de puissance.
+    """
+    lines = description.split("\n")
+    result = []
+    in_interval_section = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Détecter les headers de section d'intervalles
+        if re.match(r"(?i)^(warmup|main set|cooldown)", stripped):
+            in_interval_section = True
+            result.append(line)
+            continue
+
+        # Ligne vide ou nouveau header textuel → fin de section intervalle
+        if not stripped or (
+            stripped
+            and not stripped.startswith("-")
+            and not _INTERVAL_LINE_RE.match(stripped)
+            and not in_interval_section
+        ):
+            if stripped and not re.match(r"(?i)^(warmup|main set|cooldown)", stripped):
+                in_interval_section = False
+
+        # Ligne avec tiret
+        if stripped.startswith("- "):
+            if in_interval_section and _INTERVAL_LINE_RE.match(stripped):
+                # Vraie instruction d'intervalle — garder le tiret
+                result.append(line)
+            else:
+                # Texte non-intervalle — remplacer par bullet
+                result.append(line.replace("- ", "• ", 1))
+                in_interval_section = False
+        else:
+            result.append(line)
+
+    return "\n".join(result)
+
+
 class UploadMixin:
     """Upload vers Intervals.icu."""
 
@@ -72,7 +124,7 @@ class UploadMixin:
                 "category": "WORKOUT",
                 "type": "VirtualRide",
                 "name": workout["name"],
-                "description": workout["description"],
+                "description": sanitize_description(workout["description"]),
                 "start_date_local": f"{workout['date']}T{start_time}",
             }
 

--- a/tests/test_sanitize_description.py
+++ b/tests/test_sanitize_description.py
@@ -1,0 +1,90 @@
+"""Tests du sanitizer de description workout (BT-008)."""
+
+from magma_cycling.workflows.uploader.upload import sanitize_description
+
+
+class TestSanitizeDescription:
+    """Les tirets non-intervalle sont remplacés par des bullets."""
+
+    def test_interval_lines_preserved(self):
+        desc = "Warmup\n- 10m ramp 50-65% 85rpm\n- 3m 65% 90rpm"
+        result = sanitize_description(desc)
+        assert "- 10m ramp" in result
+        assert "- 3m 65%" in result
+
+    def test_points_cles_dashes_replaced(self):
+        desc = (
+            "Warmup\n- 10m 50% 85rpm\n\n"
+            "Main set\n- 20m 75% 90rpm\n\n"
+            "Cooldown\n- 10m 50% 85rpm\n\n"
+            "Points clés\n- Garder la cadence haute\n- Hydratation toutes les 20min"
+        )
+        result = sanitize_description(desc)
+        assert "• Garder la cadence haute" in result
+        assert "• Hydratation toutes les 20min" in result
+        # Les intervalles sont préservés
+        assert "- 10m 50%" in result
+        assert "- 20m 75%" in result
+
+    def test_mixed_content(self):
+        desc = (
+            "Sweet Spot 3x10 (74min, 78 TSS)\n\n"
+            "Warmup\n- 12m ramp 50-65% 85rpm\n- 5m 65% 90rpm\n\n"
+            "Main set 3x\n- 10m 90% 92rpm\n- 4m 62% 85rpm\n\n"
+            "Cooldown\n- 10m ramp 65-50% 85rpm\n\n"
+            "Points clés\n- Maintenir cadence >90rpm\n- Ne pas dépasser 95%"
+        )
+        result = sanitize_description(desc)
+        # Intervalles préservés
+        assert "- 12m ramp" in result
+        assert "- 10m 90%" in result
+        assert "- 10m ramp 65-50%" in result
+        # Points clés transformés
+        assert "• Maintenir cadence" in result
+        assert "• Ne pas dépasser" in result
+
+    def test_no_dashes_unchanged(self):
+        desc = "Endurance Base (70min, 52 TSS)\n\nWarmup\n- 10m 50% 85rpm"
+        result = sanitize_description(desc)
+        assert result == desc
+
+    def test_empty_description(self):
+        assert sanitize_description("") == ""
+
+    def test_text_only_dashes(self):
+        desc = "Notes de séance\n- Boire régulièrement\n- Rester assis"
+        result = sanitize_description(desc)
+        assert "• Boire régulièrement" in result
+        assert "• Rester assis" in result
+
+    def test_real_world_bt008(self):
+        """Cas réel BT-008 : Endurance Longue + Tempo avec Points clés."""
+        desc = (
+            "Endurance Longue + Tempo (3h30, 200 TSS)\n\n"
+            "Warmup\n- 15m ramp 50-65% 85rpm\n\n"
+            "Main set\n- 120m 65-70% 88rpm\n- 30m 76-80% 90rpm\n\n"
+            "Cooldown\n- 15m ramp 60-45% 80rpm\n\n"
+            "Points clés\n"
+            "- Nutrition : 60g glucides/h dès la première heure\n"
+            "- Hydratation : 500ml/h minimum\n"
+            "- Tempo : attendre 2h avant de monter en intensité"
+        )
+        result = sanitize_description(desc)
+        # Intervalles intacts
+        assert "- 15m ramp 50-65%" in result
+        assert "- 120m 65-70%" in result
+        assert "- 30m 76-80%" in result
+        assert "- 15m ramp 60-45%" in result
+        # Points clés transformés
+        assert "• Nutrition" in result
+        assert "• Hydratation" in result
+        assert "• Tempo" in result
+        # Aucun tiret parasite restant dans les Points clés
+        lines = result.split("\n")
+        after_points_cles = False
+        for line in lines:
+            if "Points clés" in line:
+                after_points_cles = True
+                continue
+            if after_points_cles and line.strip():
+                assert not line.strip().startswith("- "), f"Tiret non transformé: {line}"


### PR DESCRIPTION
## Summary
- Ajout `sanitize_description()` dans le pipeline upload : remplace les tirets `-` par des bullets `•` dans les sections non-intervalle (Points clés, notes)
- Préserve les tirets dans les sections Warmup/Main set/Cooldown (format natif Intervals.icu)
- Mise à jour template `peaks_methodology.md` : Points clés utilise `•` au lieu de `-`
- Instruction explicite dans le template interdisant les tirets hors sections d'intervalles

## Contexte
BT-008 : beta-testeur Max signale que les "Points clés" avec tirets sont interprétés par Intervals.icu comme des blocs d'intervalles, générant des barres parasites sur le graphique de puissance.

## Test plan
- [x] 7 tests unitaires `test_sanitize_description.py` (cas réel BT-008 inclus)
- [x] 29 tests workout (0 régression)
- [ ] Vérifier visuellement sur Intervals.icu après prochain upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)