### PR TITLE
feat(notes): remove prefix restriction for calendar notes (BT-009)

### DIFF
--- a/magma_cycling/_mcp/handlers/remote_events.py
+++ b/magma_cycling/_mcp/handlers/remote_events.py
@@ -293,16 +293,6 @@ async def handle_create_remote_note(args: dict) -> list[TextContent]:
     name = args["name"]
     description = args["description"]
 
-    ALLOWED_PREFIXES = ["[ANNULÉE]", "[SAUTÉE]", "[REMPLACÉE]"]
-    if not any(name.startswith(prefix) for prefix in ALLOWED_PREFIXES):
-        error = {
-            "success": False,
-            "error": f"Invalid NOTE name. Name must start with one of: {', '.join(ALLOWED_PREFIXES)}",
-            "provided_name": name,
-            "allowed_prefixes": ALLOWED_PREFIXES,
-        }
-        return mcp_response(error)
-
     try:
         with suppress_stdout_stderr():
             client = create_intervals_client()

--- a/magma_cycling/_mcp/schemas/remote.py
+++ b/magma_cycling/_mcp/schemas/remote.py
@@ -251,7 +251,7 @@ def get_tools() -> list[Tool]:
         ),
         Tool(
             name="create-remote-note",
-            description="Create a NOTE (calendar note) on the training calendar (category=NOTE, type=null). NOTE: Name MUST start with one of the allowed prefixes: [ANNULÉE], [SAUTÉE], or [REMPLACÉE]",
+            description="Create a NOTE (calendar note) on the training calendar. Supports free-form titles and optional planning integration via session ID detection.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -262,8 +262,7 @@ def get_tools() -> list[Tool]:
                     },
                     "name": {
                         "type": "string",
-                        "description": "Note title - MUST start with [ANNULÉE], [SAUTÉE], or [REMPLACÉE] prefix followed by session details (e.g., '[ANNULÉE] S081-04-INT-TempoSoutenu')",
-                        "pattern": "^\\[(ANNULÉE|SAUTÉE|REMPLACÉE)\\] .+",
+                        "description": "Titre de la note (texte libre). Si le nom contient un session_id (ex: S081-04), le planning local sera mis à jour.",
                     },
                     "description": {
                         "type": "string",

--- a/tests/_mcp/handlers/test_remote_events.py
+++ b/tests/_mcp/handlers/test_remote_events.py
@@ -313,19 +313,30 @@ class TestHandleCreateRemoteNote:
     """Tests for handle_create_remote_note."""
 
     @pytest.mark.asyncio
-    async def test_rejects_invalid_prefix(self):
-        """Rejects note names without allowed prefix."""
-        result = await handle_create_remote_note(
-            {"date": "2026-03-02", "name": "Bad Name", "description": "test"}
-        )
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_create_note_freeform(self, mock_factory, mock_client):
+        """Accepts free-form note names (no prefix restriction)."""
+        mock_factory.return_value = mock_client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+
+            result = await handle_create_remote_note(
+                {
+                    "date": "2026-03-02",
+                    "name": "Course reconnaissance parcours",
+                    "description": "test",
+                }
+            )
+
         data = json.loads(result[0].text)
-        assert data["success"] is False
-        assert "allowed_prefixes" in data
+        assert data["success"] is True
+        assert data["event_id"] == 99
 
     @pytest.mark.asyncio
     @patch("magma_cycling.config.create_intervals_client")
     async def test_create_note_success(self, mock_factory, mock_client):
-        """Creates note on API successfully."""
+        """Creates note with prefix on API successfully."""
         mock_factory.return_value = mock_client
 
         with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:


### PR DESCRIPTION
## Summary
- Remove `ALLOWED_PREFIXES` validation in `create-remote-note` handler
- Remove `pattern` constraint from schema — free-form titles now accepted
- Session ID detection and status mapping still active when prefixes present
- Test `test_rejects_invalid_prefix` replaced by `test_create_note_freeform`

## Test plan
- [x] `pytest tests/_mcp/handlers/test_remote_events.py -v` — 16/16 passed
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)