### PR TITLE
fix(mcp): patch-coach-analysis accepts pipe-delimited header format

### DIFF
--- a/magma_cycling/_mcp/handlers/rest.py
+++ b/magma_cycling/_mcp/handlers/rest.py
@@ -217,9 +217,11 @@ def _locate_entry(
         if m:
             anchor_pos = m.start()
 
-    # Fallback: session_id
+    # Fallback: session_id (word-boundary match — supports both legacy hyphen
+    # format `### S018-01-EnduranceLongue` and pipe-delimited format
+    # `### S018-01 | activity_id | date | name`).
     if anchor_pos is None and session_id:
-        m = re.search(rf"^### {re.escape(session_id)}-", content, re.MULTILINE)
+        m = re.search(rf"^###\s+{re.escape(session_id)}\b", content, re.MULTILINE)
         if m:
             anchor_pos = m.start()
 

--- a/tests/_mcp/handlers/test_rest.py
+++ b/tests/_mcp/handlers/test_rest.py
@@ -496,3 +496,51 @@ class TestPatchNoSleepInAttention:
         assert "- Sommeil : 7.8h" in written
         # No error
         assert "error" not in data
+
+
+class TestLocateEntryHeaderFormats:
+    """8. _locate_entry must accept both legacy hyphen and pipe-delimited headers.
+
+    Two header conventions coexist in workouts-history.md:
+    - Legacy auto-pipeline: `### S084-04-END-RecupActive-V001` (hyphen-separated)
+    - Pipe-delimited (manually pasted entries): `### S018-01 | activity_id | date | name`
+
+    `get-coach-analysis` already handles both via word-boundary regex.
+    `patch-coach-analysis` previously required a hyphen after session_id and
+    failed silently on the pipe format (returns "Entry not found").
+    """
+
+    def test_locate_entry_matches_legacy_hyphen_format(self):
+        from magma_cycling._mcp.handlers.rest import _locate_entry
+
+        content = (
+            "### S084-04-END-RecupActive-V001\n"
+            "ID : i131572602\n"
+            "Date : 15/03/2026\n"
+            "Some content\n"
+        )
+        result = _locate_entry(content, activity_id=None, session_id="S084-04")
+        assert result is not None
+        start, end = result
+        assert content[start:end].startswith("### S084-04-END-RecupActive-V001")
+
+    def test_locate_entry_matches_pipe_delimited_format(self):
+        from magma_cycling._mcp.handlers.rest import _locate_entry
+
+        content = (
+            "### S018-01 | i143294645 | 2026-04-27 | ReposPostTinyRaces\n"
+            "ID : i143294645\n"
+            "Date : 27/04/2026\n"
+            "Some content\n"
+        )
+        result = _locate_entry(content, activity_id=None, session_id="S018-01")
+        assert result is not None, "patch must support pipe-delimited headers"
+        start, end = result
+        assert content[start:end].startswith("### S018-01 | i143294645")
+
+    def test_locate_entry_does_not_match_partial_session_id(self):
+        from magma_cycling._mcp.handlers.rest import _locate_entry
+
+        content = "### S084-040-END-RecupActive-V001\n" "ID : i131572602\n" "Date : 15/03/2026\n"
+        result = _locate_entry(content, activity_id=None, session_id="S084-04")
+        assert result is None, "word boundary must prevent S084-04 matching S084-040"


### PR DESCRIPTION
## Summary

`_locate_entry` in `rest.py` used a regex requiring a literal hyphen after `session_id` (`^### {session_id}-`), which only matched the legacy auto-pipeline header format `### S084-04-END-RecupActive-V001`. It failed silently on the pipe-delimited format `### S018-01 | activity_id | date | name` used for manually pasted entries.

Symptom: `get-coach-analysis session_id=...` succeeded (it uses a word-boundary regex), but `patch-coach-analysis session_id=...` on the same entry returned `"Entry not found"`.

## Changes

- `magma_cycling/_mcp/handlers/rest.py`: align `_locate_entry` regex on the same word-boundary pattern used by `analysis.py:705` (get-coach-analysis): `^###\s+{session_id}\b`.
- `tests/_mcp/handlers/test_rest.py`: new `TestLocateEntryHeaderFormats` class with 3 tests covering both header formats and a non-regression on partial `session_id` matches.

## Test plan

- [x] Local: `pytest tests/_mcp/handlers/test_rest.py::TestLocateEntryHeaderFormats -x` (3/3 passed)
- [ ] CI: lint + tests on PR