### PR TITLE
fix(docker): install magma-cycling-tools for data-repo-sync

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,14 @@ COPY scripts/ scripts/
 COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir -e .
 
+# Installer magma-cycling-tools (source of truth pour data_repo_sync et futurs
+# adapters/ops, spin-off d'outillages). Repo public → pas d'auth nécessaire au
+# build. Restaure l'entry point `data-repo-sync` invoqué par supercronic au
+# tick 22:30 (cron quotidien) et 20:30 (dimanche), KO depuis le commit
+# 8e01f8d (extraction des tools vers outillages sans mise à jour du Dockerfile).
+RUN pip install --no-cache-dir \
+    git+https://github.com/stephanejouve/magma-cycling-tools.git@main
+
 # Crontab + entrypoint
 COPY docker/crontab /app/crontab
 COPY docker/entrypoint.sh /app/entrypoint.sh


### PR DESCRIPTION
## Context

Après le refactor extraction tools (commit `8e01f8d`, 10/04/2026) `scripts/maintenance/data_repo_sync.py` a quitté magma-cycling vers outillages puis est porté dans `magma-cycling-tools` (scaffold `f165e98`). Le Dockerfile n a jamais été mis à jour → l entry point `data-repo-sync` manque dans l image `:stable` → le cron supercronic du container `magma-cycling-cron-jobs-1` plante silencieusement sur `command not found` à chaque tick 22:30 UTC + 20:30 dim.

## Fix

1 ligne ajoutée dans `docker/Dockerfile` : `RUN pip install git+https://github.com/stephanejouve/magma-cycling-tools.git@main` (repo public, zéro secret build).

## Scope

- 1 fichier modifié (`docker/Dockerfile`)
- Zéro code magma-cycling Python touché
- Pas de nouveau test (le fix est au niveau image runtime, covered par smoke post-redeploy)

## Post-merge plan

1. Build image `:latest` via workflow Release
2. Admin tag `:latest` → `:stable` local NAS
3. Admin redeploy stack #33 via `portainer_ctl redeploy`
4. Smoke : prochain tick cron 22:30 UTC → vérifier `data-repo-sync` exécute + `Rebased on origin/main` dans les logs (fix PR #29 outillages = pull-rebase-push)

## Contexte admin

PR ouverte par admin côté API pour débloquer la chaîne Phase 1 Étape 4 ADR training-logs-sync (pivot NAS prod writer bloqué tant que cette fix n est pas mergée). Junior a push la branche mais n a pas le scope magma-cycling pour ouvrir la PR.

cc @stephanejouve (PO) @devleader (review)