### PR TITLE
chore(gitignore): block Withings credentials from any path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,9 @@ project-docs/prompts/S*_*_DevLead_*.md
 project-docs/prompts/doc_claude_desktop_*.md
 project-docs/prompts/magma_config_wizard.*
 project-docs/prompts/beta-support-secretary.md
+
+# Withings OAuth credentials — never commit tokens to any path in this repo
+.withings_credentials.json
+withings-local.json
+**/withings_credentials.json
+**/withings-local.json


### PR DESCRIPTION
## Summary

Ajout préventif de 4 lignes au `.gitignore` pour empêcher qu'un fichier de credentials OAuth Withings (`.withings_credentials.json` ou `withings-local.json`) ne soit accidentellement tracké dans ce repo, où qu'il soit déposé.

## Contexte

Incident détecté sur le repo voisin `stephanejouve/training-logs` : `.withings_credentials.json` y était tracké historiquement (commit `0270b2f`), embarquant les tokens OAuth à chaque push. Fix appliqué côté training-logs (`git rm --cached` + ajout gitignore).

Pour magma-cycling, aucun fichier similaire n'est actuellement tracked ni présent sur disque — vérifié avant ce commit. Ce `.gitignore` agit donc en **defense in depth** : si quelqu'un déposait par erreur un fichier credentials dans le repo (copy/paste manuel, script mal rangé, packaging maladroit), git l'ignorera dès la création.

## Règles ajoutées

```gitignore
# Withings OAuth credentials — never commit tokens to any path in this repo
.withings_credentials.json
withings-local.json
**/withings_credentials.json
**/withings-local.json
```

Les 2 premières lignes couvrent la racine, les 2 avec `**/` couvrent n'importe quel sous-dossier. L'exclusion legacy `withings_integration/withings_credentials.json` est conservée (spécifique à l'ancienne structure module `withings_integration/`).

## Test plan

- [ ] `git check-ignore -v .withings_credentials.json` → match gitignore
- [ ] `git check-ignore -v foo/bar/withings_credentials.json` → match `**/withings_credentials.json`
- [ ] Aucun impact fonctionnel sur le code, uniquement une règle d'exclusion d'ajout