### PR TITLE
feat(hrv): nocturnal RMSSD via HealthProvider — first HRV adapter (Withings)

### DIFF
--- a/magma_cycling/api/withings/hrv.py
+++ b/magma_cycling/api/withings/hrv.py
@@ -1,0 +1,68 @@
+"""HRV mixin for WithingsClient.
+
+Exposes nocturnal RMSSD start/end averages from Withings Sleep Analyzer
+via the ``v2/sleep/getsummary`` endpoint. Daytime SDNN via
+``v2/measure/getintradayactivity`` is covered in a separate method that
+may ship in a later iteration.
+
+Only devices capable of HRV capture fill these fields — Sleep Analyzer
+(model 32) in the EU and Sleep Rx in the US. Other devices return no HRV
+data and the methods return an empty list without raising.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class HrvMixin:
+    """Sleep HRV retrieval (nocturnal start/end RMSSD averages)."""
+
+    def get_sleep_hrv(
+        self,
+        start_date: date,
+        end_date: date | None = None,
+    ) -> list[dict[str, Any]]:
+        """Retrieve nocturnal HRV summaries via sleep/getsummary.
+
+        Args:
+            start_date: First night to cover (inclusive).
+            end_date: Last night to cover (inclusive, default: today).
+
+        Returns:
+            One dict per night with keys ``date``, ``rmssd_start_avg`` (float|None, ms),
+            ``rmssd_end_avg`` (float|None, ms), ``model`` (int|None), ``model_id``
+            (int|None). Nights without HRV data (unsupported device) are still
+            returned with rmssd_*_avg = None so the caller can see the gap.
+        """
+        if end_date is None:
+            end_date = date.today()
+
+        params = {
+            "action": "getsummary",
+            "startdateymd": start_date.strftime("%Y-%m-%d"),
+            "enddateymd": end_date.strftime("%Y-%m-%d"),
+            "data_fields": "rmssd_start_avg,rmssd_end_avg",
+        }
+
+        body = self._make_request("v2/sleep", params)
+
+        result = []
+        for session in body.get("series", []):
+            data = session.get("data") or {}
+            result.append(
+                {
+                    "date": session.get("date"),
+                    "rmssd_start_avg": data.get("rmssd_start_avg"),
+                    "rmssd_end_avg": data.get("rmssd_end_avg"),
+                    "model": session.get("model"),
+                    "model_id": session.get("model_id"),
+                }
+            )
+
+        logger.info("Retrieved %d HRV sleep summaries", len(result))
+        return result

--- a/magma_cycling/api/withings_client.py
+++ b/magma_cycling/api/withings_client.py
@@ -22,6 +22,7 @@ import logging
 from pathlib import Path
 
 from magma_cycling.api.withings.credentials import CredentialsMixin
+from magma_cycling.api.withings.hrv import HrvMixin
 from magma_cycling.api.withings.http import HttpMixin
 from magma_cycling.api.withings.measurements import MeasurementsMixin
 from magma_cycling.api.withings.oauth import OAuthMixin
@@ -36,6 +37,7 @@ class WithingsClient(
     HttpMixin,
     SleepMixin,
     MeasurementsMixin,
+    HrvMixin,
 ):
     """Client for Withings API with OAuth 2.0 authentication.
 

--- a/magma_cycling/health/base.py
+++ b/magma_cycling/health/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from datetime import date
 from typing import Any
 
+from magma_cycling.models.hrv_models import HrvReading
 from magma_cycling.models.withings_models import (
     BloodPressureMeasurement,
     SleepData,
@@ -52,6 +53,14 @@ class HealthProvider(ABC):
     @abstractmethod
     def auth_status(self) -> dict[str, Any]:
         """Authentication / configuration status."""
+
+    def get_hrv_nocturnal(self, target_date: date) -> HrvReading | None:
+        """HRV reading captured at the end of the night ending on target_date.
+
+        Default: return None (provider does not expose HRV). Subclasses override
+        when they have access to such data (e.g. Withings Sleep Analyzer).
+        """
+        return None
 
     def get_provider_info(self) -> dict[str, str]:
         """Provider metadata (concrete — not abstract)."""

--- a/magma_cycling/health/withings_provider.py
+++ b/magma_cycling/health/withings_provider.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from magma_cycling.api.withings_client import WithingsClient
 from magma_cycling.health.base import HealthProvider
+from magma_cycling.models.hrv_models import HrvReading
 from magma_cycling.models.withings_models import (
     BloodPressureMeasurement,
     SleepData,
@@ -93,6 +94,30 @@ class WithingsProvider(HealthProvider):
         if weight:
             readiness_dict["weight_kg"] = weight.weight_kg
         return TrainingReadiness(**readiness_dict)
+
+    # -- hrv -----------------------------------------------------------------
+
+    def get_hrv_nocturnal(self, target_date: date) -> HrvReading | None:
+        """Nocturnal RMSSD for the night ending on target_date.
+
+        Uses the "end-of-night" average exposed by Sleep Analyzer devices,
+        which is the most representative of the wake-up state and therefore
+        the most useful signal for pre-session readiness.
+        """
+        summaries = self._client.get_sleep_hrv(target_date, target_date)
+        if not summaries:
+            return None
+        entry = summaries[0]
+        value = entry.get("rmssd_end_avg")
+        if value is None or value <= 0:
+            return None
+        return HrvReading(
+            measurement_date=target_date,
+            metric_type="rmssd",
+            value_ms=float(value),
+            context="nocturnal_end",
+            source_provider="withings",
+        )
 
     # -- auth ----------------------------------------------------------------
 

--- a/magma_cycling/models/hrv_models.py
+++ b/magma_cycling/models/hrv_models.py
@@ -1,0 +1,42 @@
+"""HRV (Heart Rate Variability) models, provider-agnostic.
+
+These models describe HRV readings consumed by the training pipeline,
+independent of the source provider (Withings, Apple HealthKit, Garmin,
+Polar, etc.). Providers translate their native payloads into HrvReading
+instances. The pipeline never imports provider-specific code.
+"""
+
+from __future__ import annotations
+
+from datetime import date as DateType
+from datetime import datetime as DateTimeType
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+MetricType = Literal["rmssd", "sdnn", "lnrmssd"]
+Context = Literal["nocturnal_start", "nocturnal_end", "nocturnal_avg", "daytime_median"]
+DataQuality = Literal["ok", "partial", "missing"]
+
+
+class HrvReading(BaseModel):
+    """One HRV measurement, provider-agnostic."""
+
+    measurement_date: DateType = Field(description="Reference date of the measurement.")
+    measurement_time: DateTimeType | None = Field(
+        default=None,
+        description="Timestamp of the measurement if known. Nocturnal readings use the "
+        "morning of the ending night; daytime readings use the sample timestamp.",
+    )
+    metric_type: MetricType = Field(description="Which HRV metric this value represents.")
+    value_ms: float = Field(description="HRV value in milliseconds.", gt=0)
+    context: Context = Field(description="When/how the measurement was taken.")
+    source_provider: str = Field(
+        description="Provider name (withings, healthkit, …) — traceability only. "
+        "Never consumed by domain logic.",
+    )
+    data_quality: DataQuality = Field(
+        default="ok",
+        description="ok = full confidence, partial = degraded but usable, "
+        "missing = no data (typically wrapped as None upstream).",
+    )

--- a/tests/health/test_hrv_nocturnal.py
+++ b/tests/health/test_hrv_nocturnal.py
@@ -1,0 +1,173 @@
+"""Tests for HRV nocturnal provider capability."""
+
+from datetime import date
+from unittest.mock import Mock
+
+import pytest
+
+from magma_cycling.health.base import HealthProvider
+from magma_cycling.health.intervals_provider import IntervalsHealthProvider
+from magma_cycling.health.null_provider import NullProvider
+from magma_cycling.health.withings_provider import WithingsProvider
+from magma_cycling.models.hrv_models import HrvReading
+
+
+class TestHrvReadingModel:
+    def test_minimal_valid_reading(self):
+        r = HrvReading(
+            measurement_date=date(2026, 4, 19),
+            metric_type="rmssd",
+            value_ms=42.5,
+            context="nocturnal_end",
+            source_provider="withings",
+        )
+        assert r.value_ms == 42.5
+        assert r.data_quality == "ok"  # default
+
+    def test_zero_value_rejected(self):
+        with pytest.raises(ValueError):
+            HrvReading(
+                measurement_date=date(2026, 4, 19),
+                metric_type="rmssd",
+                value_ms=0,
+                context="nocturnal_end",
+                source_provider="withings",
+            )
+
+    def test_negative_value_rejected(self):
+        with pytest.raises(ValueError):
+            HrvReading(
+                measurement_date=date(2026, 4, 19),
+                metric_type="rmssd",
+                value_ms=-1,
+                context="nocturnal_end",
+                source_provider="withings",
+            )
+
+
+class TestHealthProviderDefault:
+    def test_null_provider_returns_none(self):
+        assert NullProvider().get_hrv_nocturnal(date(2026, 4, 19)) is None
+
+    def test_intervals_provider_returns_none(self):
+        """Intervals.icu has no HRV endpoint in the current impl — returns None by default."""
+        p = IntervalsHealthProvider(Mock())
+        assert p.get_hrv_nocturnal(date(2026, 4, 19)) is None
+
+    def test_base_returns_none_by_default(self):
+        """HealthProvider.get_hrv_nocturnal has a concrete default returning None."""
+
+        class _Stub(HealthProvider):
+            # Abstract methods stubs — not under test
+            def get_sleep_summary(self, target_date):
+                return None
+
+            def get_sleep_range(self, start_date, end_date):
+                return []
+
+            def get_body_composition(self):
+                return None
+
+            def get_body_composition_range(self, start_date, end_date):
+                return []
+
+            def get_blood_pressure_range(self, start_date, end_date):
+                return []
+
+            def get_readiness(self, target_date=None):
+                return None
+
+            def auth_status(self):
+                return {}
+
+        assert _Stub().get_hrv_nocturnal(date(2026, 4, 19)) is None
+
+
+class TestWithingsHrvNocturnal:
+    def test_returns_reading_when_rmssd_end_avg_present(self):
+        client = Mock()
+        client.get_sleep_hrv.return_value = [
+            {
+                "date": "2026-04-19",
+                "rmssd_start_avg": 45,
+                "rmssd_end_avg": 42,
+                "model": 32,
+                "model_id": 63,
+            }
+        ]
+        p = WithingsProvider(client)
+        reading = p.get_hrv_nocturnal(date(2026, 4, 19))
+        assert reading is not None
+        assert reading.metric_type == "rmssd"
+        assert reading.value_ms == 42.0
+        assert reading.context == "nocturnal_end"
+        assert reading.source_provider == "withings"
+        assert reading.measurement_date == date(2026, 4, 19)
+        client.get_sleep_hrv.assert_called_once_with(date(2026, 4, 19), date(2026, 4, 19))
+
+    def test_returns_none_when_no_summary(self):
+        client = Mock()
+        client.get_sleep_hrv.return_value = []
+        p = WithingsProvider(client)
+        assert p.get_hrv_nocturnal(date(2026, 4, 19)) is None
+
+    def test_returns_none_when_rmssd_end_avg_missing(self):
+        client = Mock()
+        client.get_sleep_hrv.return_value = [
+            {"date": "2026-04-19", "rmssd_start_avg": 45, "rmssd_end_avg": None}
+        ]
+        p = WithingsProvider(client)
+        assert p.get_hrv_nocturnal(date(2026, 4, 19)) is None
+
+    def test_returns_none_when_rmssd_end_avg_zero_or_negative(self):
+        client = Mock()
+        client.get_sleep_hrv.return_value = [{"date": "2026-04-19", "rmssd_end_avg": 0}]
+        p = WithingsProvider(client)
+        assert p.get_hrv_nocturnal(date(2026, 4, 19)) is None
+
+        client.get_sleep_hrv.return_value = [{"date": "2026-04-19", "rmssd_end_avg": -1}]
+        assert p.get_hrv_nocturnal(date(2026, 4, 19)) is None
+
+
+class TestHrvMixinParsing:
+    """HrvMixin unpacks Withings sleep/getsummary series to a normalized dict."""
+
+    def test_unpacks_series(self):
+        from magma_cycling.api.withings.hrv import HrvMixin
+
+        class _FakeClient(HrvMixin):
+            def __init__(self, body):
+                self._body = body
+
+            def _make_request(self, endpoint, params):
+                return self._body
+
+        body = {
+            "series": [
+                {
+                    "date": "2026-04-18",
+                    "model": 32,
+                    "model_id": 63,
+                    "data": {"rmssd_start_avg": 45, "rmssd_end_avg": 42},
+                },
+                {
+                    "date": "2026-04-19",
+                    "model": 32,
+                    "model_id": 63,
+                    "data": {"rmssd_start_avg": 42, "rmssd_end_avg": 42},
+                },
+            ]
+        }
+        rows = _FakeClient(body).get_sleep_hrv(date(2026, 4, 18), date(2026, 4, 19))
+        assert len(rows) == 2
+        assert rows[0]["rmssd_end_avg"] == 42
+        assert rows[1]["model"] == 32
+
+    def test_empty_series(self):
+        from magma_cycling.api.withings.hrv import HrvMixin
+
+        class _FakeClient(HrvMixin):
+            def _make_request(self, endpoint, params):
+                return {"series": []}
+
+        assert _FakeClient().get_sleep_hrv(date(2026, 4, 19)) == []


### PR DESCRIPTION
## Résumé

Ajoute un support HRV nocturne **provider-agnostique** dans `HealthProvider` avec Withings comme premier adaptateur. La pipeline d'entraînement ne fait aucun import Withings-specifique — elle consomme des `HrvReading` typés.

Première livraison (PR minimale) pour la feature TLS [#264](https://github.com/stephanejouve/magma-cycling/issues/264). Les PRs suivantes ajouteront : HRV jour (Apple Watch/HealthKit), `HrvService` avec baseline/trend, intégration pre-session-check et get-readiness, stockage longitudinal.

## Décision d'architecture

J'ai **étendu `HealthProvider`** (dans `magma_cycling/health/base.py`) plutôt que d'introduire un nouveau ABC `HrvProvider` dédié. Raisons :

1. Le pattern agnostique existe déjà : ABC avec méthodes typées, factory avec priority chain (Withings → Intervals → Null), Pydantic models partagés.
2. Ajouter un second ABC dupliquerait la factory sans valeur ajoutée.
3. Les providers qui n'exposent pas de HRV (NullProvider, IntervalsHealthProvider) **n'ont pas besoin d'être modifiés** — ils héritent d'un default `return None`.

Cette décision peut être revisitée plus tard si un provider HRV-only émerge (ex: HRV4Training sans sommeil structurel). Pour le moment ça réduit la surface à reviewer.

## Fichiers

| Fichier | Statut | Rôle |
|---|---|---|
| `magma_cycling/models/hrv_models.py` | new | `HrvReading` Pydantic model agnostique (`metric_type`, `value_ms`, `context`, `source_provider`, `data_quality`) |
| `magma_cycling/api/withings/hrv.py` | new | `HrvMixin` avec `get_sleep_hrv()` → appelle `v2/sleep/getsummary` avec `data_fields=rmssd_start_avg,rmssd_end_avg` |
| `magma_cycling/api/withings_client.py` | modifié | ajout `HrvMixin` au MRO de `WithingsClient` |
| `magma_cycling/health/base.py` | modifié | nouvelle méthode non-abstract `HealthProvider.get_hrv_nocturnal(date) -> HrvReading \| None`, default `None` |
| `magma_cycling/health/withings_provider.py` | modifié | override `get_hrv_nocturnal()` qui extrait `rmssd_end_avg` et renvoie un `HrvReading` |
| `tests/health/test_hrv_nocturnal.py` | new | 12 tests unitaires |

## Tests

- **12/12 HRV passent** (model, default, Withings impl, mixin parsing)
- **57/57 tests `tests/health/`** verts (aucune régression `WithingsProvider`, `IntervalsHealthProvider`, `NullProvider`, factory)
- Suite de tests complète à laisser tourner en CI

## Champ utilisé et justification

Investigation API Withings documentée dans l'[issue #264 comment thread](https://github.com/stephanejouve/magma-cycling/issues/264#issuecomment-4275625953). Résumé :
- `v2/sleep/getsummary` expose `rmssd_start_avg` et `rmssd_end_avg` pour les Sleep Analyzer EU / Sleep Rx US
- `rmssd_end_avg` (fin de nuit) = proxy du réveil, le plus pertinent pour la décision go/no-go de la séance matinale
- Test API côté preprod confirme les valeurs plausibles (42-45 ms RMSSD pour cycliste entraîné)

Les formes `sdnn_1` / `rmssd` intraday sont disponibles via `v2/sleep/get` action (endpoint distinct) — **out of scope** de cette PR.

## Out of scope

- Daytime HRV (SDNN Apple Watch via HealthKit) : PR suivante
- Service `HrvService` (baseline 7d/30d, trend, lnRMSSD) : PR suivante
- Intégration pipeline (pre-session-check, get-readiness) : PRs suivantes
- Stockage longitudinal : PR suivante

## Test plan

- [ ] CI verte (pre-commit + tests unitaires sur Python 3.12 + 3.13)
- [ ] Smoke test manuel : appel `create_health_provider().get_hrv_nocturnal(date.today())` depuis un shell magma-cycling branché sur un compte Withings avec Sleep Analyzer → doit retourner un `HrvReading` RMSSD cohérent
- [ ] Smoke test régression : `get_sleep_summary()`, `get_body_composition()`, `get_readiness()` inchangés