### PR TITLE
fix(withings-presync): include blood_pressure in daily sync data_types

### DIFF
--- a/magma_cycling/scripts/withings_presync.py
+++ b/magma_cycling/scripts/withings_presync.py
@@ -36,7 +36,7 @@ def main() -> int:
     today = date.today()
     yesterday = today - timedelta(days=1)
 
-    log(f"Syncing {yesterday} → {today} (sleep, weight)")
+    log(f"Syncing {yesterday} → {today} (sleep, weight, blood pressure)")
 
     try:
         from magma_cycling._mcp.handlers.health import sync_health_to_calendar
@@ -44,7 +44,7 @@ def main() -> int:
         result = sync_health_to_calendar(
             start_date=yesterday,
             end_date=today,
-            data_types=["sleep", "weight"],
+            data_types=["sleep", "weight", "blood_pressure"],
         )
 
         synced = result.get("synced_count", 0)


### PR DESCRIPTION
## Root cause

\`withings_presync.py\` (LaunchAgent cron 21h00 qui syncs Withings → Intervals.icu wellness) a depuis sa création (commit \`4954242\` du 10 avril 2026) :

\`\`\`python
data_types=["sleep", "weight"],   # ← blood_pressure absent
\`\`\`

Oubli d'origine, pas une régression. Conséquence : ~1 mois de mesures BP Withings jamais propagées vers Intervals.icu wellness (systolic/diastolic vides dans le dashboard).

## Fix

2 lignes modifiées :
- \`data_types\` inclut désormais \`"blood_pressure"\`
- Log associé à jour (\`"(sleep, weight, blood pressure)"\`)

## Backfill historique

Les 30 dates manquantes (2026-03-23 → 2026-04-24) ont déjà été synchronisées manuellement via un one-shot Python appelant \`sync_health_to_calendar(data_types=["blood_pressure"])\` directement. 31 mesures récupérées depuis Withings, 30 dates syncées (31-30 = 1 jour avec 2 mesures, dédupliqué).

## Chemin runtime validé

Toutes les briques supportent déjà \`"blood_pressure"\` :
- \`magma_cycling/_mcp/handlers/health.py:332\` : \`sync_bp = "all" in types or "blood_pressure" in types\`
- \`magma_cycling/health/withings_provider.py:76\` : \`get_blood_pressure_range\` implémenté
- \`magma_cycling/_mcp/schemas/health.py:112\` : enum inclut \`"blood_pressure"\`

Seul \`withings_presync.py\` omettait l'inclusion — ce qui est corrigé ici.

## Test plan

- [x] Backfill historique effectué (30 dates syncées, 0 erreur)
- [ ] Prochain tick LaunchAgent 21h00 Mac : log doit afficher \`"(sleep, weight, blood pressure)"\` et synchroniser automatiquement la mesure du jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)