### PR TITLE
feat: native macOS SwiftUI app bundle for beta testers

### DIFF
--- a/.github/workflows/build-macos-app.yml
+++ b/.github/workflows/build-macos-app.yml
@@ -1,0 +1,109 @@
+name: Build macOS App Bundle
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build MagmaCycling.app (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-intel
+            arch: x86_64
+          - runner: macos-15
+            arch: arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Swift package
+        working-directory: packaging/MagmaCycling
+        run: swift build -c release
+
+      - name: Create .app bundle
+        run: |
+          APP="MagmaCycling.app"
+          mkdir -p "$APP/Contents/MacOS"
+          mkdir -p "$APP/Contents/Resources"
+
+          # Copier le binaire
+          cp packaging/MagmaCycling/.build/release/MagmaCycling "$APP/Contents/MacOS/"
+
+          # Info.plist
+          cat > "$APP/Contents/Info.plist" << 'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>CFBundleName</key>
+              <string>Magma Cycling</string>
+              <key>CFBundleDisplayName</key>
+              <string>Magma Cycling</string>
+              <key>CFBundleIdentifier</key>
+              <string>eu.alliancejr.magma-cycling</string>
+              <key>CFBundleVersion</key>
+              <string>1.0.0</string>
+              <key>CFBundleShortVersionString</key>
+              <string>1.0.0</string>
+              <key>CFBundleExecutable</key>
+              <string>MagmaCycling</string>
+              <key>CFBundlePackageType</key>
+              <string>APPL</string>
+              <key>LSMinimumSystemVersion</key>
+              <string>13.0</string>
+              <key>LSUIElement</key>
+              <true/>
+              <key>NSHighResolutionCapable</key>
+              <true/>
+              <key>CFBundleIconFile</key>
+              <string>AppIcon</string>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Inject version (release only)
+        if: github.event_name == 'release'
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" MagmaCycling.app/Contents/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" MagmaCycling.app/Contents/Info.plist
+
+      - name: Smoke test
+        run: |
+          # Verifier que le binaire demarre (menu bar app, kill apres 3s)
+          MagmaCycling.app/Contents/MacOS/MagmaCycling &
+          PID=$!
+          sleep 3
+          if kill -0 $PID 2>/dev/null; then
+            kill $PID
+            echo "App started successfully"
+          fi
+
+      - name: Create DMG
+        run: |
+          hdiutil create -volname "Magma Cycling" \
+            -srcfolder MagmaCycling.app \
+            -ov -format UDZO \
+            "MagmaCycling-macos-${{ matrix.arch }}.dmg"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MagmaCycling-macos-${{ matrix.arch }}
+          path: "*.dmg"
+          retention-days: 30
+
+      - name: Attach to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          gh release upload "$VERSION" "MagmaCycling-macos-${{ matrix.arch }}.dmg" --clobber

--- a/packaging/MagmaCycling/Package.swift
+++ b/packaging/MagmaCycling/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MagmaCycling",
+    platforms: [.macOS(.v13)],
+    targets: [
+        .executableTarget(
+            name: "MagmaCycling",
+            path: "Sources"
+        ),
+    ]
+)

--- a/packaging/MagmaCycling/Sources/AppState.swift
+++ b/packaging/MagmaCycling/Sources/AppState.swift
@@ -1,0 +1,165 @@
+import Combine
+import Foundation
+import SwiftUI
+
+@MainActor
+final class AppState: ObservableObject {
+    // MARK: - Server
+
+    @Published var serverRunning = false
+    @Published var serverPID: Int32?
+    @Published var serverLog: [String] = []
+
+    // MARK: - Setup
+
+    @Published var isConfigured: Bool
+    @Published var athleteName: String
+
+    // MARK: - Update
+
+    @Published var updateAvailable: String?
+    @Published var isDownloading = false
+    @Published var downloadProgress: Double = 0
+
+    // MARK: - Services
+
+    let server = ServerManager()
+    let releases = ReleaseChecker()
+    let launchAgent = LaunchAgentManager()
+    let claudeDesktop = ClaudeDesktopConfigurator()
+
+    // MARK: - Paths
+
+    static let appSupport: URL = {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return base.appendingPathComponent("MagmaCycling")
+    }()
+
+    static let binaryPath: URL = appSupport.appendingPathComponent("magma-cycling")
+    static let configDir: URL = appSupport.appendingPathComponent("config")
+    static let envFile: URL = configDir.appendingPathComponent(".env")
+    static let logsDir: URL = appSupport.appendingPathComponent("logs")
+
+    init() {
+        let configured = FileManager.default.fileExists(atPath: Self.envFile.path)
+        self.isConfigured = configured
+        self.athleteName = UserDefaults.standard.string(forKey: "athleteName") ?? ""
+
+        Task { await bootstrap() }
+    }
+
+    func bootstrap() async {
+        ensureDirectories()
+        serverRunning = server.isRunning()
+
+        if let latest = try? await releases.latestVersion() {
+            let current = currentVersion()
+            if latest != current {
+                updateAvailable = latest
+            }
+        }
+    }
+
+    func currentVersion() -> String {
+        guard FileManager.default.fileExists(atPath: Self.binaryPath.path) else { return "0.0.0" }
+        let pipe = Pipe()
+        let proc = Process()
+        proc.executableURL = Self.binaryPath
+        proc.arguments = ["--version"]
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        try? proc.run()
+        proc.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let raw = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "0.0.0"
+        // Parse "magma-cycling 3.14.0" → "3.14.0"
+        return raw.split(separator: " ").last.map(String.init) ?? raw
+    }
+
+    func ensureDirectories() {
+        let fm = FileManager.default
+        for dir in [Self.appSupport, Self.configDir, Self.logsDir] {
+            try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+    }
+
+    // MARK: - Server control
+
+    func startServer() {
+        guard !serverRunning else { return }
+        do {
+            try server.start(binary: Self.binaryPath, envFile: Self.envFile, logsDir: Self.logsDir)
+            serverRunning = true
+            serverPID = server.pid
+            appendLog("Serveur MCP demarr\u{e9} (PID \(server.pid ?? 0))")
+        } catch {
+            appendLog("Erreur demarrage: \(error.localizedDescription)")
+        }
+    }
+
+    func stopServer() {
+        server.stop()
+        serverRunning = false
+        serverPID = nil
+        appendLog("Serveur MCP arret\u{e9}")
+    }
+
+    func appendLog(_ line: String) {
+        let ts = ISO8601DateFormatter().string(from: Date())
+        serverLog.append("[\(ts)] \(line)")
+        if serverLog.count > 200 { serverLog.removeFirst() }
+    }
+
+    // MARK: - Setup completion
+
+    func completeSetup(athleteID: String, apiKey: String, name: String) throws {
+        let env = """
+        ATHLETE_ID=\(athleteID)
+        INTERVALS_API_KEY=\(apiKey)
+        """
+        try env.write(to: Self.envFile, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: Self.envFile.path
+        )
+
+        athleteName = name
+        UserDefaults.standard.set(name, forKey: "athleteName")
+        isConfigured = true
+
+        // Configurer Claude Desktop
+        claudeDesktop.configure(binaryPath: Self.binaryPath)
+
+        // Installer LaunchAgent
+        launchAgent.install(binaryPath: Self.binaryPath, envFile: Self.envFile)
+    }
+
+    // MARK: - Update
+
+    func installUpdate() async throws {
+        guard let version = updateAvailable else { return }
+        isDownloading = true
+        defer { isDownloading = false }
+
+        let wasRunning = serverRunning
+        if wasRunning { stopServer() }
+
+        try await releases.download(
+            version: version,
+            destination: Self.binaryPath
+        ) { progress in
+            Task { @MainActor in self.downloadProgress = progress }
+        }
+
+        // chmod +x
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: Self.binaryPath.path
+        )
+
+        updateAvailable = nil
+        appendLog("Mise \u{e0} jour \(version) install\u{e9}e")
+
+        if wasRunning { startServer() }
+    }
+}

--- a/packaging/MagmaCycling/Sources/MagmaCyclingApp.swift
+++ b/packaging/MagmaCycling/Sources/MagmaCyclingApp.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+@main
+struct MagmaCyclingApp: App {
+    @StateObject private var state = AppState()
+
+    var body: some Scene {
+        MenuBarExtra {
+            MenuBarView()
+                .environmentObject(state)
+        } label: {
+            Label {
+                Text("Magma Cycling")
+            } icon: {
+                Image(systemName: state.serverRunning ? "flame.fill" : "flame")
+            }
+        }
+        .menuBarExtraStyle(.window)
+
+        Window("Configuration Magma Cycling", id: "setup") {
+            SetupWizardView()
+                .environmentObject(state)
+                .frame(minWidth: 520, minHeight: 480)
+        }
+        .defaultSize(width: 560, height: 520)
+        .windowResizability(.contentSize)
+    }
+}

--- a/packaging/MagmaCycling/Sources/Services/ClaudeDesktopConfigurator.swift
+++ b/packaging/MagmaCycling/Sources/Services/ClaudeDesktopConfigurator.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Configure Claude Desktop pour utiliser le serveur MCP Magma Cycling.
+final class ClaudeDesktopConfigurator {
+    private var configURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Claude/claude_desktop_config.json")
+    }
+
+    /// Injecte la configuration MCP dans claude_desktop_config.json.
+    func configure(binaryPath: URL) {
+        let fm = FileManager.default
+        let configDir = configURL.deletingLastPathComponent()
+
+        // Creer le dossier si besoin
+        try? fm.createDirectory(at: configDir, withIntermediateDirectories: true)
+
+        // Charger la config existante ou creer une vierge
+        var config: [String: Any] = [:]
+        if let data = fm.contents(atPath: configURL.path),
+           let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        {
+            config = existing
+        }
+
+        // Section mcpServers
+        var mcpServers = config["mcpServers"] as? [String: Any] ?? [:]
+
+        mcpServers["magma-cycling"] = [
+            "command": binaryPath.path,
+            "args": ["mcp-server", "--transport", "stdio"],
+        ]
+
+        config["mcpServers"] = mcpServers
+
+        // Ecrire
+        if let data = try? JSONSerialization.data(
+            withJSONObject: config,
+            options: [.prettyPrinted, .sortedKeys]
+        ) {
+            try? data.write(to: configURL, options: .atomic)
+            // Permissions 600
+            try? fm.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: configURL.path
+            )
+        }
+    }
+
+    /// Verifie si magma-cycling est deja configure dans Claude Desktop.
+    var isConfigured: Bool {
+        guard let data = FileManager.default.contents(atPath: configURL.path),
+              let config = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let mcpServers = config["mcpServers"] as? [String: Any]
+        else {
+            return false
+        }
+        return mcpServers["magma-cycling"] != nil
+    }
+}

--- a/packaging/MagmaCycling/Sources/Services/IntervalsValidator.swift
+++ b/packaging/MagmaCycling/Sources/Services/IntervalsValidator.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Validation des credentials Intervals.icu.
+enum IntervalsValidator {
+    enum ValidationError: LocalizedError {
+        case authFailed
+        case networkError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .authFailed:
+                return "Connexion echouee -- verifie ton ID et ta cle API."
+            case .networkError(let msg):
+                return "Erreur reseau: \(msg)"
+            }
+        }
+    }
+
+    /// Valide les credentials et retourne le nom de l'athlete.
+    static func validate(athleteID: String, apiKey: String) async throws -> String {
+        let urlString = "https://intervals.icu/api/v1/athlete/\(athleteID)"
+        guard let url = URL(string: urlString) else {
+            throw ValidationError.authFailed
+        }
+
+        // Basic auth : "API_KEY:{apiKey}" en base64
+        let credentials = "API_KEY:\(apiKey)"
+        guard let credData = credentials.data(using: .utf8) else {
+            throw ValidationError.authFailed
+        }
+        let base64 = credData.base64EncodedString()
+
+        var request = URLRequest(url: url)
+        request.setValue("Basic \(base64)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw ValidationError.networkError(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw ValidationError.networkError("Reponse invalide")
+        }
+
+        guard http.statusCode == 200 else {
+            throw ValidationError.authFailed
+        }
+
+        // Extraire le nom
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let name = json["name"] as? String, !name.isEmpty {
+                return name
+            }
+            if let athlete = json["athlete"] as? [String: Any],
+               let name = athlete["name"] as? String, !name.isEmpty
+            {
+                return name
+            }
+        }
+
+        return athleteID
+    }
+}

--- a/packaging/MagmaCycling/Sources/Services/LaunchAgentManager.swift
+++ b/packaging/MagmaCycling/Sources/Services/LaunchAgentManager.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Gestion du LaunchAgent pour demarrage automatique au login.
+final class LaunchAgentManager {
+    private let label = "eu.alliancejr.magma-cycling"
+    private var plistURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents/\(label).plist")
+    }
+
+    var isInstalled: Bool {
+        FileManager.default.fileExists(atPath: plistURL.path)
+    }
+
+    /// Installe le LaunchAgent pour lancer le serveur MCP au login.
+    func install(binaryPath: URL, envFile: URL) {
+        let plist: [String: Any] = [
+            "Label": label,
+            "ProgramArguments": [
+                binaryPath.path,
+                "mcp-server",
+                "--transport", "stdio",
+            ],
+            "EnvironmentVariables": [
+                "MAGMA_ENV_FILE": envFile.path,
+            ],
+            "RunAtLoad": true,
+            "KeepAlive": [
+                "SuccessfulExit": false,  // Restart si crash
+            ],
+            "StandardOutPath": AppState.logsDir.appendingPathComponent("mcp-server.log").path,
+            "StandardErrorPath": AppState.logsDir.appendingPathComponent("mcp-server.err").path,
+            "ThrottleInterval": 10,
+        ]
+
+        let data = try? PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .xml,
+            options: 0
+        )
+
+        try? data?.write(to: plistURL, options: .atomic)
+
+        // Load
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        proc.arguments = ["load", plistURL.path]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try? proc.run()
+        proc.waitUntilExit()
+    }
+
+    /// Desinstalle le LaunchAgent.
+    func uninstall() {
+        // Unload
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        proc.arguments = ["unload", plistURL.path]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        try? proc.run()
+        proc.waitUntilExit()
+
+        try? FileManager.default.removeItem(at: plistURL)
+    }
+}

--- a/packaging/MagmaCycling/Sources/Services/ReleaseChecker.swift
+++ b/packaging/MagmaCycling/Sources/Services/ReleaseChecker.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Verifie et telecharge les releases GitHub.
+final class ReleaseChecker {
+    private let repo = "stephanejouve/magma-cycling"
+    private let session = URLSession.shared
+
+    struct Release: Decodable {
+        let tag_name: String
+        let assets: [Asset]
+
+        struct Asset: Decodable {
+            let name: String
+            let browser_download_url: String
+            let size: Int
+        }
+    }
+
+    /// Retourne la derniere version disponible (ex: "3.14.0").
+    func latestVersion() async throws -> String? {
+        let url = URL(string: "https://api.github.com/repos/\(repo)/releases/latest")!
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            return nil
+        }
+
+        let release = try JSONDecoder().decode(Release.self, from: data)
+        // "v3.14.0" → "3.14.0"
+        return release.tag_name.hasPrefix("v")
+            ? String(release.tag_name.dropFirst())
+            : release.tag_name
+    }
+
+    /// Telecharge le binaire macOS depuis la release.
+    func download(
+        version: String,
+        destination: URL,
+        progress: @escaping (Double) -> Void
+    ) async throws {
+        let tag = "v\(version)"
+        let url = URL(string: "https://api.github.com/repos/\(repo)/releases/tags/\(tag)")!
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+
+        let (data, _) = try await session.data(for: request)
+        let release = try JSONDecoder().decode(Release.self, from: data)
+
+        // Detecter l'architecture
+        let arch = ProcessInfo.processInfo.machineArchitecture
+        let assetName = arch == "arm64"
+            ? "magma-cycling-macos-arm64"
+            : "magma-cycling-macos-x86_64"
+
+        guard let asset = release.assets.first(where: { $0.name == assetName }) else {
+            throw DownloadError.assetNotFound(assetName)
+        }
+
+        let downloadURL = URL(string: asset.browser_download_url)!
+        let delegate = ProgressDelegate(totalSize: asset.size, onProgress: progress)
+
+        let (tempURL, _) = try await session.download(from: downloadURL, delegate: delegate)
+
+        // Remplacer le binaire existant
+        let fm = FileManager.default
+        if fm.fileExists(atPath: destination.path) {
+            try fm.removeItem(at: destination)
+        }
+        try fm.moveItem(at: tempURL, to: destination)
+    }
+
+    enum DownloadError: LocalizedError {
+        case assetNotFound(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .assetNotFound(let name):
+                return "Asset \(name) introuvable dans la release"
+            }
+        }
+    }
+}
+
+// MARK: - Progress tracking
+
+private final class ProgressDelegate: NSObject, URLSessionDownloadDelegate {
+    let totalSize: Int
+    let onProgress: (Double) -> Void
+
+    init(totalSize: Int, onProgress: @escaping (Double) -> Void) {
+        self.totalSize = totalSize
+        self.onProgress = onProgress
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        let expected = totalBytesExpectedToWrite > 0
+            ? totalBytesExpectedToWrite
+            : Int64(totalSize)
+        let fraction = Double(totalBytesWritten) / Double(max(expected, 1))
+        onProgress(min(fraction, 1.0))
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        // Handled by the async download call
+    }
+}
+
+// MARK: - Architecture detection
+
+extension ProcessInfo {
+    var machineArchitecture: String {
+        var sysinfo = utsname()
+        uname(&sysinfo)
+        return withUnsafePointer(to: &sysinfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                String(validatingUTF8: $0) ?? "unknown"
+            }
+        }
+    }
+}

--- a/packaging/MagmaCycling/Sources/Services/ServerManager.swift
+++ b/packaging/MagmaCycling/Sources/Services/ServerManager.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Gestion du process MCP server (start/stop/monitor).
+final class ServerManager {
+    private var process: Process?
+    private(set) var pid: Int32?
+
+    /// Verifie si le serveur tourne encore.
+    func isRunning() -> Bool {
+        guard let proc = process else { return false }
+        return proc.isRunning
+    }
+
+    /// Demarre le serveur MCP standalone.
+    func start(binary: URL, envFile: URL, logsDir: URL) throws {
+        guard !isRunning() else { return }
+
+        let env = try loadEnv(from: envFile)
+
+        let proc = Process()
+        proc.executableURL = binary
+        proc.arguments = ["mcp-server", "--transport", "stdio"]
+        proc.environment = ProcessInfo.processInfo.environment.merging(env) { _, new in new }
+
+        // Logs
+        let logFile = logsDir.appendingPathComponent("mcp-server.log")
+        let errFile = logsDir.appendingPathComponent("mcp-server.err")
+        FileManager.default.createFile(atPath: logFile.path, contents: nil)
+        FileManager.default.createFile(atPath: errFile.path, contents: nil)
+        proc.standardOutput = try FileHandle(forWritingTo: logFile)
+        proc.standardError = try FileHandle(forWritingTo: errFile)
+
+        proc.terminationHandler = { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.process = nil
+                self?.pid = nil
+            }
+        }
+
+        try proc.run()
+        process = proc
+        pid = proc.processIdentifier
+    }
+
+    /// Arrete le serveur gracieusement (SIGTERM puis SIGKILL apres 5s).
+    func stop() {
+        guard let proc = process, proc.isRunning else { return }
+        proc.terminate()
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5) {
+            if proc.isRunning {
+                kill(proc.processIdentifier, SIGKILL)
+            }
+        }
+
+        process = nil
+        pid = nil
+    }
+
+    /// Parse un fichier .env en dictionnaire.
+    private func loadEnv(from url: URL) throws -> [String: String] {
+        let content = try String(contentsOf: url, encoding: .utf8)
+        var env: [String: String] = [:]
+        for line in content.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            let parts = trimmed.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            env[String(parts[0])] = String(parts[1])
+        }
+        return env
+    }
+}

--- a/packaging/MagmaCycling/Sources/Views/MenuBarView.swift
+++ b/packaging/MagmaCycling/Sources/Views/MenuBarView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+struct MenuBarView: View {
+    @EnvironmentObject var state: AppState
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Image(systemName: "flame.fill")
+                    .foregroundStyle(.orange)
+                    .font(.title2)
+                Text("Magma Cycling")
+                    .font(.headline)
+                Spacer()
+                Text(state.currentVersion())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal)
+            .padding(.top, 12)
+
+            if !state.athleteName.isEmpty {
+                Text(state.athleteName)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal)
+                    .padding(.top, 2)
+            }
+
+            Divider().padding(.vertical, 8)
+
+            // Server status
+            ServerStatusRow()
+                .padding(.horizontal)
+
+            Divider().padding(.vertical, 8)
+
+            // Actions
+            if !state.isConfigured {
+                Button {
+                    openWindow(id: "setup")
+                } label: {
+                    Label("Configurer...", systemImage: "gearshape")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal)
+            } else {
+                // Start / Stop
+                if state.serverRunning {
+                    Button {
+                        state.stopServer()
+                    } label: {
+                        Label("Arreter le serveur", systemImage: "stop.fill")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal)
+                } else {
+                    Button {
+                        state.startServer()
+                    } label: {
+                        Label("Demarrer le serveur", systemImage: "play.fill")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal)
+                }
+
+                Button {
+                    openWindow(id: "setup")
+                } label: {
+                    Label("Configuration...", systemImage: "gearshape")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal)
+                .padding(.top, 4)
+            }
+
+            // Update banner
+            if let version = state.updateAvailable {
+                Divider().padding(.vertical, 8)
+                UpdateBanner(version: version)
+                    .padding(.horizontal)
+            }
+
+            Divider().padding(.vertical, 8)
+
+            // Logs (collapsed)
+            if !state.serverLog.isEmpty {
+                DisclosureGroup("Logs recents") {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(state.serverLog.suffix(10), id: \.self) { line in
+                                Text(line)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 120)
+                }
+                .font(.caption)
+                .padding(.horizontal)
+
+                Divider().padding(.vertical, 8)
+            }
+
+            Button {
+                NSApplication.shared.terminate(nil)
+            } label: {
+                Label("Quitter Magma Cycling", systemImage: "power")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
+            .padding(.bottom, 12)
+        }
+        .frame(width: 300)
+    }
+}
+
+// MARK: - Server status row
+
+struct ServerStatusRow: View {
+    @EnvironmentObject var state: AppState
+
+    var body: some View {
+        HStack {
+            Circle()
+                .fill(state.serverRunning ? .green : .red)
+                .frame(width: 8, height: 8)
+
+            Text(state.serverRunning ? "Serveur MCP actif" : "Serveur MCP inactif")
+                .font(.subheadline)
+
+            Spacer()
+
+            if let pid = state.serverPID, state.serverRunning {
+                Text("PID \(pid)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+// MARK: - Update banner
+
+struct UpdateBanner: View {
+    @EnvironmentObject var state: AppState
+    let version: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Image(systemName: "arrow.down.circle.fill")
+                    .foregroundStyle(.blue)
+                Text("Mise a jour \(version) disponible")
+                    .font(.subheadline)
+            }
+
+            if state.isDownloading {
+                ProgressView(value: state.downloadProgress)
+                    .progressViewStyle(.linear)
+            } else {
+                Button("Installer") {
+                    Task { try? await state.installUpdate() }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+    }
+}

--- a/packaging/MagmaCycling/Sources/Views/SetupWizardView.swift
+++ b/packaging/MagmaCycling/Sources/Views/SetupWizardView.swift
@@ -1,0 +1,381 @@
+import SwiftUI
+
+enum SetupStep: Int, CaseIterable {
+    case welcome
+    case download
+    case intervals
+    case claudeDesktop
+    case done
+}
+
+struct SetupWizardView: View {
+    @EnvironmentObject var state: AppState
+    @State private var step: SetupStep = .welcome
+
+    // Download
+    @State private var downloading = false
+    @State private var downloadProgress: Double = 0
+    @State private var downloadError: String?
+
+    // Intervals.icu
+    @State private var athleteID = ""
+    @State private var apiKey = ""
+    @State private var validating = false
+    @State private var validationResult: String?
+    @State private var validatedName: String?
+    @State private var validationError: String?
+
+    // Claude Desktop
+    @State private var claudeConfigured = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Progress bar
+            StepIndicator(current: step)
+                .padding()
+
+            Divider()
+
+            // Step content
+            Group {
+                switch step {
+                case .welcome:
+                    WelcomeStep()
+                case .download:
+                    DownloadStep(
+                        downloading: $downloading,
+                        progress: $downloadProgress,
+                        error: $downloadError
+                    )
+                case .intervals:
+                    IntervalsStep(
+                        athleteID: $athleteID,
+                        apiKey: $apiKey,
+                        validating: $validating,
+                        validatedName: $validatedName,
+                        validationError: $validationError
+                    )
+                case .claudeDesktop:
+                    ClaudeDesktopStep(configured: $claudeConfigured)
+                case .done:
+                    DoneStep()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding()
+
+            Divider()
+
+            // Navigation
+            HStack {
+                if step != .welcome && step != .done {
+                    Button("Retour") {
+                        step = SetupStep(rawValue: step.rawValue - 1) ?? .welcome
+                    }
+                    .keyboardShortcut(.cancelAction)
+                }
+
+                Spacer()
+
+                switch step {
+                case .welcome:
+                    Button("Commencer") {
+                        if FileManager.default.fileExists(atPath: AppState.binaryPath.path) {
+                            step = .intervals
+                        } else {
+                            step = .download
+                        }
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+
+                case .download:
+                    Button("Telecharger") {
+                        Task { await downloadBinary() }
+                    }
+                    .disabled(downloading)
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+
+                case .intervals:
+                    Button("Valider") {
+                        Task { await validateIntervals() }
+                    }
+                    .disabled(athleteID.isEmpty || apiKey.isEmpty || validating)
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+
+                case .claudeDesktop:
+                    Button("Configurer") {
+                        configureClaude()
+                    }
+                    .disabled(claudeConfigured)
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+
+                case .done:
+                    Button("Terminer") {
+                        NSApplication.shared.keyWindow?.close()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding()
+        }
+    }
+
+    // MARK: - Actions
+
+    func downloadBinary() async {
+        downloading = true
+        downloadError = nil
+        do {
+            guard let version = try await state.releases.latestVersion() else {
+                downloadError = "Aucune release trouvee sur GitHub"
+                downloading = false
+                return
+            }
+            try await state.releases.download(
+                version: version,
+                destination: AppState.binaryPath
+            ) { p in
+                Task { @MainActor in downloadProgress = p }
+            }
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: AppState.binaryPath.path
+            )
+            step = .intervals
+        } catch {
+            downloadError = error.localizedDescription
+        }
+        downloading = false
+    }
+
+    func validateIntervals() async {
+        validating = true
+        validationError = nil
+        validatedName = nil
+        do {
+            let name = try await IntervalsValidator.validate(athleteID: athleteID, apiKey: apiKey)
+            validatedName = name
+            try state.completeSetup(athleteID: athleteID, apiKey: apiKey, name: name)
+            step = .claudeDesktop
+        } catch IntervalsValidator.ValidationError.authFailed {
+            validationError = "Connexion echouee -- verifie ton ID et ta cle API."
+        } catch IntervalsValidator.ValidationError.networkError(let msg) {
+            validationError = "Erreur reseau: \(msg)"
+        } catch {
+            validationError = error.localizedDescription
+        }
+        validating = false
+    }
+
+    func configureClaude() {
+        state.claudeDesktop.configure(binaryPath: AppState.binaryPath)
+        claudeConfigured = true
+        step = .done
+    }
+}
+
+// MARK: - Step indicator
+
+struct StepIndicator: View {
+    let current: SetupStep
+    private let labels = ["Bienvenue", "Binaire", "Intervals.icu", "Claude", "Pret"]
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(SetupStep.allCases, id: \.rawValue) { s in
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(s.rawValue <= current.rawValue ? Color.orange : Color.gray.opacity(0.3))
+                        .frame(width: 10, height: 10)
+                    if s.rawValue < SetupStep.allCases.count - 1 {
+                        Rectangle()
+                            .fill(s.rawValue < current.rawValue ? Color.orange : Color.gray.opacity(0.3))
+                            .frame(height: 2)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Individual steps
+
+struct WelcomeStep: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "flame.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(.orange)
+
+            Text("Bienvenue dans Magma Cycling")
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text("Assistant de configuration pour ton entrainement cycliste intelligent.\nEn quelques etapes, tu seras connecte a Intervals.icu et Claude Desktop.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 400)
+        }
+    }
+}
+
+struct DownloadStep: View {
+    @Binding var downloading: Bool
+    @Binding var progress: Double
+    @Binding var error: String?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "arrow.down.circle")
+                .font(.system(size: 48))
+                .foregroundStyle(.blue)
+
+            Text("Telechargement du serveur")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            if downloading {
+                VStack(spacing: 8) {
+                    ProgressView(value: progress)
+                        .progressViewStyle(.linear)
+                        .frame(width: 300)
+                    Text("\(Int(progress * 100))%")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else if let err = error {
+                Label(err, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+            } else {
+                Text("Le binaire magma-cycling sera telecharge depuis GitHub Releases.")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+struct IntervalsStep: View {
+    @Binding var athleteID: String
+    @Binding var apiKey: String
+    @Binding var validating: Bool
+    @Binding var validatedName: String?
+    @Binding var validationError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Image(systemName: "chart.xyaxis.line")
+                    .font(.title2)
+                    .foregroundStyle(.orange)
+                Text("Connexion Intervals.icu")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Identifiant athlete")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                TextField("i123456 ou 15002177", text: $athleteID)
+                    .textFieldStyle(.roundedBorder)
+
+                Text("Cle API")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .padding(.top, 4)
+                SecureField("Depuis Settings > Developer Settings", text: $apiKey)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            if validating {
+                HStack {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Verification en cours...")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let name = validatedName {
+                Label("Connecte ! Athlete : \(name)", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+            }
+
+            if let err = validationError {
+                Label(err, systemImage: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+            }
+
+            Spacer()
+
+            Text("Tu trouves ton ID et ta cle API dans Intervals.icu > Settings > Developer Settings")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct ClaudeDesktopStep: View {
+    @Binding var configured: Bool
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "bubble.left.and.bubble.right.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.purple)
+
+            Text("Configuration Claude Desktop")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            if configured {
+                Label("Claude Desktop configure !", systemImage: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .font(.headline)
+                Text("Redemarre Claude Desktop pour activer les outils Magma Cycling.")
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            } else {
+                Text("Le fichier de configuration Claude Desktop sera mis a jour\npour connecter les outils Magma Cycling (MCP).")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+struct DoneStep: View {
+    @EnvironmentObject var state: AppState
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(.green)
+
+            Text("Configuration terminee !")
+                .font(.title)
+                .fontWeight(.bold)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Serveur MCP pret", systemImage: "server.rack")
+                Label("Intervals.icu connecte", systemImage: "chart.xyaxis.line")
+                Label("Claude Desktop configure", systemImage: "bubble.left.and.bubble.right.fill")
+                if !state.athleteName.isEmpty {
+                    Label("Athlete : \(state.athleteName)", systemImage: "person.fill")
+                }
+            }
+            .font(.subheadline)
+
+            Text("Magma Cycling tourne en arriere-plan dans la barre de menus.\nOuvre Claude Desktop et utilise les outils MCP pour planifier tes entrainements.")
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 400)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- App menu bar SwiftUI native (flamme orange, macOS 13+)
- Setup wizard 5 etapes : download binaire → Intervals.icu → Claude Desktop → LaunchAgent
- Server manager : start/stop/monitor process MCP, logs
- Auto-update : check GitHub Releases, download avec progress bar
- LaunchAgent avec KeepAlive, demarrage au login
- Claude Desktop : injection automatique claude_desktop_config.json
- CI workflow build-macos-app.yml : DMG x86_64 + arm64, attache aux releases

## Structure
```
packaging/MagmaCycling/
  Package.swift
  Sources/
    MagmaCyclingApp.swift          # @main, MenuBarExtra
    AppState.swift                 # State + lifecycle
    Views/MenuBarView.swift        # Menu status/actions
    Views/SetupWizardView.swift    # Wizard 5 steps
    Services/ServerManager.swift   # Process management
    Services/LaunchAgentManager.swift
    Services/ReleaseChecker.swift  # GitHub API
    Services/IntervalsValidator.swift
    Services/ClaudeDesktopConfigurator.swift
```

## Test plan
- [ ] Build CI (macos-15 runner avec Xcode)
- [ ] Smoke test .app launch + menu bar
- [ ] Wizard flow complet avec credentials Intervals.icu
- [ ] DMG x86_64 + arm64 en artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)