### PR TITLE
fix(mcp): inline type validation — fixes VALID-001 test 6

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -791,6 +791,11 @@ async def handle_modify_session_details(args: dict) -> list[TextContent]:
                                 f"{session.name}-{session.version}"
                             )
 
+                        # Capture state for post-save type validation
+                        _val_type = session.session_type
+                        _val_desc = session.description or ""
+                        _val_tss = session.tss_planned
+
                         session_found = True
                         break
 
@@ -804,28 +809,19 @@ async def handle_modify_session_details(args: dict) -> list[TextContent]:
                 update_workouts_file(week_id, _wt_intervals_name, description)
                 modifications.append("workouts_txt_updated")
 
-        # Semantic type validation (non-blocking warning)
+        # Semantic type validation (non-blocking, uses captured state)
         type_warnings = None
         try:
-            with suppress_stdout_stderr():
-                plan = planning_tower.read_week(week_id)
-                for session in plan.planned_sessions:
-                    if session.session_id == session_id:
-                        from magma_cycling.utils.type_validator import validate_session_type
+            from magma_cycling.utils.type_validator import validate_session_type
 
-                        validation = validate_session_type(
-                            session.session_type,
-                            session.description or "",
-                            session.tss_planned,
-                        )
-                        if not validation.valid:
-                            type_warnings = {
-                                "warnings": validation.warnings,
-                                "suggested_type": validation.suggested_type,
-                            }
-                        break
-        except Exception:
-            pass
+            validation = validate_session_type(_val_type, _val_desc, _val_tss)
+            if not validation.valid:
+                type_warnings = {
+                    "warnings": validation.warnings,
+                    "suggested_type": validation.suggested_type,
+                }
+        except Exception as e:
+            logger.debug("Type validation skipped: %s", e)
 
         result = {
             "status": "success",

--- a/tests/_mcp/handlers/test_planning_duration.py
+++ b/tests/_mcp/handlers/test_planning_duration.py
@@ -1,4 +1,4 @@
-"""Tests for duration recalculation from workout blocks."""
+"""Tests for duration recalculation and type validation in modify-session-details."""
 
 import json
 from datetime import UTC, date, datetime
@@ -115,3 +115,122 @@ Cooldown
         modified = mock_plan.planned_sessions[0]
         assert modified.description == new_description
         assert modified.duration_min == 75
+
+
+class TestModifySessionTypeValidation:
+    """Test that modify-session-details includes type_validation warnings."""
+
+    def _make_plan(self, session_type="END", description="Endurance Z2", tss=70):
+        from magma_cycling.planning.models import Session, WeeklyPlan
+
+        session = Session(
+            session_id="S089-03",
+            date=date(2026, 4, 16),
+            name="TestSession",
+            type=session_type,
+            version="V001",
+            tss_planned=tss,
+            duration_min=60,
+            description=description,
+            status="planned",
+        )
+        return WeeklyPlan(
+            week_id="S089",
+            start_date=date(2026, 4, 13),
+            end_date=date(2026, 4, 19),
+            tss_target=350,
+            planned_sessions=[session],
+            created_at=datetime.now(UTC),
+            last_updated=datetime.now(UTC),
+            version=1,
+            athlete_id="i000000",
+        )
+
+    @pytest.mark.asyncio
+    async def test_rec_with_intensity_keywords_triggers_warning(self):
+        """REC type + intensity keywords in description → type_validation in response."""
+        from magma_cycling._mcp.handlers.planning import handle_modify_session_details
+
+        mock_plan = self._make_plan()
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_plan)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.workout_parser.update_workouts_file"),
+        ):
+            mock_tower.modify_week.return_value = mock_cm
+
+            result = await handle_modify_session_details(
+                {
+                    "week_id": "S089",
+                    "session_id": "S089-03",
+                    "type": "REC",
+                    "description": "4x8min @ 95% FTP sweet spot",
+                }
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert "type_validation" in data, "Expected type_validation for REC + intensity"
+        assert data["type_validation"]["suggested_type"] == "INT"
+
+    @pytest.mark.asyncio
+    async def test_valid_end_no_warning(self):
+        """Valid END session → no type_validation in response."""
+        from magma_cycling._mcp.handlers.planning import handle_modify_session_details
+
+        mock_plan = self._make_plan()
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_plan)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.workout_parser.update_workouts_file"),
+        ):
+            mock_tower.modify_week.return_value = mock_cm
+
+            result = await handle_modify_session_details(
+                {
+                    "week_id": "S089",
+                    "session_id": "S089-03",
+                    "type": "END",
+                    "description": "Endurance Z2 steady cadence 2h",
+                }
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert "type_validation" not in data
+
+    @pytest.mark.asyncio
+    async def test_end_with_intervals_triggers_warning(self):
+        """END type + interval pattern in description → type_validation."""
+        from magma_cycling._mcp.handlers.planning import handle_modify_session_details
+
+        mock_plan = self._make_plan()
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_plan)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower,
+            patch("magma_cycling.workout_parser.update_workouts_file"),
+        ):
+            mock_tower.modify_week.return_value = mock_cm
+
+            result = await handle_modify_session_details(
+                {
+                    "week_id": "S089",
+                    "session_id": "S089-03",
+                    "type": "END",
+                    "description": "3x20min sweet spot progression 88-92% FTP",
+                }
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert "type_validation" in data
+        assert data["type_validation"]["suggested_type"] == "INT"


### PR DESCRIPTION
## Summary
- Replace fragile `read_week()` re-read in type validation with captured session state from the `modify_week` block
- Silent `except Exception: pass` replaced with `logger.debug` for diagnostics
- 3 new integration tests covering REC+intensity, valid END, END+intervals

## Context
VALID-001 test 6 on preprod: `modify-session-details` with `type=REC` + intensity keywords didn't include `type_validation` in the response. Root cause: the post-save `planning_tower.read_week()` call could fail silently (exception swallowed by bare `except: pass`).

## Test plan
- [x] `pytest tests/_mcp/handlers/test_planning_duration.py -v` — 5/5 passed
- [x] `pytest tests/ -x` — 3385 passed, 0 failed
- [ ] Preprod: re-run test 6 (REC + "4x8min @ 95% FTP sweet spot")

🤖 Generated with [Claude Code](https://claude.com/claude-code)