### PR TITLE
feat(health): filter Withings false positives + IntervalsHealthProvider (SLEEP-001)

### DIFF
--- a/magma_cycling/api/withings/sleep.py
+++ b/magma_cycling/api/withings/sleep.py
@@ -125,11 +125,41 @@ class SleepMixin:
                 }
             )
 
+        # Filter false positives before aggregation
+        sleep_sessions = self._filter_false_positives(sleep_sessions)
+
         # Aggregate segments by sleep_date
         sleep_sessions = self._aggregate_sleep_segments(sleep_sessions)
 
         logger.info(f"Retrieved {len(sleep_sessions)} sleep sessions")
         return sleep_sessions
+
+    @staticmethod
+    def _filter_false_positives(
+        sessions: list[dict],
+        min_sleep_hours: float = 2.0,
+        min_nap_hours: float = 1.5,
+    ) -> list[dict]:
+        """Filter out Withings false positive sleep segments.
+
+        Short segments during the night (< 2h) and short daytime segments
+        (< 1.5h, 06:00-20:00) are likely inactivity misdetected as sleep.
+        """
+        filtered = []
+        for s in sessions:
+            hours = s["total_sleep_hours"]
+            start_str = s.get("start_datetime", "")
+            start_hour = int(start_str[11:13]) if len(start_str) >= 13 else 0
+            is_daytime = 6 <= start_hour < 20
+
+            if not is_daytime and hours < min_sleep_hours:
+                logger.warning("Filtered short night segment: %.1fh (%s)", hours, start_str)
+                continue
+            if is_daytime and hours < min_nap_hours:
+                logger.warning("Filtered short daytime segment: %.1fh (%s)", hours, start_str)
+                continue
+            filtered.append(s)
+        return filtered
 
     @staticmethod
     def _aggregate_sleep_segments(

--- a/magma_cycling/health/__init__.py
+++ b/magma_cycling/health/__init__.py
@@ -6,11 +6,13 @@ that decouples the training system from any specific health device API.
 
 from magma_cycling.health.base import HealthProvider
 from magma_cycling.health.factory import create_health_provider
+from magma_cycling.health.intervals_provider import IntervalsHealthProvider
 from magma_cycling.health.null_provider import NullProvider
 from magma_cycling.health.withings_provider import WithingsProvider
 
 __all__ = [
     "HealthProvider",
+    "IntervalsHealthProvider",
     "NullProvider",
     "WithingsProvider",
     "create_health_provider",

--- a/magma_cycling/health/factory.py
+++ b/magma_cycling/health/factory.py
@@ -2,27 +2,53 @@
 
 from __future__ import annotations
 
+import logging
+
 from magma_cycling.health.base import HealthProvider
+
+logger = logging.getLogger(__name__)
 
 
 def create_health_provider() -> HealthProvider:
     """Create a HealthProvider based on available configuration.
 
-    Returns WithingsProvider if Withings is configured, NullProvider otherwise.
+    Priority chain:
+        1. WithingsProvider if Withings is configured
+        2. IntervalsHealthProvider if Intervals.icu has sleep data
+        3. NullProvider (silent fallback)
+
     Never raises — falls back silently to NullProvider on any error.
     """
+    # 1. Try Withings
     try:
         from magma_cycling.config import create_withings_client, get_withings_config
         from magma_cycling.health.withings_provider import WithingsProvider
 
         config = get_withings_config()
-        if not config.is_configured():
-            from magma_cycling.health.null_provider import NullProvider
-
-            return NullProvider()
-        client = create_withings_client()
-        return WithingsProvider(client)
+        if config.is_configured():
+            client = create_withings_client()
+            return WithingsProvider(client)
     except Exception:
-        from magma_cycling.health.null_provider import NullProvider
+        pass
 
-        return NullProvider()
+    # 2. Try Intervals.icu wellness (Garmin/other watch)
+    try:
+        from datetime import date, timedelta
+
+        from magma_cycling.config import create_intervals_client
+
+        client = create_intervals_client()
+        yesterday = str(date.today() - timedelta(days=1))
+        wellness = client.get_wellness(oldest=yesterday, newest=yesterday)
+        if wellness and wellness[0].get("sleepTime"):
+            from magma_cycling.health.intervals_provider import IntervalsHealthProvider
+
+            logger.info("Using IntervalsHealthProvider (sleep data found in wellness)")
+            return IntervalsHealthProvider(client)
+    except Exception:
+        pass
+
+    # 3. Fallback
+    from magma_cycling.health.null_provider import NullProvider
+
+    return NullProvider()

--- a/magma_cycling/health/intervals_provider.py
+++ b/magma_cycling/health/intervals_provider.py
@@ -1,0 +1,131 @@
+"""Intervals.icu wellness-based health provider (Garmin/other watch sources)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from magma_cycling.health.base import HealthProvider
+from magma_cycling.models.withings_models import (
+    BloodPressureMeasurement,
+    SleepData,
+    TrainingReadiness,
+    WeightMeasurement,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class IntervalsHealthProvider(HealthProvider):
+    """Read health data from Intervals.icu wellness (Garmin/other sources)."""
+
+    def __init__(self, client: Any) -> None:
+        """Initialize with an IntervalsClient instance."""
+        self._client = client
+
+    def _get_wellness_day(self, target_date: date) -> dict | None:
+        """Fetch a single day's wellness data."""
+        date_str = str(target_date)
+        wellness = self._client.get_wellness(oldest=date_str, newest=date_str)
+        if not wellness:
+            return None
+        return wellness[0]
+
+    # -- sleep ---------------------------------------------------------------
+
+    def get_sleep_summary(self, target_date: date) -> SleepData | None:
+        """Get sleep data from Intervals.icu wellness (Garmin push)."""
+        w = self._get_wellness_day(target_date)
+        if not w:
+            return None
+        sleep_secs = w.get("sleepTime")
+        if not sleep_secs:
+            return None
+        # Build a SleepData from available wellness fields
+        sleep_hours = round(sleep_secs / 3600, 2)
+        # Estimate start/end from sleep duration ending at 07:00
+        end_dt = datetime.combine(target_date, datetime.min.time()).replace(hour=7)
+        start_dt = end_dt - timedelta(seconds=sleep_secs)
+        return SleepData(
+            date=target_date,
+            start_datetime=start_dt,
+            end_datetime=end_dt,
+            total_sleep_hours=sleep_hours,
+            sleep_score=w.get("sleepScore"),
+            sleep_efficiency=None,
+            wakeup_count=w.get("wakeupCount", 0),
+        )
+
+    def get_sleep_range(self, start_date: date, end_date: date) -> list[SleepData]:
+        """Get sleep sessions over a date range from wellness data."""
+        results = []
+        current = start_date
+        while current <= end_date:
+            summary = self.get_sleep_summary(current)
+            if summary:
+                results.append(summary)
+            current += timedelta(days=1)
+        return results
+
+    # -- body composition (not available from Intervals.icu wellness) --------
+
+    def get_body_composition(self) -> WeightMeasurement | None:
+        """Return None — not available from Intervals.icu wellness."""
+        return None
+
+    def get_body_composition_range(
+        self, start_date: date, end_date: date
+    ) -> list[WeightMeasurement]:
+        """Return empty list — not available from Intervals.icu wellness."""
+        return []
+
+    # -- blood pressure (not available) --------------------------------------
+
+    def get_blood_pressure_range(
+        self, start_date: date, end_date: date
+    ) -> list[BloodPressureMeasurement]:
+        """Return empty list — not available from Intervals.icu wellness."""
+        return []
+
+    # -- readiness -----------------------------------------------------------
+
+    def get_readiness(self, target_date: date | None = None) -> TrainingReadiness | None:
+        """Evaluate readiness from Intervals.icu sleep data."""
+        sleep = self.get_sleep_summary(target_date or date.today())
+        if not sleep:
+            return None
+        ready = sleep.total_sleep_hours >= 6.5
+        if sleep.total_sleep_hours >= 7:
+            intensity = "all_systems_go"
+        elif sleep.total_sleep_hours >= 6:
+            intensity = "moderate"
+        elif sleep.total_sleep_hours >= 5:
+            intensity = "endurance_max"
+        else:
+            intensity = "recovery_only"
+        veto = []
+        if sleep.total_sleep_hours < 5.5:
+            veto.append(f"Insufficient sleep: {sleep.total_sleep_hours}h")
+        return TrainingReadiness(
+            date=target_date or date.today(),
+            sleep_hours=sleep.total_sleep_hours,
+            sleep_score=sleep.sleep_score,
+            ready_for_intense=ready,
+            recommended_intensity=intensity,
+            veto_reasons=veto,
+        )
+
+    # -- auth ----------------------------------------------------------------
+
+    def auth_status(self) -> dict[str, Any]:
+        """Return provider status."""
+        return {
+            "configured": True,
+            "has_credentials": True,
+            "provider": "intervals_icu_wellness",
+        }
+
+    def get_provider_info(self) -> dict[str, str]:
+        """Return IntervalsHealthProvider metadata."""
+        return {"provider": "IntervalsHealthProvider", "status": "ready"}

--- a/tests/api/test_withings_sleep_segments.py
+++ b/tests/api/test_withings_sleep_segments.py
@@ -1,5 +1,6 @@
-"""Tests for Withings sleep segment aggregation."""
+"""Tests for Withings sleep segment aggregation and false positive filtering."""
 
+from magma_cycling.api.withings.sleep import SleepMixin
 from magma_cycling.api.withings_client import WithingsClient
 
 
@@ -175,3 +176,54 @@ class TestDifferentDates:
         assert len(result) == 2
         assert result[0]["segments_count"] == 1
         assert result[1]["segments_count"] == 1
+
+
+class TestFalsePositiveFiltering:
+    """SLEEP-001: filter short false-positive segments before aggregation."""
+
+    def test_short_night_segment_filtered(self):
+        """A 30min segment at 03:00 (nighttime) should be filtered out."""
+        seg = _make_segment("2026-04-10", "2026-04-10T03:00:00", "2026-04-10T03:30:00", 0.5)
+        result = SleepMixin._filter_false_positives([seg])
+        assert len(result) == 0
+
+    def test_normal_night_segment_kept(self):
+        """A 7h night segment should pass through."""
+        seg = _make_segment("2026-04-10", "2026-04-09T23:00:00", "2026-04-10T06:00:00", 7.0)
+        result = SleepMixin._filter_false_positives([seg])
+        assert len(result) == 1
+
+    def test_short_daytime_segment_filtered(self):
+        """A 45min segment at 14:00 (desk inactivity) should be filtered."""
+        seg = _make_segment("2026-04-10", "2026-04-10T14:00:00", "2026-04-10T14:45:00", 0.75)
+        result = SleepMixin._filter_false_positives([seg])
+        assert len(result) == 0
+
+    def test_long_nap_kept(self):
+        """A 1.5h+ daytime nap should be kept."""
+        seg = _make_segment("2026-04-10", "2026-04-10T13:00:00", "2026-04-10T14:45:00", 1.75)
+        result = SleepMixin._filter_false_positives([seg])
+        assert len(result) == 1
+
+    def test_mixed_segments_only_valid_kept(self):
+        """Only valid segments survive filtering."""
+        segments = [
+            _make_segment("2026-04-10", "2026-04-09T23:00:00", "2026-04-10T06:00:00", 7.0),
+            _make_segment("2026-04-10", "2026-04-10T10:30:00", "2026-04-10T11:00:00", 0.5),
+            _make_segment("2026-04-10", "2026-04-10T02:00:00", "2026-04-10T02:15:00", 0.25),
+        ]
+        result = SleepMixin._filter_false_positives(segments)
+        assert len(result) == 1
+        assert result[0]["total_sleep_hours"] == 7.0
+
+    def test_boundary_2h_night_segment_kept(self):
+        """A 2h night segment is exactly at the threshold — should be kept."""
+        seg = _make_segment("2026-04-10", "2026-04-10T01:00:00", "2026-04-10T03:00:00", 2.0)
+        result = SleepMixin._filter_false_positives([seg])
+        assert len(result) == 1
+
+    def test_boundary_1h5_nap_kept(self):
+        """A 1.5h daytime nap is at the threshold — should be kept."""
+        seg = _make_segment("2026-04-10", "2026-04-10T14:00:00", "2026-04-10T15:30:00", 1.5)
+        result = SleepMixin._filter_false_positives([seg])
+        assert len(result) == 1

--- a/tests/health/test_intervals_provider.py
+++ b/tests/health/test_intervals_provider.py
@@ -1,0 +1,80 @@
+"""Tests for IntervalsHealthProvider."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from magma_cycling.health.intervals_provider import IntervalsHealthProvider
+
+
+@pytest.fixture
+def mock_client():
+    """Mock IntervalsClient with wellness data."""
+    client = MagicMock()
+    client.get_wellness.return_value = [
+        {
+            "id": "2026-04-15",
+            "sleepTime": 27000,  # 7.5h in seconds
+            "sleepScore": 82,
+            "wakeupCount": 2,
+        }
+    ]
+    return client
+
+
+@pytest.fixture
+def provider(mock_client):
+    return IntervalsHealthProvider(mock_client)
+
+
+class TestGetSleepSummary:
+    def test_returns_sleep_data(self, provider):
+        result = provider.get_sleep_summary(date(2026, 4, 15))
+        assert result is not None
+        assert result.total_sleep_hours == 7.5
+        assert result.sleep_score == 82
+        assert result.wakeup_count == 2
+
+    def test_returns_none_when_no_wellness(self, mock_client):
+        mock_client.get_wellness.return_value = []
+        provider = IntervalsHealthProvider(mock_client)
+        assert provider.get_sleep_summary(date(2026, 4, 15)) is None
+
+    def test_returns_none_when_no_sleep_time(self, mock_client):
+        mock_client.get_wellness.return_value = [{"id": "2026-04-15"}]
+        provider = IntervalsHealthProvider(mock_client)
+        assert provider.get_sleep_summary(date(2026, 4, 15)) is None
+
+
+class TestGetReadiness:
+    def test_good_sleep_all_systems_go(self, provider):
+        readiness = provider.get_readiness(date(2026, 4, 15))
+        assert readiness is not None
+        assert readiness.ready_for_intense is True
+        assert readiness.recommended_intensity == "all_systems_go"
+        assert readiness.veto_reasons == []
+
+    def test_low_sleep_veto(self, mock_client):
+        mock_client.get_wellness.return_value = [
+            {"id": "2026-04-15", "sleepTime": 18000, "sleepScore": 45}  # 5h
+        ]
+        provider = IntervalsHealthProvider(mock_client)
+        readiness = provider.get_readiness(date(2026, 4, 15))
+        assert readiness.recommended_intensity == "endurance_max"
+        assert len(readiness.veto_reasons) == 1
+
+
+class TestBodyComposition:
+    def test_returns_none(self, provider):
+        assert provider.get_body_composition() is None
+
+    def test_range_returns_empty(self, provider):
+        assert provider.get_body_composition_range(date(2026, 4, 1), date(2026, 4, 15)) == []
+
+
+class TestAuthStatus:
+    def test_configured(self, provider):
+        status = provider.auth_status()
+        assert status["configured"] is True
+        assert status["provider"] == "intervals_icu_wellness"


### PR DESCRIPTION
## Summary
- Filter Withings false positives: night segments < 2h and daytime segments < 1.5h excluded before aggregation
- New `IntervalsHealthProvider` reads sleep from Intervals.icu wellness (Garmin/watch push)
- Factory chain: Withings → Intervals.icu wellness → NullProvider
- 15 new tests (7 filtering + 8 provider)

## Test plan
- [x] `pytest tests/api/test_withings_sleep_segments.py -v` — 20/20 passed
- [x] `pytest tests/health/test_intervals_provider.py -v` — 8/8 passed
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)