### PR TITLE
fix(logging): force UTF-8 on RotatingFileHandler (Windows cp1252 corruption)

### DIFF
--- a/magma_cycling/config/logging_config.py
+++ b/magma_cycling/config/logging_config.py
@@ -108,7 +108,13 @@ def setup_logging(
     # Add file handler if requested
     if file_path:
         Path(file_path).parent.mkdir(parents=True, exist_ok=True)
-        file_handler = RotatingFileHandler(file_path, maxBytes=max_bytes, backupCount=backup_count)
+        file_handler = RotatingFileHandler(
+            file_path,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+            errors="replace",
+        )
         file_handler.setLevel(log_level)
         file_handler.setFormatter(logging.Formatter(log_format, datefmt="%Y-%m-%d %H:%M:%S"))
         logging.getLogger().addHandler(file_handler)

--- a/tests/config/test_logging_config.py
+++ b/tests/config/test_logging_config.py
@@ -1,0 +1,60 @@
+"""Tests for logging_config — non-regression on UTF-8 file handler."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from magma_cycling.config.logging_config import setup_logging
+
+
+@pytest.fixture
+def reset_root_logger():
+    """Reset root logger handlers after each test."""
+    yield
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+        h.close()
+
+
+def test_rotating_file_handler_writes_utf8_on_windows_locales(tmp_path: Path, reset_root_logger):
+    """Regression test for BT-Georges/BT-Max: RotatingFileHandler must write UTF-8.
+
+    Previously the handler was created without explicit `encoding=`, which on
+    Windows defaults to cp1252 and corrupts non-ASCII characters (em-dash,
+    accented letters) silently. The log file then contains raw cp1252 bytes
+    that look like mojibake when read with any UTF-8 reader.
+    """
+    log_file = tmp_path / "test.log"
+
+    setup_logging(level="INFO", file_path=str(log_file), force=True)
+
+    logger = logging.getLogger("test_utf8")
+    logger.info("Workflow coach IA — procédure actée S018")
+    logger.info("Kiné midi — données complètes")
+
+    for h in logging.getLogger().handlers:
+        h.flush()
+
+    content = log_file.read_text(encoding="utf-8")
+    assert "Workflow coach IA — procédure actée S018" in content
+    assert "Kiné midi — données complètes" in content
+
+
+def test_rotating_file_handler_replaces_undecodable_chars(tmp_path: Path, reset_root_logger):
+    """`errors="replace"` ensures no UnicodeEncodeError crashes the logger
+    if a string somehow contains chars unencodable in UTF-8 (extremely rare
+    but the safety belt is the contract)."""
+    log_file = tmp_path / "test.log"
+    setup_logging(level="INFO", file_path=str(log_file), force=True)
+
+    logger = logging.getLogger("test_replace")
+    logger.info("emoji ok 🚴 sleep ok 🛌")
+
+    for h in logging.getLogger().handlers:
+        h.flush()
+
+    content = log_file.read_text(encoding="utf-8")
+    assert "emoji ok 🚴" in content
+    assert "sleep ok 🛌" in content


### PR DESCRIPTION
## Summary

The MCP server log file was created via `RotatingFileHandler` in `magma_cycling/config/logging_config.py` without an explicit `encoding` argument. On Windows the default is `cp1252`, which silently corrupts non-ASCII characters (`é`, `è`, em-dash, etc.) when the log file is later read with any UTF-8 reader.

Reported by beta-testers on the PyInstaller Windows bundle: log entries like `Created event: 106151540 - Kiné midi` appeared as `Created event: ... - Kin\xe9 midi` or `Created event: ... - Kin  midi` depending on the editor used to read the file.

A round-trip test via the Intervals.icu API on Mac (name with accents and em-dash) confirmed the bug was strictly local to the logger — the API stores and returns UTF-8 correctly.

## Changes

- `magma_cycling/config/logging_config.py`: add `encoding="utf-8", errors="replace"` to the `RotatingFileHandler`.
- `tests/config/test_logging_config.py`: new file with 2 non-regression tests covering accents, em-dash, and emoji.

## Test plan

- [x] Local: `pytest tests/config/test_logging_config.py -x` (2/2 passed)
- [x] CI: lint + tests on PR
- [ ] Manual validation by beta-testers after next bundle release: log entries with accents/em-dash should be readable as UTF-8.
