### PR TITLE
feat(mcp): context-handoff tools — save/resume conversational state

### DIFF
--- a/magma_cycling/_mcp/handlers/handoff.py
+++ b/magma_cycling/_mcp/handlers/handoff.py
@@ -1,0 +1,109 @@
+"""Context handoff handlers — save/resume conversational context between MCP sessions."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from magma_cycling._mcp._utils import mcp_response
+from magma_cycling.models.handoff import HandoffSnapshot
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
+
+__all__ = ["handle_context_handoff_save", "handle_context_handoff_resume"]
+
+logger = logging.getLogger(__name__)
+
+
+def _handoff_dir() -> Path:
+    """Return the handoff directory, creating it if needed."""
+    from magma_cycling.config import get_data_config
+
+    directory = get_data_config().handoff_dir
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _write_snapshot(snapshot: HandoffSnapshot, handoff_dir: Path) -> Path:
+    """Serialize snapshot to handoff_dir/YYYY-MM-DD-HHMM.json and return the path.
+
+    On same-minute collision, falls back to second-precision filename.
+    """
+    filename = snapshot.created_at.strftime("%Y-%m-%d-%H%M") + ".json"
+    path = handoff_dir / filename
+    if path.exists():
+        path = handoff_dir / (snapshot.created_at.strftime("%Y-%m-%d-%H%M%S") + ".json")
+    path.write_text(snapshot.model_dump_json(indent=2) + "\n")
+    return path
+
+
+def _latest_unconsumed(handoff_dir: Path) -> tuple[Path, HandoffSnapshot] | None:
+    """Return (path, snapshot) of the most-recent non-consumed snapshot, or None."""
+    if not handoff_dir.exists():
+        return None
+    candidates: list[tuple[Path, HandoffSnapshot]] = []
+    for path in handoff_dir.glob("*.json"):
+        try:
+            snap = HandoffSnapshot.model_validate_json(path.read_text())
+        except Exception as exc:
+            logger.warning("Skipping invalid handoff file %s: %s", path, exc)
+            continue
+        if snap.consumed:
+            continue
+        candidates.append((path, snap))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[1].created_at, reverse=True)
+    return candidates[0]
+
+
+async def handle_context_handoff_save(args: dict) -> list[TextContent]:
+    """Save a snapshot of conversational context to the training data repo."""
+    snapshot = HandoffSnapshot(
+        created_at=datetime.now(),
+        decisions_pending=args.get("decisions_pending") or [],
+        open_questions=args.get("open_questions") or [],
+        user_mood=args.get("user_mood") or "",
+        next_actions=args.get("next_actions") or [],
+        referenced_files=args.get("referenced_files") or [],
+    )
+    handoff_dir = _handoff_dir()
+    path = _write_snapshot(snapshot, handoff_dir)
+    logger.info("Handoff snapshot written to %s", path)
+    return mcp_response(
+        {
+            "status": "saved",
+            "path": str(path),
+            "created_at": snapshot.created_at.isoformat(),
+            "summary": {
+                "decisions_pending": len(snapshot.decisions_pending),
+                "open_questions": len(snapshot.open_questions),
+                "next_actions": len(snapshot.next_actions),
+                "referenced_files": len(snapshot.referenced_files),
+                "has_user_mood": bool(snapshot.user_mood),
+            },
+        }
+    )
+
+
+async def handle_context_handoff_resume(args: dict) -> list[TextContent]:
+    """Load latest non-consumed handoff and return it; mark consumed unless peek."""
+    peek = bool(args.get("peek", False))
+    handoff_dir = _handoff_dir()
+    found = _latest_unconsumed(handoff_dir)
+    if found is None:
+        return mcp_response({"status": "empty", "snapshot": None})
+    path, snapshot = found
+    if not peek:
+        snapshot.consumed = True
+        path.write_text(snapshot.model_dump_json(indent=2) + "\n")
+    return mcp_response(
+        {
+            "status": "resumed" if not peek else "peeked",
+            "path": str(path),
+            "snapshot": snapshot.model_dump(mode="json"),
+        }
+    )

--- a/magma_cycling/_mcp/schemas/handoff.py
+++ b/magma_cycling/_mcp/schemas/handoff.py
@@ -1,0 +1,72 @@
+"""Context handoff tool schemas — save/resume conversational state across MCP sessions."""
+
+from mcp.types import Tool
+
+
+def get_tools() -> list[Tool]:
+    """Return context handoff tool schemas."""
+    return [
+        Tool(
+            name="context-handoff-save",
+            description=(
+                "Save a snapshot of non-persisted conversational context "
+                "(pending decisions, open questions, user mood, next actions, "
+                "referenced files) to the training data repo so the NEXT session "
+                "can resume from it. Use at the end of a long conversation before "
+                "closing the session. Written under {training_logs}/handoff/."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "decisions_pending": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Decisions still open at session end.",
+                        "default": [],
+                    },
+                    "open_questions": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Questions left unanswered in this session.",
+                        "default": [],
+                    },
+                    "user_mood": {
+                        "type": "string",
+                        "description": "Athlete's momentary state (one short paragraph).",
+                        "default": "",
+                    },
+                    "next_actions": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "TODOs to pick up in the next session.",
+                        "default": [],
+                    },
+                    "referenced_files": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Paths to artefacts (screenshots, FIT exports, etc.).",
+                        "default": [],
+                    },
+                },
+            },
+        ),
+        Tool(
+            name="context-handoff-resume",
+            description=(
+                "Load the latest non-consumed context-handoff snapshot from the "
+                "training data repo and return it. Marks the snapshot as consumed to "
+                "prevent double-injection. Use at the START of a new session to "
+                "recover conversational context that would otherwise be lost."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "peek": {
+                        "type": "boolean",
+                        "description": "If true, do not mark the snapshot as consumed.",
+                        "default": False,
+                    },
+                },
+            },
+        ),
+    ]

--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -91,12 +91,18 @@ class DataRepoConfig:
         """Path to .workflow_state.json in data repo."""
         return self.data_repo_path / ".workflow_state.json"
 
+    @property
+    def handoff_dir(self) -> Path:
+        """Path to handoff/ directory in data repo (context-handoff snapshots)."""
+        return self.data_repo_path / "handoff"
+
     def ensure_directories(self):
         """Create required directories if they don't exist."""
         self.bilans_dir.mkdir(parents=True, exist_ok=True)
         self.week_planning_dir.mkdir(parents=True, exist_ok=True)
         self.workout_templates_dir.mkdir(parents=True, exist_ok=True)
         self.terrain_circuits_dir.mkdir(parents=True, exist_ok=True)
+        self.handoff_dir.mkdir(parents=True, exist_ok=True)
 
     def validate(self) -> bool:
         """Validate data repository structure.

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -52,6 +52,10 @@ from magma_cycling._mcp.handlers.athlete import (  # noqa: F401
 from magma_cycling._mcp.handlers.catalog import (  # noqa: F401
     handle_list_workout_catalog,
 )
+from magma_cycling._mcp.handlers.handoff import (  # noqa: F401
+    handle_context_handoff_resume,
+    handle_context_handoff_save,
+)
 from magma_cycling._mcp.handlers.health import (  # noqa: F401
     handle_analyze_health_trends,
     handle_enrich_session_health,
@@ -119,6 +123,7 @@ from magma_cycling._mcp.schemas import admin as _s_admin
 from magma_cycling._mcp.schemas import analysis as _s_analysis
 from magma_cycling._mcp.schemas import athlete as _s_athlete
 from magma_cycling._mcp.schemas import catalog as _s_catalog
+from magma_cycling._mcp.schemas import handoff as _s_handoff
 from magma_cycling._mcp.schemas import health as _s_health
 from magma_cycling._mcp.schemas import planning as _s_planning
 from magma_cycling._mcp.schemas import remote as _s_remote
@@ -159,6 +164,7 @@ async def list_tools() -> list[Tool]:
         *_s_health.get_tools(),
         *_s_rest.get_tools(),
         *_s_terrain.get_tools(),
+        *_s_handoff.get_tools(),
     ]
 
 
@@ -234,6 +240,9 @@ TOOL_HANDLERS = {
     "list-terrain-circuits": handle_list_terrain_circuits,
     "adapt-workout-to-terrain": handle_adapt_workout_to_terrain,
     "evaluate-outdoor-execution": handle_evaluate_outdoor_execution,
+    # Context handoff (2)
+    "context-handoff-save": handle_context_handoff_save,
+    "context-handoff-resume": handle_context_handoff_resume,
 }
 
 

--- a/magma_cycling/models/handoff.py
+++ b/magma_cycling/models/handoff.py
@@ -1,0 +1,43 @@
+"""Context handoff snapshot model.
+
+A HandoffSnapshot captures the conversational soft-state that is lost when an MCP
+session ends: pending decisions, open questions, user mood, next actions. The MCP
+server writes one file per snapshot under {training_logs}/handoff/ and the next
+session reads the latest non-consumed one to recover context.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class HandoffSnapshot(BaseModel):
+    """One saved conversation handoff between MCP sessions."""
+
+    created_at: datetime = Field(description="When the snapshot was written.")
+    decisions_pending: list[str] = Field(
+        default_factory=list,
+        description="Open decisions not yet committed to planning or calendar.",
+    )
+    open_questions: list[str] = Field(
+        default_factory=list,
+        description="Questions left unanswered in the prior session.",
+    )
+    user_mood: str = Field(
+        default="",
+        description="Athlete's momentary state (fatigue, motivation, constraints).",
+    )
+    next_actions: list[str] = Field(
+        default_factory=list,
+        description="Follow-up TODOs for the next conversation.",
+    )
+    referenced_files: list[str] = Field(
+        default_factory=list,
+        description="Paths to artefacts evoked in the conversation (screenshots, FIT, etc.).",
+    )
+    consumed: bool = Field(
+        default=False,
+        description="True once read by context-handoff-resume; prevents double-injection.",
+    )

--- a/tests/_mcp/handlers/test_handoff.py
+++ b/tests/_mcp/handlers/test_handoff.py
@@ -1,0 +1,223 @@
+"""Tests for _mcp/handlers/handoff.py — context-handoff-save and resume."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.handoff import (
+    _latest_unconsumed,
+    _write_snapshot,
+    handle_context_handoff_resume,
+    handle_context_handoff_save,
+)
+from magma_cycling.models.handoff import HandoffSnapshot
+
+
+@pytest.fixture
+def handoff_dir(tmp_path: Path) -> Path:
+    """Empty handoff dir under tmp."""
+    d = tmp_path / "handoff"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def mock_config(handoff_dir: Path):
+    """Patch get_data_config() so handoff_dir points to tmp."""
+    cfg = MagicMock()
+    cfg.handoff_dir = handoff_dir
+    with patch("magma_cycling.config.get_data_config", return_value=cfg):
+        yield cfg
+
+
+def _tc_payload(result):
+    """Unwrap the single TextContent result into a dict."""
+    assert len(result) == 1
+    return json.loads(result[0].text)
+
+
+class TestWriteSnapshot:
+    def test_writes_json_file_with_timestamp_name(self, handoff_dir: Path):
+        snap = HandoffSnapshot(created_at=datetime(2026, 4, 19, 23, 30))
+        path = _write_snapshot(snap, handoff_dir)
+        assert path.name == "2026-04-19-2330.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["created_at"] == "2026-04-19T23:30:00"
+
+    def test_same_minute_collision_falls_back_to_second_precision(self, handoff_dir: Path):
+        ts = datetime(2026, 4, 19, 23, 30, 15)
+        snap1 = HandoffSnapshot(created_at=ts)
+        snap2 = HandoffSnapshot(created_at=ts)
+        p1 = _write_snapshot(snap1, handoff_dir)
+        p2 = _write_snapshot(snap2, handoff_dir)
+        assert p1 != p2
+        assert p1.name == "2026-04-19-2330.json"
+        assert p2.name == "2026-04-19-233015.json"
+
+
+class TestLatestUnconsumed:
+    def test_empty_dir_returns_none(self, handoff_dir: Path):
+        assert _latest_unconsumed(handoff_dir) is None
+
+    def test_missing_dir_returns_none(self, tmp_path: Path):
+        assert _latest_unconsumed(tmp_path / "does_not_exist") is None
+
+    def test_picks_latest_by_created_at(self, handoff_dir: Path):
+        older = HandoffSnapshot(created_at=datetime(2026, 4, 19, 8, 0))
+        newer = HandoffSnapshot(created_at=datetime(2026, 4, 19, 20, 0))
+        _write_snapshot(older, handoff_dir)
+        _write_snapshot(newer, handoff_dir)
+        found = _latest_unconsumed(handoff_dir)
+        assert found is not None
+        _, snap = found
+        assert snap.created_at == newer.created_at
+
+    def test_skips_consumed_snapshots(self, handoff_dir: Path):
+        consumed = HandoffSnapshot(created_at=datetime(2026, 4, 19, 20, 0), consumed=True)
+        fresh = HandoffSnapshot(created_at=datetime(2026, 4, 19, 8, 0))
+        _write_snapshot(consumed, handoff_dir)
+        _write_snapshot(fresh, handoff_dir)
+        found = _latest_unconsumed(handoff_dir)
+        assert found is not None
+        _, snap = found
+        assert snap.created_at == fresh.created_at
+
+    def test_skips_invalid_json_file(self, handoff_dir: Path):
+        (handoff_dir / "garbage.json").write_text("{ not valid")
+        good = HandoffSnapshot(created_at=datetime(2026, 4, 19, 20, 0))
+        _write_snapshot(good, handoff_dir)
+        found = _latest_unconsumed(handoff_dir)
+        assert found is not None
+
+
+@pytest.mark.asyncio
+class TestHandleSave:
+    async def test_save_minimal(self, mock_config, handoff_dir: Path):
+        result = await handle_context_handoff_save({})
+        payload = _tc_payload(result)
+        assert payload["status"] == "saved"
+        assert Path(payload["path"]).exists()
+        assert payload["summary"]["decisions_pending"] == 0
+        assert payload["summary"]["has_user_mood"] is False
+
+    async def test_save_full(self, mock_config, handoff_dir: Path):
+        result = await handle_context_handoff_save(
+            {
+                "decisions_pending": ["a", "b"],
+                "open_questions": ["q1"],
+                "user_mood": "fatigué",
+                "next_actions": ["do X"],
+                "referenced_files": ["/tmp/file.png"],
+            }
+        )
+        payload = _tc_payload(result)
+        assert payload["summary"] == {
+            "decisions_pending": 2,
+            "open_questions": 1,
+            "next_actions": 1,
+            "referenced_files": 1,
+            "has_user_mood": True,
+        }
+        data = json.loads(Path(payload["path"]).read_text())
+        assert data["decisions_pending"] == ["a", "b"]
+        assert data["user_mood"] == "fatigué"
+        assert data["consumed"] is False
+
+    async def test_save_handles_none_fields(self, mock_config, handoff_dir: Path):
+        result = await handle_context_handoff_save({"decisions_pending": None, "user_mood": None})
+        payload = _tc_payload(result)
+        assert payload["status"] == "saved"
+
+
+@pytest.mark.asyncio
+class TestHandleResume:
+    async def test_resume_empty(self, mock_config, handoff_dir: Path):
+        result = await handle_context_handoff_resume({})
+        payload = _tc_payload(result)
+        assert payload["status"] == "empty"
+        assert payload["snapshot"] is None
+
+    async def test_resume_marks_consumed(self, mock_config, handoff_dir: Path):
+        snap = HandoffSnapshot(
+            created_at=datetime(2026, 4, 19, 20, 0),
+            decisions_pending=["choice A"],
+        )
+        path = _write_snapshot(snap, handoff_dir)
+        result = await handle_context_handoff_resume({})
+        payload = _tc_payload(result)
+        assert payload["status"] == "resumed"
+        assert payload["snapshot"]["decisions_pending"] == ["choice A"]
+        assert payload["snapshot"]["consumed"] is True
+        # Disk reflects consumed=True
+        on_disk = json.loads(path.read_text())
+        assert on_disk["consumed"] is True
+
+    async def test_resume_peek_does_not_consume(self, mock_config, handoff_dir: Path):
+        snap = HandoffSnapshot(created_at=datetime(2026, 4, 19, 20, 0))
+        path = _write_snapshot(snap, handoff_dir)
+        result = await handle_context_handoff_resume({"peek": True})
+        payload = _tc_payload(result)
+        assert payload["status"] == "peeked"
+        on_disk = json.loads(path.read_text())
+        assert on_disk["consumed"] is False
+
+    async def test_resume_then_resume_returns_empty(self, mock_config, handoff_dir: Path):
+        snap = HandoffSnapshot(created_at=datetime(2026, 4, 19, 20, 0))
+        _write_snapshot(snap, handoff_dir)
+        first = _tc_payload(await handle_context_handoff_resume({}))
+        second = _tc_payload(await handle_context_handoff_resume({}))
+        assert first["status"] == "resumed"
+        assert second["status"] == "empty"
+
+    async def test_resume_picks_latest_of_multiple(self, mock_config, handoff_dir: Path):
+        older = HandoffSnapshot(created_at=datetime(2026, 4, 19, 8, 0), user_mood="matin")
+        newer = HandoffSnapshot(created_at=datetime(2026, 4, 19, 20, 0), user_mood="soir")
+        _write_snapshot(older, handoff_dir)
+        _write_snapshot(newer, handoff_dir)
+        result = await handle_context_handoff_resume({})
+        payload = _tc_payload(result)
+        assert payload["snapshot"]["user_mood"] == "soir"
+
+
+@pytest.mark.asyncio
+async def test_save_resume_roundtrip(mock_config, handoff_dir: Path):
+    """End-to-end: save a snapshot, resume returns exactly what was saved."""
+    save = await handle_context_handoff_save(
+        {
+            "decisions_pending": ["Sweet Spot ou Tempo mercredi ?"],
+            "user_mood": "bien reposé",
+            "next_actions": ["trancher mardi soir"],
+        }
+    )
+    saved = _tc_payload(save)
+    assert saved["status"] == "saved"
+
+    resumed = _tc_payload(await handle_context_handoff_resume({}))
+    snap = resumed["snapshot"]
+    assert snap["decisions_pending"] == ["Sweet Spot ou Tempo mercredi ?"]
+    assert snap["user_mood"] == "bien reposé"
+    assert snap["next_actions"] == ["trancher mardi soir"]
+
+
+@pytest.mark.asyncio
+async def test_multiple_saves_preserve_history(mock_config, handoff_dir: Path):
+    """Each save creates a new file; old files remain on disk."""
+    with patch("magma_cycling._mcp.handlers.handoff.datetime") as mock_dt:
+        # first save at 08:00
+        mock_dt.now.return_value = datetime(2026, 4, 19, 8, 0)
+        await handle_context_handoff_save({"user_mood": "A"})
+        # second save at 20:00
+        mock_dt.now.return_value = datetime(2026, 4, 19, 20, 0)
+        await handle_context_handoff_save({"user_mood": "B"})
+
+    files = list(handoff_dir.glob("*.json"))
+    assert len(files) == 2
+    # The latest-resume semantics already tested above — just confirm both persist.
+    moods = sorted(json.loads(f.read_text())["user_mood"] for f in files)
+    assert moods == ["A", "B"]

--- a/tests/test_handoff_model.py
+++ b/tests/test_handoff_model.py
@@ -1,0 +1,53 @@
+"""Tests for HandoffSnapshot model."""
+
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from magma_cycling.models.handoff import HandoffSnapshot
+
+
+class TestHandoffSnapshot:
+    def test_minimal_snapshot_only_created_at(self):
+        now = datetime(2026, 4, 19, 23, 30)
+        snap = HandoffSnapshot(created_at=now)
+        assert snap.created_at == now
+        assert snap.decisions_pending == []
+        assert snap.open_questions == []
+        assert snap.user_mood == ""
+        assert snap.next_actions == []
+        assert snap.referenced_files == []
+        assert snap.consumed is False
+
+    def test_full_snapshot(self):
+        snap = HandoffSnapshot(
+            created_at=datetime(2026, 4, 19, 23, 30),
+            decisions_pending=["alléger ou déplacer mercredi"],
+            open_questions=["TSB bruit ou signal ?"],
+            user_mood="Fatigué, cherche à récupérer",
+            next_actions=["Décider sortie mercredi", "Planifier test FTP"],
+            referenced_files=["/tmp/zwift_20260418.png"],
+        )
+        assert len(snap.decisions_pending) == 1
+        assert snap.user_mood.startswith("Fatigué")
+
+    def test_created_at_is_required(self):
+        with pytest.raises(ValidationError):
+            HandoffSnapshot()
+
+    def test_json_roundtrip(self):
+        original = HandoffSnapshot(
+            created_at=datetime(2026, 4, 19, 23, 30),
+            decisions_pending=["A", "B"],
+            next_actions=["X"],
+        )
+        json_str = original.model_dump_json()
+        restored = HandoffSnapshot.model_validate_json(json_str)
+        assert restored == original
+
+    def test_consumed_flag_flips(self):
+        snap = HandoffSnapshot(created_at=datetime(2026, 4, 19, 23, 30))
+        assert snap.consumed is False
+        snap.consumed = True
+        assert snap.consumed is True


### PR DESCRIPTION
## Problem

MCP persists plans, activities, metrics, profile, coach analyses — but **not** the conversational soft-state : pending decisions, open questions, user mood, next actions, referenced artefacts. Each new session restarts from zero on that strate.

Gap identified in Georges beta-test (plan Free, 1 question/session): opening a fresh session wastes a chunk of his daily quota just to rebuild context.

## Solution

Two new MCP tools :

- **`context-handoff-save`** — snapshot the 5 fields above. Written to `{training_logs}/handoff/YYYY-MM-DD-HHMM.json`.
- **`context-handoff-resume`** — load latest non-consumed snapshot, mark consumed (opt-out via `peek: true`).

**Resolution policy** : latest `created_at` wins. `consumed: true` snapshots are skipped (prevents double-injection). Invalid JSON files are skipped with a warning. Same-minute collisions fall back to second-precision filenames.

## Storage-agnostic

Works identically across the 3 deploys :
- Standalone macOS : `~/training-logs/handoff/`
- Standalone Windows : `%USERPROFILE%\training-logs\handoff\`
- Docker NAS : `/data/training-logs/handoff/` (bind mount)

No platform branching in the code — only `Path` operations resolved via existing `DataRepoConfig`.

## Tests

22 new tests (model + handlers), 3386 total passed locally, 0 regression.

- Pydantic model validation (5 tests)
- `_write_snapshot` filename scheme + collision handling (2 tests)
- `_latest_unconsumed` resolution, skip-consumed, skip-invalid-json (5 tests)
- `handle_context_handoff_save` — minimal, full, None-safe (3 tests)
- `handle_context_handoff_resume` — empty, consumed, peek, double-resume, multi-file (5 tests)
- End-to-end round-trip + multi-save history (2 tests)

## Files

- `magma_cycling/models/handoff.py` — `HandoffSnapshot` Pydantic model
- `magma_cycling/_mcp/schemas/handoff.py` — 2 Tool schemas
- `magma_cycling/_mcp/handlers/handoff.py` — async handlers + helpers
- `magma_cycling/config/data_repo.py` — new `handoff_dir` property + `ensure_directories`
- `magma_cycling/mcp_server.py` — wiring (schema import + TOOL_HANDLERS entries)
- `tests/test_handoff_model.py` + `tests/_mcp/handlers/test_handoff.py`

## Test plan

- [x] Unit tests pass locally (22/22)
- [x] Full suite pass (3386/3386)
- [x] Lint + black clean
- [x] `TOOL_HANDLERS` registers both tools (`len == 59`)
- [ ] CI green (automated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)