### PR TITLE
fix(mcp): create-remote-note status write-back requires explicit prefix

### DIFF
--- a/magma_cycling/_mcp/handlers/remote_events.py
+++ b/magma_cycling/_mcp/handlers/remote_events.py
@@ -308,51 +308,61 @@ async def handle_create_remote_note(args: dict) -> list[TextContent]:
             created_event = client.create_event(event_data)
 
             if created_event and "id" in created_event:
-                session_id_match = re.search(SESSION_ID_PATTERN, name)
-                if session_id_match:
-                    session_id = session_id_match.group()
-                    week_id = session_id.split("-")[0]
+                # Status write-back is opt-in: only triggered if the note name
+                # starts with an explicit status prefix. A note merely mentioning
+                # a session_id (e.g. documentation) must NOT mutate the planning.
+                status_map = {
+                    "[ANNULÉE]": "cancelled",
+                    "[SAUTÉE]": "skipped",
+                    "[REMPLACÉE]": "replaced",
+                }
+                new_status = next(
+                    (status for prefix, status in status_map.items() if name.startswith(prefix)),
+                    None,
+                )
 
-                    try:
-                        status_map = {
-                            "[ANNULÉE]": "cancelled",
-                            "[SAUTÉE]": "skipped",
-                            "[REMPLACÉE]": "replaced",
-                        }
-                        new_status = next(
-                            (
-                                status
-                                for prefix, status in status_map.items()
-                                if name.startswith(prefix)
-                            ),
-                            "cancelled",
-                        )
-
-                        with planning_tower.modify_week(
-                            week_id,
-                            requesting_script="create-remote-note",
-                            reason=f"Write-back from NOTE creation: {new_status} session {session_id}",
-                        ) as plan:
-                            updated_sessions = []
-                            for session in plan.planned_sessions:
-                                if session.session_id == session_id:
-                                    session_dict = session.model_dump()
-                                    session_dict["status"] = new_status
-                                    session_dict["reason"] = description[:100]
-                                    updated_session = Session(**session_dict)
-                                    updated_sessions.append(updated_session)
-                                else:
-                                    updated_sessions.append(session)
-
-                            plan.planned_sessions = updated_sessions
-
-                        local_update_msg = (
-                            f" (+ local planning {week_id}/{session_id} → {new_status})"
-                        )
-                    except Exception as e:
-                        local_update_msg = f" (local planning update failed: {str(e)})"
+                if new_status is None:
+                    local_update_msg = (
+                        " (documentary note — local planning not updated; "
+                        "use [ANNULÉE]/[SAUTÉE]/[REMPLACÉE] prefix to opt in)"
+                    )
                 else:
-                    local_update_msg = " (no session_id found in name, local planning not updated)"
+                    session_id_match = re.search(SESSION_ID_PATTERN, name)
+                    if not session_id_match:
+                        local_update_msg = (
+                            " (status prefix found but no session_id — "
+                            "local planning not updated)"
+                        )
+                    else:
+                        session_id = session_id_match.group()
+                        week_id = session_id.split("-")[0]
+                        try:
+                            with planning_tower.modify_week(
+                                week_id,
+                                requesting_script="create-remote-note",
+                                reason=(
+                                    f"Write-back from NOTE creation: "
+                                    f"{new_status} session {session_id}"
+                                ),
+                            ) as plan:
+                                updated_sessions = []
+                                for session in plan.planned_sessions:
+                                    if session.session_id == session_id:
+                                        session_dict = session.model_dump()
+                                        session_dict["status"] = new_status
+                                        session_dict["reason"] = description[:100]
+                                        updated_session = Session(**session_dict)
+                                        updated_sessions.append(updated_session)
+                                    else:
+                                        updated_sessions.append(session)
+
+                                plan.planned_sessions = updated_sessions
+
+                            local_update_msg = (
+                                f" (+ local planning {week_id}/{session_id} → {new_status})"
+                            )
+                        except Exception as e:
+                            local_update_msg = f" (local planning update failed: {str(e)})"
 
                 result = {
                     "success": True,

--- a/tests/_mcp/handlers/test_remote_events.py
+++ b/tests/_mcp/handlers/test_remote_events.py
@@ -398,3 +398,130 @@ class TestHandleCreateRemoteNote:
         assert data["success"] is True
         # Verify local planning was updated
         assert "local planning" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_documentary_note_does_not_mutate_planning(self, mock_factory, patch_tower):
+        """Note name leading with the session_id (without status prefix) is documentary
+        and must NOT mutate the local planning status."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = {"id": 99}
+        mock_factory.return_value = client
+
+        result = await handle_create_remote_note(
+            {
+                "date": "2026-03-02",
+                "name": "S999-01 données complètes — patch impossible",
+                "description": "Documentation only",
+            }
+        )
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert "local planning not updated" in data["message"]
+        assert "documentary" in data["message"]
+
+        plan_path = patch_tower / "week_planning_S999.json"
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        s01 = next(s for s in plan["planned_sessions"] if s["session_id"] == "S999-01")
+        assert s01["status"] == "uploaded"
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_session_id_mid_sentence_does_not_mutate_planning(
+        self, mock_factory, patch_tower
+    ):
+        """Session_id buried in prose (mid-name) must NOT mutate the local planning."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = {"id": 99}
+        mock_factory.return_value = client
+
+        result = await handle_create_remote_note(
+            {
+                "date": "2026-03-02",
+                "name": "Analyse hebdo — résultats S999-01 et S999-02",
+                "description": "Recap analytique",
+            }
+        )
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert "documentary" in data["message"]
+
+        plan_path = patch_tower / "week_planning_S999.json"
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        s01 = next(s for s in plan["planned_sessions"] if s["session_id"] == "S999-01")
+        assert s01["status"] == "uploaded"
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_skipped_prefix_sets_status_skipped(self, mock_factory, patch_tower):
+        """[SAUTÉE] prefix sets status=skipped."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = {"id": 99}
+        mock_factory.return_value = client
+
+        await handle_create_remote_note(
+            {
+                "date": "2026-03-02",
+                "name": "[SAUTÉE] S999-01 Endurance",
+                "description": "Oubli",
+            }
+        )
+
+        plan_path = patch_tower / "week_planning_S999.json"
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        s01 = next(s for s in plan["planned_sessions"] if s["session_id"] == "S999-01")
+        assert s01["status"] == "skipped"
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_replaced_prefix_sets_status_replaced(self, mock_factory, patch_tower):
+        """[REMPLACÉE] prefix sets status=replaced."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = {"id": 99}
+        mock_factory.return_value = client
+
+        await handle_create_remote_note(
+            {
+                "date": "2026-03-02",
+                "name": "[REMPLACÉE] S999-01 par INT",
+                "description": "Swap",
+            }
+        )
+
+        plan_path = patch_tower / "week_planning_S999.json"
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        s01 = next(s for s in plan["planned_sessions"] if s["session_id"] == "S999-01")
+        assert s01["status"] == "replaced"
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_prefix_without_session_id_no_planning_update(self, mock_factory, patch_tower):
+        """[ANNULÉE] without a parseable session_id in the name → planning untouched,
+        explicit message in response."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = {"id": 99}
+        mock_factory.return_value = client
+
+        result = await handle_create_remote_note(
+            {
+                "date": "2026-03-02",
+                "name": "[ANNULÉE] vacances",
+                "description": "Off-week",
+            }
+        )
+
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert "no session_id" in data["message"]
+
+        plan_path = patch_tower / "week_planning_S999.json"
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        s01 = next(s for s in plan["planned_sessions"] if s["session_id"] == "S999-01")
+        assert s01["status"] == "uploaded"


### PR DESCRIPTION
## Summary

`handle_create_remote_note` previously triggered a local planning status update whenever the note name contained a session_id pattern anywhere in the string, defaulting to status `cancelled` if no `[ANNULÉE]/[SAUTÉE]/[REMPLACÉE]` prefix was present.

This caused documentary notes mentioning a session_id (e.g. `"S999-01 données complètes — patch impossible"` or `"Analyse — résultats S999-01"`) to silently mutate the planning into `cancelled`, requiring a manual `update-session` to revert.

## Fix — write-back is now opt-in

The local planning is mutated only when the note name **starts with** an explicit status prefix:

- `[ANNULÉE]` → `cancelled`
- `[SAUTÉE]` → `skipped`
- `[REMPLACÉE]` → `replaced`

Names without a prefix are treated as documentary notes — the response explicitly states `(documentary note — local planning not updated; use [ANNULÉE]/[SAUTÉE]/[REMPLACÉE] prefix to opt in)`.

The implicit default (`cancelled` when prefix absent) is removed.

## Behaviour change

This is a **deliberate contract change** for `create-remote-note`:

| Note name pattern                              | Before                        | After                  |
| ---------------------------------------------- | ----------------------------- | ---------------------- |
| `[ANNULÉE] S999-01 ...`                        | planning → cancelled          | planning → cancelled   |
| `[SAUTÉE] S999-01 ...`                         | planning → skipped            | planning → skipped     |
| `[REMPLACÉE] S999-01 ...`                      | planning → replaced           | planning → replaced    |
| `S999-01 documentation ...` (leading id, no prefix) | **planning → cancelled (bug)** | **planning untouched** |
| `Analyse résultats S999-01` (mid-sentence)     | **planning → cancelled (bug)** | **planning untouched** |
| `[ANNULÉE] random text` (prefix, no session_id)| no-op                         | no-op (explicit msg)   |

## Changes

- `magma_cycling/_mcp/handlers/remote_events.py`: `handle_create_remote_note` reordered — check status prefix first, only then resolve session_id and apply the planning update. Remove the implicit `cancelled` default.
- `tests/_mcp/handlers/test_remote_events.py`: `TestHandleCreateRemoteNote` gains 5 new cases (documentary leading id, mid-sentence id, SAUTÉE, REMPLACÉE, prefix-without-session-id).

## Test plan

- [x] Local: `pytest tests/_mcp/handlers/test_remote_events.py::TestHandleCreateRemoteNote -x` (9/9 passed)
- [ ] CI: lint + tests on PR