### PR TITLE
feat(validation): semantic type↔content validator (VALID-001)

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -804,6 +804,29 @@ async def handle_modify_session_details(args: dict) -> list[TextContent]:
                 update_workouts_file(week_id, _wt_intervals_name, description)
                 modifications.append("workouts_txt_updated")
 
+        # Semantic type validation (non-blocking warning)
+        type_warnings = None
+        try:
+            with suppress_stdout_stderr():
+                plan = planning_tower.read_week(week_id)
+                for session in plan.planned_sessions:
+                    if session.session_id == session_id:
+                        from magma_cycling.utils.type_validator import validate_session_type
+
+                        validation = validate_session_type(
+                            session.session_type,
+                            session.description or "",
+                            session.tss_planned,
+                        )
+                        if not validation.valid:
+                            type_warnings = {
+                                "warnings": validation.warnings,
+                                "suggested_type": validation.suggested_type,
+                            }
+                        break
+        except Exception:
+            pass
+
         result = {
             "status": "success",
             "week_id": week_id,
@@ -811,6 +834,8 @@ async def handle_modify_session_details(args: dict) -> list[TextContent]:
             "modifications": modifications,
             "message": f"Session {session_id} updated successfully",
         }
+        if type_warnings:
+            result["type_validation"] = type_warnings
 
         return mcp_response(result)
 

--- a/magma_cycling/utils/type_validator.py
+++ b/magma_cycling/utils/type_validator.py
@@ -1,0 +1,62 @@
+"""Semantic validation between session_type and content (description + TSS)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+_INTENSITY_KEYWORDS = re.compile(r"\d+\s*%|FTP|seuil|threshold|VO2|MAP|sprint|force", re.IGNORECASE)
+_INTERVAL_PATTERN = re.compile(r"\d+\s*x\s*\d+\s*m(?:in)?", re.IGNORECASE)
+_HIGH_ZONE_KEYWORDS = re.compile(r"1[0-2]\d\s*%|VO2\s*max|MAP|zone\s*[56]|PMA", re.IGNORECASE)
+
+
+@dataclass
+class TypeValidation:
+    """Result of session type validation."""
+
+    valid: bool
+    warnings: list[str] = field(default_factory=list)
+    suggested_type: str | None = None
+
+
+def validate_session_type(
+    session_type: str,
+    description: str,
+    tss: int | float | None = None,
+) -> TypeValidation:
+    """Validate coherence between session_type and its content.
+
+    Args:
+        session_type: Session type code (REC, END, INT, VO2, MAP, FRC, etc.)
+        description: Session description text.
+        tss: Planned TSS (optional).
+
+    Returns:
+        TypeValidation with valid flag, warnings, and optional suggested type.
+    """
+    warnings: list[str] = []
+    suggested: str | None = None
+    tss_val = tss or 0
+
+    if session_type == "REC":
+        if tss_val > 40:
+            warnings.append(f"REC avec TSS={tss_val} (attendu <= 40)")
+        if _INTENSITY_KEYWORDS.search(description):
+            warnings.append("REC contient des mots-clés d'intensité")
+            suggested = "INT"
+
+    elif session_type == "END":
+        if _INTERVAL_PATTERN.search(description):
+            warnings.append("END contient une structure d'intervalles")
+            suggested = "INT"
+
+    elif session_type in ("INT", "VO2", "MAP", "FRC"):
+        if tss_val < 30 and not _INTENSITY_KEYWORDS.search(description):
+            warnings.append(f"{session_type} avec TSS={tss_val} et pas de mots-clés intensité")
+            suggested = "REC" if tss_val <= 30 else "END"
+
+    return TypeValidation(
+        valid=len(warnings) == 0,
+        warnings=warnings,
+        suggested_type=suggested,
+    )

--- a/magma_cycling/workflows/planner/output.py
+++ b/magma_cycling/workflows/planner/output.py
@@ -156,5 +156,26 @@ class OutputMixin:
             file_timestamp=planning_dict["created_at"],
         )
 
+        # Semantic type validation (non-blocking warnings)
+        from magma_cycling.utils.type_validator import validate_session_type
+
+        for session in plan.planned_sessions:
+            validation = validate_session_type(
+                session.session_type,
+                session.description or "",
+                session.tss_planned,
+            )
+            if not validation.valid:
+                for w in validation.warnings:
+                    print(
+                        f"  ⚠️ {session.session_id}: {w}"
+                        + (
+                            f" (suggestion: {validation.suggested_type})"
+                            if validation.suggested_type
+                            else ""
+                        ),
+                        file=sys.stderr,
+                    )
+
         print(f"\n📄 Planning JSON sauvegardé : {json_file}", file=sys.stderr)
         return json_file

--- a/tests/utils/test_type_validator.py
+++ b/tests/utils/test_type_validator.py
@@ -1,0 +1,99 @@
+"""Tests for semantic type ↔ content validator."""
+
+from magma_cycling.utils.type_validator import TypeValidation, validate_session_type
+
+
+class TestRecovery:
+    """REC sessions: low TSS, no intensity keywords."""
+
+    def test_valid_rec(self):
+        result = validate_session_type("REC", "Repos complet", tss=0)
+        assert result.valid is True
+
+    def test_rec_high_tss(self):
+        result = validate_session_type("REC", "Récup facile Z1", tss=55)
+        assert result.valid is False
+        assert any("TSS=55" in w for w in result.warnings)
+
+    def test_rec_with_intensity_keywords(self):
+        result = validate_session_type("REC", "3x12min à 90% FTP intervalles", tss=0)
+        assert result.valid is False
+        assert result.suggested_type == "INT"
+
+    def test_rec_with_ftp_keyword(self):
+        result = validate_session_type("REC", "Maintien FTP steady state", tss=30)
+        assert result.valid is False
+
+
+class TestEndurance:
+    """END sessions: no structured intervals."""
+
+    def test_valid_end(self):
+        result = validate_session_type("END", "Endurance Z2 2h 75rpm", tss=70)
+        assert result.valid is True
+
+    def test_end_with_intervals(self):
+        result = validate_session_type("END", "2x20min sweet spot", tss=75)
+        assert result.valid is False
+        assert result.suggested_type == "INT"
+
+    def test_end_no_intervals(self):
+        result = validate_session_type("END", "Long ride Z2 steady cadence", tss=80)
+        assert result.valid is True
+
+
+class TestIntensity:
+    """INT/VO2/MAP/FRC sessions: should have intensity markers."""
+
+    def test_valid_int(self):
+        result = validate_session_type("INT", "4x8min @ 95% FTP", tss=70)
+        assert result.valid is True
+
+    def test_int_low_tss_no_keywords(self):
+        result = validate_session_type("INT", "Easy spinning", tss=20)
+        assert result.valid is False
+        assert result.suggested_type == "REC"
+
+    def test_int_with_keywords_low_tss(self):
+        """INT with intensity keywords but low TSS should pass (keywords present)."""
+        result = validate_session_type("INT", "Neuromuscular sprint efforts", tss=25)
+        assert result.valid is True
+
+    def test_vo2_valid(self):
+        result = validate_session_type("VO2", "5x4min VO2max 110% FTP", tss=80)
+        assert result.valid is True
+
+    def test_map_low_tss_no_keywords(self):
+        result = validate_session_type("MAP", "Easy ride", tss=15)
+        assert result.valid is False
+
+    def test_frc_valid(self):
+        result = validate_session_type("FRC", "6x30s force sprint max", tss=50)
+        assert result.valid is True
+
+
+class TestOtherTypes:
+    """Types not explicitly covered should always pass."""
+
+    def test_unknown_type(self):
+        result = validate_session_type("RACE", "Race day 100km", tss=150)
+        assert result.valid is True
+
+    def test_tempo_type(self):
+        result = validate_session_type("TMP", "Tempo steady 88%", tss=65)
+        assert result.valid is True
+
+
+class TestEdgeCases:
+    def test_none_tss(self):
+        result = validate_session_type("REC", "Repos", tss=None)
+        assert result.valid is True
+
+    def test_empty_description(self):
+        result = validate_session_type("INT", "", tss=0)
+        assert result.valid is False
+
+    def test_dataclass_structure(self):
+        result = validate_session_type("REC", "test", tss=0)
+        assert isinstance(result, TypeValidation)
+        assert isinstance(result.warnings, list)


### PR DESCRIPTION
## Summary
- New `utils/type_validator.py` — pure functions validating session_type vs content
- Rules: REC (TSS≤40, no intensity), END (no intervals), INT/VO2/MAP/FRC (needs intensity markers)
- Integrated in `modify-session-details` handler (non-blocking `type_validation` field in response)
- Integrated in weekly planner `save_planning_json` (stderr warnings post-generation)
- 18 new tests covering all types + edge cases

## Test plan
- [x] `pytest tests/utils/test_type_validator.py -v` — 18/18 passed
- [x] `pytest tests/ -x` — 3382 passed, 0 failed
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)