### PR TITLE
feat(mcp): append [meta] server_time to every tool response

### DIFF
--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -25,6 +25,7 @@ Claude Desktop config (~/.config/claude/claude_desktop_config.json):
 import json
 import os
 import time
+from datetime import datetime
 
 from mcp.server import Server
 from mcp.types import TextContent, Tool
@@ -246,6 +247,20 @@ TOOL_HANDLERS = {
 }
 
 
+def _server_time_meta() -> TextContent:
+    """Return a meta TextContent with the current server time.
+
+    Appended to every tool response so LLM clients automatically refresh
+    their temporal context on each tool call. Prevents stale "today" in
+    long-running conversations that cross midnight.
+    """
+    now = datetime.now().astimezone()
+    return TextContent(
+        type="text",
+        text=f"[meta] server_time={now.isoformat(timespec='seconds')}",
+    )
+
+
 async def dispatch_tool(name: str, arguments: dict) -> list[TextContent]:
     """Dispatch a tool call with logging and timing."""
     logger.info("tool_call_start: %s", name)
@@ -257,7 +272,7 @@ async def dispatch_tool(name: str, arguments: dict) -> list[TextContent]:
         result = await handler(arguments)
         elapsed = time.monotonic() - t0
         logger.info("tool_call_ok: %s (%.3fs)", name, elapsed)
-        return result
+        return [*result, _server_time_meta()]
     except Exception as e:
         elapsed = time.monotonic() - t0
         logger.error("tool_call_error: %s (%.3fs) — %s", name, elapsed, e)
@@ -272,7 +287,8 @@ async def dispatch_tool(name: str, arguments: dict) -> list[TextContent]:
                     },
                     indent=2,
                 ),
-            )
+            ),
+            _server_time_meta(),
         ]
 
 

--- a/tests/test_mcp_logging.py
+++ b/tests/test_mcp_logging.py
@@ -148,3 +148,33 @@ class TestDispatcherLogging:
         messages = caplog.text
         assert "tool_call_start: nonexistent-tool" in messages
         assert "tool_call_error: nonexistent-tool" in messages
+
+
+class TestServerTimeMeta:
+    """Tests for the server_time meta block appended to tool responses."""
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_appends_server_time_on_success(self):
+        """Successful tool calls end with a [meta] server_time= line."""
+        from mcp.types import TextContent
+
+        from magma_cycling.mcp_server import TOOL_HANDLERS, dispatch_tool
+
+        mock_handler = AsyncMock(return_value=[TextContent(type="text", text="ok")])
+        with patch.dict(TOOL_HANDLERS, {"test-tool": mock_handler}):
+            result = await dispatch_tool("test-tool", {})
+
+        assert len(result) == 2
+        assert result[0].text == "ok"
+        assert result[1].text.startswith("[meta] server_time=")
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_appends_server_time_on_error(self):
+        """Failed tool calls also end with a [meta] server_time= line."""
+        from magma_cycling.mcp_server import dispatch_tool
+
+        result = await dispatch_tool("nonexistent-tool", {})
+
+        assert len(result) == 2
+        assert "error" in result[0].text
+        assert result[1].text.startswith("[meta] server_time=")


### PR DESCRIPTION
## Contexte

Signalement Stéphane : dans les sessions Claude Desktop longues (magma-cycling MCP), le LLM ne se rend pas compte que l'horloge a tourné — il continue à raisonner avec "aujourd'hui = hier". Problème de **context freeze** : la date est dans le system prompt au démarrage de session, pas rafraîchie par la suite.

## Fix

Chaque tool response dispatchée via `dispatch_tool()` se termine désormais par un bloc texte :

```
[meta] server_time=2026-04-23T08:15:30+02:00
```

Le LLM passe devant à chaque tool call → recalage passif de la date sans effort de sa part. Dès qu'il consulte un rapport, un planning, une activité, il voit la date vraie.

## Design

- **1 point d'injection** (`dispatch_tool()` dans `magma_cycling/mcp_server.py`) au lieu de modifier 17 handlers. Pattern centralisé, rétrocompatible.
- **Format texte explicite** (`[meta] server_time=…`) plutôt que JSON : lisible même sans parsing, préfixe `[meta]` signale clairement que c'est du contexte système et non applicatif.
- **ISO8601 avec offset local** (`+02:00`) : info timezone incluse.
- **Couvre succès ET erreur** : même sur un tool call qui échoue, le LLM reçoit le meta.
- **Pas d'impact consumer** : le bloc s'ajoute en queue, les tools existants ne sont pas touchés.

## YAGNI rejected

L'option "tool dédié `recalibrate_context`" (pattern 3 de ma proposition) a été rejetée par Stéphane comme YAGNI. Pattern 2 seul suffit ; si besoin futur d'un tool explicite, trivial à ajouter.

## Tests

2 nouveaux cas dans `tests/test_mcp_logging.py` (`TestServerTimeMeta`) :
- Happy path : response tool se termine par `[meta] server_time=`
- Error path (tool inconnu) : même comportement

12/12 tests passent dans `test_mcp_logging.py`.

## Test plan

- [x] Tests unitaires verts
- [ ] Après merge : Stéphane observe sur une session Claude Desktop qui traverse minuit que le LLM se recale tout seul après un tool call magma-cycling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)