### PR TITLE
fix(docker): install openssh-client for SSH git push to training-logs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,11 @@ RUN pip install --no-cache-dir poetry poetry-plugin-export \
 # =============================================================================
 FROM python:3.12-slim
 
-# Deps systeme : git (push data repo) + curl (healthcheck)
+# Deps systeme : git (push data repo) + curl (healthcheck) +
+# openssh-client (SSH deploy key pour git push vers training-logs, cf. bascule
+# HTTPS→SSH du 18/04 suite expiration PAT — ephemere auparavant, pérennisé ici)
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git curl \
+    && apt-get install -y --no-install-recommends git curl openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Supercronic (cron leger pour Docker) — multi-arch via TARGETARCH


### PR DESCRIPTION
## Contexte

Pérennise l'ajout éphémère d'\`openssh-client\` fait par Admin le **18/04** lors de la bascule training-logs HTTPS→SSH (PAT GitHub expiré → deploy key ed25519 read-write). Référence Talk admin id=913.

Sans \`openssh-client\`, le binaire \`ssh\` est absent du container slim → \`git push origin main\` via URL SSH échoue au premier rebuild d'image (l'install éphémère ne survit pas).

## Scope

1 ligne ajoutée à l'\`apt-get install\` (ligne 20 du Dockerfile) + 2 lignes de commentaire qui expliquent le contexte. Aucun autre changement.

## Impact image

~1 MB (openssh-client), négligeable sur une image magma-cycling déjà à plusieurs centaines de MB.

## Test plan

- [x] Ajout cohérent avec \`git\` + \`curl\` dans le même \`apt-get install\`
- [ ] Après merge + rebuild : Admin vérifie que \`ssh -V\` retourne une version dans le container
- [ ] Tick cron data-repo-sync 22:30 UTC : push SSH réussit sans fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)