### PR TITLE
fix(planning): inject skip_reason when adding cancelled session from remote

### DIFF
--- a/magma_cycling/planning/control_tower.py
+++ b/magma_cycling/planning/control_tower.py
@@ -500,6 +500,15 @@ class PlanningControlTower:
 
                 else:
                     # Add new session from remote
+                    # Session pydantic model requires skip_reason non-null when
+                    # status is "cancelled" (cf. models.py validator). The remote
+                    # status can only be "cancelled" here via an [ANNULÉE] /
+                    # [SAUTÉE] NOTE — inject a default skip_reason so the
+                    # constructor does not raise.
+                    skip_reason: str | None = None
+                    if remote_data["status"] == "cancelled":
+                        skip_reason = "Cancelled via Intervals.icu note ([ANNULÉE]/[SAUTÉE])"
+
                     new_session = Session(
                         session_id=session_id,
                         session_date=remote_data["session_date"],
@@ -512,7 +521,7 @@ class PlanningControlTower:
                         status=remote_data["status"],
                         intervals_id=remote_data["intervals_id"],
                         description_hash=None,
-                        skip_reason=None,
+                        skip_reason=skip_reason,
                     )
                     plan.planned_sessions.append(new_session)
                     stats["sessions_added"].append(session_id)

--- a/tests/planning/test_control_tower.py
+++ b/tests/planning/test_control_tower.py
@@ -70,9 +70,11 @@ class TestSyncFromRemoteNoteFiltering:
 
         tower = PlanningControlTower()
 
-        # Mock the local plan: one session S016-02 pinned to a given intervals_id
+        # Mock the local plan: one session S016-02 pinned to a given intervals_id.
+        # session_date must be a real date for the post-sync sort to succeed.
         local_session = MagicMock()
         local_session.session_id = "S016-02"
+        local_session.session_date = date(2026, 4, 14)
         local_session.name = "TempoSoutenu"
         local_session.description = "existing description"
         local_session.intervals_id = local_intervals_id_for_02
@@ -114,12 +116,7 @@ class TestSyncFromRemoteNoteFiltering:
         assert stats["intervals_ids_fixed"] == []
 
     def test_cancellation_note_still_reaches_parser(self):
-        """[ANNULÉE] / [SAUTÉE] notes must not be skipped by the NOTE filter.
-
-        Validates the parser path only — full add/update of cancelled sessions
-        depends on upstream Session model validators (skip_reason required when
-        status=cancelled) which is a separate concern, not part of this fix.
-        """
+        """[ANNULÉE] / [SAUTÉE] notes must not be skipped by the NOTE filter."""
         from magma_cycling.planning.models import WORKOUT_NAME_REGEX
 
         cancel_name = "[ANNULÉE] S016-06-END-EnduranceDouce-V001"
@@ -128,6 +125,19 @@ class TestSyncFromRemoteNoteFiltering:
         # And the filter keeps it (does NOT continue)
         has_cancel_marker = "[ANNULÉE]" in cancel_name or "[SAUTÉE]" in cancel_name
         assert has_cancel_marker, "Cancellation note must bypass the NOTE filter"
+
+    def test_cancellation_note_adds_session_with_skip_reason(self):
+        """Adding a cancelled session from a NOTE must inject a default skip_reason.
+
+        The Session pydantic model requires skip_reason non-null when
+        status='cancelled'. sync_from_remote must provide a default, otherwise
+        the constructor raises ValidationError. Regression test for BT-011.
+        """
+        events = self._build_events()
+        stats = self._run_sync(events)
+
+        # Session S016-06 should be added via the cancellation NOTE, not crash
+        assert "S016-06" in stats["sessions_added"]
 
     def test_regular_note_alone_is_silently_dropped(self):
         """If a session is only referenced by an analysis NOTE, it must not be added to planning."""


### PR DESCRIPTION
## Issue

Closes #278 (BT-011).

## Root cause

\`Session\` pydantic model exige \`skip_reason\` non-null quand \`status='cancelled'\`. La branche \`Add new session from remote\` de \`sync_from_remote\` hardcodait \`skip_reason=None\` même pour un status \`cancelled\`, provoquant \`ValidationError\` à la construction.

## Fix

1 bloc 3 lignes : quand \`remote_data["status"] == "cancelled"\`, set \`skip_reason\` à un string descriptif par défaut (\`"Cancelled via Intervals.icu note ([ANNULÉE]/[SAUTÉE])"\`). Les adds \`planned\` gardent \`skip_reason=None\`.

## Tests

- \`test_cancellation_note_adds_session_with_skip_reason\` : réactivé (il avait été rétrogradé en parser-only assert dans PR #276 quand ce souci pydantic était hors scope)
- 5/5 tests \`test_control_tower.py\` passent
- 211 tests \`tests/planning/\` passent, 0 régression

## Contexte historique

Le bug a été surfacé pendant le fix de BT-010 (#276 — sync-remote-to-local ignore les NOTEs analyse). À ce moment-là, j'ai délibérément sorti ce bug du scope pour rester chirurgical sur BT-010. Cette PR traite BT-011 de manière isolée comme convenu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)