### PR TITLE
fix(health): widen Intervals provider probe to 7-day window

### DIFF
--- a/magma_cycling/health/factory.py
+++ b/magma_cycling/health/factory.py
@@ -31,19 +31,23 @@ def create_health_provider() -> HealthProvider:
     except Exception:
         pass
 
-    # 2. Try Intervals.icu wellness (Garmin/other watch)
+    # 2. Try Intervals.icu wellness (Garmin/other watch).
+    # Probe a 7-day window (not just yesterday) so that a single missing day
+    # — late Garmin sync, day off without watch, weekend retreat, etc. — does
+    # not silently disable the provider for the whole session.
     try:
         from datetime import date, timedelta
 
         from magma_cycling.config import create_intervals_client
 
         client = create_intervals_client()
+        seven_days_ago = str(date.today() - timedelta(days=7))
         yesterday = str(date.today() - timedelta(days=1))
-        wellness = client.get_wellness(oldest=yesterday, newest=yesterday)
-        if wellness and wellness[0].get("sleepTime"):
+        wellness = client.get_wellness(oldest=seven_days_ago, newest=yesterday)
+        if wellness and any(w.get("sleepTime") for w in wellness):
             from magma_cycling.health.intervals_provider import IntervalsHealthProvider
 
-            logger.info("Using IntervalsHealthProvider (sleep data found in wellness)")
+            logger.info("Using IntervalsHealthProvider (sleep data found in last 7 days)")
             return IntervalsHealthProvider(client)
     except Exception:
         pass

--- a/tests/health/test_factory.py
+++ b/tests/health/test_factory.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 from magma_cycling.health.factory import create_health_provider
+from magma_cycling.health.intervals_provider import IntervalsHealthProvider
 from magma_cycling.health.null_provider import NullProvider
 from magma_cycling.health.withings_provider import WithingsProvider
 
@@ -33,3 +34,106 @@ class TestCreateHealthProvider:
         ):
             provider = create_health_provider()
         assert isinstance(provider, NullProvider)
+
+
+class TestIntervalsHealthProviderProbeWindow:
+    """The Intervals provider probe must accept any sleep entry within a 7-day
+    window. A single missing day (late Garmin sync, day off, weekend without
+    the watch) must not silently disable the provider for the whole session."""
+
+    def _withings_unconfigured(self):
+        cfg = Mock()
+        cfg.is_configured.return_value = False
+        return cfg
+
+    def test_returns_intervals_when_yesterday_has_sleep(self):
+        """Happy path: yesterday already has sleepTime."""
+        client = Mock()
+        client.get_wellness.return_value = [
+            {"id": "2026-04-21", "sleepTime": 26100},  # 7h15m
+        ]
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                return_value=self._withings_unconfigured(),
+            ),
+            patch("magma_cycling.config.create_intervals_client", return_value=client),
+        ):
+            provider = create_health_provider()
+        assert isinstance(provider, IntervalsHealthProvider)
+
+    def test_returns_intervals_when_only_older_day_has_sleep(self):
+        """Regression test for BT-010 NullProvider: yesterday has no sleep
+        (sync delayed / day off) but a day earlier in the week does. The
+        previous code probed only yesterday and fell back to NullProvider."""
+        client = Mock()
+        client.get_wellness.return_value = [
+            {"id": "2026-04-15", "sleepTime": 25000},  # day -7: has sleep
+            {"id": "2026-04-16", "sleepTime": None},
+            {"id": "2026-04-17", "sleepTime": None},
+            {"id": "2026-04-18", "sleepTime": None},
+            {"id": "2026-04-19", "sleepTime": None},
+            {"id": "2026-04-20", "sleepTime": None},
+            {"id": "2026-04-21", "sleepTime": None},  # yesterday: no sleep
+        ]
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                return_value=self._withings_unconfigured(),
+            ),
+            patch("magma_cycling.config.create_intervals_client", return_value=client),
+        ):
+            provider = create_health_provider()
+        assert isinstance(provider, IntervalsHealthProvider)
+
+    def test_falls_back_to_null_when_full_week_empty(self):
+        """If the entire 7-day window has no sleepTime, NullProvider is the
+        right answer (legitimately no Garmin/watch sync configured)."""
+        client = Mock()
+        client.get_wellness.return_value = [{"id": f"day-{i}", "sleepTime": None} for i in range(7)]
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                return_value=self._withings_unconfigured(),
+            ),
+            patch("magma_cycling.config.create_intervals_client", return_value=client),
+        ):
+            provider = create_health_provider()
+        assert isinstance(provider, NullProvider)
+
+    def test_falls_back_to_null_when_no_wellness_at_all(self):
+        """Empty wellness list (Intervals API returns nothing) → NullProvider."""
+        client = Mock()
+        client.get_wellness.return_value = []
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                return_value=self._withings_unconfigured(),
+            ),
+            patch("magma_cycling.config.create_intervals_client", return_value=client),
+        ):
+            provider = create_health_provider()
+        assert isinstance(provider, NullProvider)
+
+    def test_probe_uses_7_day_window(self):
+        """Verify get_wellness is called with a 7-day range, not a single day."""
+        from datetime import date, timedelta
+
+        client = Mock()
+        client.get_wellness.return_value = [{"id": "y", "sleepTime": 25000}]
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                return_value=self._withings_unconfigured(),
+            ),
+            patch("magma_cycling.config.create_intervals_client", return_value=client),
+        ):
+            create_health_provider()
+
+        call = client.get_wellness.call_args
+        oldest = call.kwargs.get("oldest") or call.args[0]
+        newest = call.kwargs.get("newest") or call.args[1]
+        expected_oldest = str(date.today() - timedelta(days=7))
+        expected_newest = str(date.today() - timedelta(days=1))
+        assert oldest == expected_oldest
+        assert newest == expected_newest


### PR DESCRIPTION
## Summary

`create_health_provider()` previously probed only **yesterday** for a `sleepTime` entry in Intervals.icu wellness to decide between `IntervalsHealthProvider` and `NullProvider`. A single missing day — late Garmin sync, day off without the watch, weekend retreat, or simply calling `get-sleep` before the morning Garmin push — caused a permanent `NullProvider` fallback for the whole MCP session, even when valid sleep data existed on every other day of the week.

## Reproduction

A beta-tester running the PyInstaller bundle had `sleepTime` + `sleepScore` visible in the Intervals.icu wellness UI on the day of the report, yet `get-sleep` and `get-body-composition` returned:

```json
{"_metadata": {"provider": {"provider": "NullProvider", "status": "not_configured"}}}
```

Likely cause: Garmin push to Intervals.icu had not yet propagated yesterday's `sleepTime` at the moment the MCP server probed.

## Fix

Probe a **7-day window** (`today - 7` to `today - 1`). Select `IntervalsHealthProvider` as soon as any single day in that window has `sleepTime`. Fall back to `NullProvider` only when the entire window is empty (legitimately no watch sync configured).

## Changes

- `magma_cycling/health/factory.py`: replace single-day probe with `client.get_wellness(oldest=today-7, newest=today-1)` + `any(w.get("sleepTime") for w in wellness)`.
- `tests/health/test_factory.py`: new `TestIntervalsHealthProviderProbeWindow` class with 5 cases (yesterday-has-sleep, only-older-day-has-sleep regression, full-week-empty fallback, empty-wellness, date-range contract).

## Test plan

- [x] Local: `pytest tests/health/test_factory.py -x` (8/8 passed)
- [ ] CI: lint + tests on PR