### PR TITLE
fix(session-monitor): use entry_points directly instead of poetry run

### DIFF
--- a/magma_cycling/session_monitor.py
+++ b/magma_cycling/session_monitor.py
@@ -14,7 +14,6 @@ Created: 2026-03-01
 """
 
 import os
-import shutil
 import subprocess
 from datetime import date, datetime
 from pathlib import Path
@@ -25,7 +24,6 @@ from magma_cycling.planning.control_tower import planning_tower
 from magma_cycling.utils.cli import cli_main
 
 PREFIX = "[session-monitor]"
-POETRY = os.environ.get("POETRY_BIN", shutil.which("poetry") or "poetry")
 PROJECT_DIR = os.environ.get(
     "MAGMA_PROJECT_DIR",
     str(Path(__file__).resolve().parent.parent),
@@ -166,13 +164,13 @@ def main() -> int:
     log(f"Activity {activity_id} detected ({len(cycling)} activities, {completed_count} completed)")
 
     # Step 6: Pre-sync Withings → Intervals.icu
-    run_command("withings-presync", [POETRY, "run", "withings-presync"])
+    run_command("withings-presync", ["withings-presync"])
 
     # Step 7a: Trigger daily-sync
     try:
         run_command(
             "daily-sync",
-            [POETRY, "run", "daily-sync", "--send-email", "--ai-analysis", "--auto-servo"],
+            ["daily-sync", "--send-email", "--ai-analysis", "--auto-servo"],
         )
     except Exception as e:
         log(f"daily-sync error: {e}")
@@ -181,13 +179,7 @@ def main() -> int:
     try:
         run_command(
             "adherence",
-            [
-                POETRY,
-                "run",
-                "python",
-                "scripts/monitoring/check_workout_adherence.py",
-                "--weekly-alert",
-            ],
+            ["check-workout-adherence", "--weekly-alert"],
         )
     except Exception as e:
         log(f"adherence error: {e}")
@@ -196,7 +188,7 @@ def main() -> int:
     try:
         run_command(
             "pid-evaluation",
-            [POETRY, "run", "pid-daily-evaluation", "--days-back", "7"],
+            ["pid-daily-evaluation", "--days-back", "7"],
         )
     except Exception as e:
         log(f"pid-evaluation error: {e}")
@@ -208,8 +200,6 @@ def main() -> int:
             run_command(
                 "end-of-week",
                 [
-                    POETRY,
-                    "run",
                     "end-of-week",
                     "--auto-calculate",
                     "--provider",


### PR DESCRIPTION
## Résumé

`magma_cycling/session_monitor.py` spawnait ses 5 sous-commandes cron via `[poetry, "run", X]`. Le container prod `magma-cycling-cron-jobs-1` (image `:stable`) n'a pas Poetry installé (stage runtime slim, `pip install -e .` uniquement) → **toutes les jobs échouent** avec `[Errno 2] No such file or directory: 'poetry'` depuis au moins 2026-04-18 19h UTC.

Ce patch remplace les 5 call sites par des entry_points directs (`withings-presync`, `daily-sync`, `check-workout-adherence`, `pid-daily-evaluation`, `end-of-week` — tous déjà déclarés dans `pyproject.toml`). Retire aussi l'import `shutil` et la variable `POETRY` devenus inutiles.

## Contexte

Découvert par admin en auditant `docker logs magma-cycling-cron-jobs-1` suite à investigation autour d'un autre sujet (isolation credentials Withings). Le container est actuellement stoppé (arrêt gracieux ~12:12 CEST le 19/04). Personne ne s'en est rendu compte car l'utilisateur principal (Stéphane) pointe Claude Desktop sur la preprod (port 3001), pas prod.

## Changements

**1 seul fichier modifié** : `magma_cycling/session_monitor.py` — 14 lignes supprimées, 4 ajoutées.

| Avant | Après |
|---|---|
| `[POETRY, "run", "withings-presync"]` | `["withings-presync"]` |
| `[POETRY, "run", "daily-sync", ...]` | `["daily-sync", ...]` |
| `[POETRY, "run", "python", "scripts/monitoring/check_workout_adherence.py", ...]` | `["check-workout-adherence", ...]` |
| `[POETRY, "run", "pid-daily-evaluation", ...]` | `["pid-daily-evaluation", ...]` |
| `[POETRY, "run", "end-of-week", ...]` | `["end-of-week", ...]` |

Le call adherence utilisait historiquement une invocation via chemin de fichier (`python scripts/monitoring/check_workout_adherence.py`). L'entry_point `check-workout-adherence` pointe déjà sur le même `:main` dans `pyproject.toml`, donc remplacement sémantiquement équivalent.

## Pattern existant aligné

`magma_cycling/scripts/backfill/processing.py` lignes 82-94 utilise déjà `python -m magma_cycling.workflow_coach` au lieu de `poetry run`. Le crontab lui-même invoque directement les entry_points (`daily-sync`, `session-monitor`, ...). Ce PR aligne session_monitor avec ces conventions.

## Tests

- [x] Suite pytest locale : **3385 passed, 0 failed**
- [x] Smoke import : `python -c "from magma_cycling.session_monitor import main"` → OK
- [ ] CI GitHub Actions
- [ ] Post-merge : redeploy container prod côté admin → vérifier `docker logs` clean sur les prochains ticks cron

## Out of scope

- Installation de Poetry dans l'image runtime : anti-pattern (bloat). On aligne session_monitor avec la convention existante.
- Autres scripts appelant `poetry run` : `grep` confirme aucun autre dans le repo (hormis des commentaires/docstrings).
- Monitoring gap (container stoppé 5h sans alerte) : à traiter séparément côté admin.

## Test plan (reviewer)

- [ ] Vérifier que les 5 entry_points cibles existent dans `pyproject.toml` `[tool.poetry.scripts]`
- [ ] Vérifier qu'aucun import ne cassait à cause du retrait de `shutil`
- [ ] CI verte