### PR TITLE
feat(lint): pre-commit + CI hook for safe I/O conformity

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,6 @@ jobs:
     - name: Run Ruff formatter check
       run: poetry run ruff format --check magma_cycling/
       continue-on-error: true
+
+    - name: Check safe I/O conformity (encoding=utf-8 enforcement)
+      run: python scripts/lint/check_safe_io.py magma_cycling/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,13 @@ repos:
         files: ^(pyproject\.toml|docs/modules/tools\.rst|magma_cycling/.*\.py)$
         pass_filenames: false
 
+      - id: check-safe-io
+        name: Check safe I/O conformity (encoding=utf-8 enforcement)
+        entry: python scripts/lint/check_safe_io.py
+        language: system
+        types: [python]
+        exclude: ^(tests/|scripts/debug/|project-docs/)
+
   # Trailing whitespace & EOF
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/magma_cycling/workflows/sync/activity_detection.py
+++ b/magma_cycling/workflows/sync/activity_detection.py
@@ -144,7 +144,7 @@ class ActivityDetectionMixin:
             import contextlib
             import os
 
-            with open(os.devnull, "w") as devnull:
+            with open(os.devnull, "w", encoding="utf-8") as devnull:
                 with contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):
                     return self._check_activities_internal(check_date)
         else:

--- a/scripts/lint/check_safe_io.py
+++ b/scripts/lint/check_safe_io.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""AST-based linter that enforces explicit ``encoding=utf-8`` on text I/O.
+
+Run as a pre-commit hook and in CI. Flags:
+
+- ``Path.read_text(...)``  without ``encoding=`` kwarg
+- ``Path.write_text(...)`` without ``encoding=`` kwarg
+- ``open(path, mode)`` in text mode without ``encoding=`` kwarg
+  (binary modes ``rb``, ``wb``, ``ab``, ``r+b``, etc. are exempted)
+
+Why
+---
+
+Without an explicit ``encoding=``, Python falls back to
+``locale.getpreferredencoding()`` which is ``cp1252`` on Windows. Any
+file containing emoji or non-Latin-1 characters then raises
+``UnicodeDecodeError`` on read or ``UnicodeEncodeError`` on write —
+exactly the daily-sync crash class fixed by PR #289 (safe_io helpers).
+
+This linter prevents regressions: a future dev who forgets to add
+``encoding="utf-8"`` (or to call ``safe_read_text`` / ``safe_write_text``)
+will be caught before merge.
+
+Usage
+-----
+
+::
+
+    python scripts/lint/check_safe_io.py [path ...]
+
+Without arguments, lints ``magma_cycling/`` recursively. Exits 1 on any
+violation, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# Files exempted from the lint (the helpers that intentionally call the
+# raw API to provide a safe wrapper around it).
+EXEMPT_PATHS: set[str] = {
+    "magma_cycling/utils/safe_io.py",
+}
+
+TEXT_MODES_DEFAULT = {""}  # No mode arg → default is "r" (text)
+
+
+def _is_text_mode(mode: str) -> bool:
+    """Return True when an open() mode string opens a file in text mode."""
+    if mode == "":
+        return True
+    return "b" not in mode
+
+
+class _IOVisitor(ast.NodeVisitor):
+    """Collect read_text / write_text / open() calls without encoding= kwarg."""
+
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        self.violations: list[tuple[int, str]] = []
+
+    def _has_encoding_kwarg(self, node: ast.Call) -> bool:
+        return any(kw.arg == "encoding" for kw in node.keywords)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # Detect Path.read_text() / Path.write_text() (attribute call).
+        # We do NOT match generic `.open()` attribute calls because that
+        # would catch unrelated APIs like `webbrowser.open()`,
+        # `subprocess.Popen.open()`, etc. The bare `open()` builtin below
+        # covers the most common file I/O cases; Path.open() is rare and
+        # can be migrated case by case if needed.
+        if isinstance(node.func, ast.Attribute):
+            attr = node.func.attr
+            if attr in {"read_text", "write_text"} and not self._has_encoding_kwarg(node):
+                self.violations.append(
+                    (
+                        node.lineno,
+                        f"{attr}() without explicit encoding= "
+                        f"(use safe_io.safe_{attr.replace('text', 'text')} or pass encoding='utf-8')",
+                    )
+                )
+
+        # Detect bare open(...) call
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "open"
+            and not self._has_encoding_kwarg(node)
+        ):
+            mode = self._extract_open_mode(node)
+            if _is_text_mode(mode):
+                self.violations.append(
+                    (
+                        node.lineno,
+                        "open() in text mode without explicit encoding= (pass encoding='utf-8')",
+                    )
+                )
+
+        # Continue walking children
+        self.generic_visit(node)
+
+    @staticmethod
+    def _extract_open_mode(node: ast.Call) -> str:
+        """Return the mode string passed to open(), or '' if implicit."""
+        # open(path, mode) — second positional arg
+        if len(node.args) >= 2:
+            arg = node.args[1]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                return arg.value
+            # Non-literal mode → assume text to be safe (force encoding= anyway)
+            return ""
+        # open(path, mode=...) — keyword
+        for kw in node.keywords:
+            if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                return kw.value.value if isinstance(kw.value.value, str) else ""
+        return ""  # default mode "r"
+
+
+def _is_exempt(path: Path) -> bool:
+    """Check whether a file should be skipped by the linter."""
+    posix = path.as_posix()
+    return any(posix.endswith(exempt) for exempt in EXEMPT_PATHS)
+
+
+def lint_file(path: Path) -> list[tuple[int, str]]:
+    """Return the list of violations found in ``path``."""
+    if _is_exempt(path):
+        return []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        # Don't fail the lint on syntax errors — that's another tool's job.
+        return []
+    visitor = _IOVisitor(str(path))
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def lint_paths(paths: list[Path]) -> int:
+    """Run the linter on the given paths. Return 1 on any violation, else 0."""
+    files: list[Path] = []
+    for arg in paths:
+        if arg.is_dir():
+            files.extend(arg.rglob("*.py"))
+        elif arg.is_file() and arg.suffix == ".py":
+            files.append(arg)
+
+    total_violations = 0
+    for path in sorted(set(files)):
+        violations = lint_file(path)
+        for line, msg in violations:
+            print(f"{path}:{line}: {msg}")
+            total_violations += 1
+
+    if total_violations:
+        print(
+            f"\n{total_violations} violation(s) — see https://github.com/stephanejouve/magma-cycling/pull/289 for context."
+        )
+        return 1
+    return 0
+
+
+def main() -> int:
+    """Entry point — lint paths from sys.argv (default ``magma_cycling/``)."""
+    args = sys.argv[1:]
+    if not args:
+        # Default scope when invoked without args
+        args = ["magma_cycling"]
+    paths = [Path(a) for a in args]
+    return lint_paths(paths)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/monitoring/check_workout_adherence.py
+++ b/scripts/monitoring/check_workout_adherence.py
@@ -179,7 +179,7 @@ class WorkoutAdherenceChecker:
         """
         log_file = self.log_dir / "workout_adherence.jsonl"
 
-        with open(log_file, "a") as f:
+        with open(log_file, "a", encoding="utf-8") as f:
             f.write(json.dumps(result) + "\n")
 
         print(f"\n📝 Results logged to: {log_file}")

--- a/tests/test_lint_safe_io.py
+++ b/tests/test_lint_safe_io.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/lint/check_safe_io.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LINTER_PATH = REPO_ROOT / "scripts" / "lint" / "check_safe_io.py"
+
+
+def _load_linter():
+    """Import the linter as a module from its filesystem path."""
+    spec = importlib.util.spec_from_file_location("check_safe_io", LINTER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_safe_io"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def linter():
+    return _load_linter()
+
+
+@pytest.fixture
+def temp_py(tmp_path: Path):
+    """Create a temporary Python file with given source and return its path."""
+
+    def _make(name: str, source: str) -> Path:
+        p = tmp_path / name
+        p.write_text(source, encoding="utf-8")
+        return p
+
+    return _make
+
+
+class TestReadWriteTextDetection:
+    def test_read_text_without_encoding_is_flagged(self, linter, temp_py):
+        path = temp_py(
+            "a.py",
+            "from pathlib import Path\nx = Path('f.md').read_text()\n",
+        )
+        violations = linter.lint_file(path)
+        assert len(violations) == 1
+        assert "read_text" in violations[0][1]
+
+    def test_read_text_with_encoding_is_clean(self, linter, temp_py):
+        path = temp_py(
+            "a.py",
+            "from pathlib import Path\nx = Path('f.md').read_text(encoding='utf-8')\n",
+        )
+        assert linter.lint_file(path) == []
+
+    def test_write_text_without_encoding_is_flagged(self, linter, temp_py):
+        path = temp_py(
+            "a.py",
+            "from pathlib import Path\nPath('f.md').write_text('hi')\n",
+        )
+        violations = linter.lint_file(path)
+        assert len(violations) == 1
+        assert "write_text" in violations[0][1]
+
+    def test_write_text_with_encoding_is_clean(self, linter, temp_py):
+        path = temp_py(
+            "a.py",
+            "from pathlib import Path\nPath('f.md').write_text('hi', encoding='utf-8')\n",
+        )
+        assert linter.lint_file(path) == []
+
+
+class TestOpenDetection:
+    def test_open_default_mode_is_flagged(self, linter, temp_py):
+        path = temp_py("a.py", "f = open('foo.txt')\n")
+        violations = linter.lint_file(path)
+        assert len(violations) == 1
+        assert "open()" in violations[0][1]
+
+    def test_open_text_mode_without_encoding_is_flagged(self, linter, temp_py):
+        path = temp_py("a.py", "f = open('foo.txt', 'w')\n")
+        violations = linter.lint_file(path)
+        assert len(violations) == 1
+
+    def test_open_binary_mode_is_clean(self, linter, temp_py):
+        path = temp_py("a.py", "f = open('foo.bin', 'rb')\n")
+        assert linter.lint_file(path) == []
+
+    def test_open_with_encoding_is_clean(self, linter, temp_py):
+        path = temp_py(
+            "a.py",
+            "f = open('foo.txt', 'r', encoding='utf-8')\n",
+        )
+        assert linter.lint_file(path) == []
+
+    def test_webbrowser_open_is_not_flagged(self, linter, temp_py):
+        """Generic .open() attribute calls (webbrowser.open, etc.) are not file I/O."""
+        path = temp_py("a.py", "import webbrowser\nwebbrowser.open('https://example.com')\n")
+        assert linter.lint_file(path) == []
+
+
+class TestExemptions:
+    def test_safe_io_module_is_exempt(self, linter, tmp_path):
+        # Simulate the actual module path that the linter exempts
+        magma_dir = tmp_path / "magma_cycling" / "utils"
+        magma_dir.mkdir(parents=True)
+        path = magma_dir / "safe_io.py"
+        path.write_text(
+            "from pathlib import Path\n"
+            "def safe_read_text(p): return p.read_text(encoding='utf-8', errors='replace')\n"
+            "def safe_write_text(p, c): p.write_text(c, encoding='utf-8')\n",
+            encoding="utf-8",
+        )
+        # The exemption matches by suffix; if our path ends with the exempt key, no violations
+        # (this test confirms the exemption mechanism, even though the file above is already clean)
+        assert linter.lint_file(path) == []
+
+
+class TestRealCodebase:
+    def test_current_codebase_is_clean(self, linter):
+        """The magma_cycling/ tree must already pass the linter (post-PR #289)."""
+        magma_dir = REPO_ROOT / "magma_cycling"
+        if not magma_dir.is_dir():
+            pytest.skip("magma_cycling not found at expected path")
+        rc = linter.lint_paths([magma_dir])
+        assert rc == 0, "magma_cycling/ has unexpected I/O violations — see linter output"


### PR DESCRIPTION
## Issue

Closes #290.

## Scope

AST-based linter qui enforce `encoding=utf-8` explicite sur les I/O texte. Prévient les régressions de la classe de bug daily-sync emoji fixé par #289.

### Linter (`scripts/lint/check_safe_io.py`)

Détecte :
- `Path.read_text(...)` sans `encoding=` kwarg
- `Path.write_text(...)` sans `encoding=` kwarg
- `open(path, mode)` builtin en mode texte sans `encoding=`

Modes binaires (rb/wb/ab/etc.) exemptés. Generic `.open()` attribute calls (webbrowser.open, etc.) **non** flaggués (faux positifs). Le module `magma_cycling/utils/safe_io.py` est exempté (il fournit les wrappers safe).

### Intégration

- **Pre-commit local** : nouveau hook `check-safe-io` dans `.pre-commit-config.yaml`. Exclut `tests/`, `scripts/debug/`, `project-docs/`. Failure bloquante au commit.
- **CI** : nouvelle étape dans `.github/workflows/lint.yml` qui run le linter sur `magma_cycling/` à chaque push/PR. Failure bloquante au merge — couvre les `--no-verify` locaux.

### Side-effect fixes

2 violations pré-existantes surface et fixées :
- `magma_cycling/workflows/sync/activity_detection.py:147` — `open(os.devnull, "w")` reçoit `encoding="utf-8"` (no-op sémantique mais cohérent)
- `scripts/monitoring/check_workout_adherence.py:182` — audit log JSONL append reçoit `encoding="utf-8"`

## Tests

11 cas dans `tests/test_lint_safe_io.py` :
- Détection : read_text/write_text/open() sans encoding
- Clean-pass : encoding explicite, modes binaires
- `webbrowser.open()` non-flaggué (anti-faux-positif)
- Exemption `safe_io.py`
- Régression : `magma_cycling/` actuel doit passer le linter

🤖 Generated with [Claude Code](https://claude.com/claude-code)