### PR TITLE
fix(api): tolerant UTF-8 decode on Intervals.icu responses

### DIFF
--- a/magma_cycling/api/intervals_client.py
+++ b/magma_cycling/api/intervals_client.py
@@ -7,6 +7,7 @@ This module provides a single, canonical implementation of the Intervals.icu API
 replacing multiple duplicated implementations across the codebase.
 """
 
+import json as _json
 import logging
 from datetime import datetime, timedelta
 from typing import Any
@@ -14,6 +15,37 @@ from typing import Any
 import requests
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_text(response: requests.Response) -> str:
+    """Decode an HTTP response body, tolerating non-UTF-8 bytes.
+
+    Intervals.icu occasionally returns responses whose body contains a raw
+    Latin-1 byte (notably 0xE9 for 'é') in user-authored fields like notes
+    or descriptions, even though the Content-Type header advertises UTF-8.
+    Plain `response.text` then raises UnicodeDecodeError before any handler
+    sees the data, crashing the MCP tool. We fall back to a UTF-8 decode
+    with errors='replace' on the raw bytes — keeps the rest of the response
+    usable and replaces only the offending byte(s).
+    """
+    try:
+        return response.text
+    except UnicodeDecodeError:
+        return response.content.decode("utf-8", errors="replace")
+
+
+def _safe_json(response: requests.Response) -> Any:
+    """Parse an HTTP response body as JSON tolerating non-UTF-8 bytes.
+
+    See _safe_text() for context on why this is needed. Falls back to a
+    raw bytes decode + json.loads only when response.json() raises
+    UnicodeDecodeError, so callers and tests relying on the standard
+    requests behaviour are unaffected.
+    """
+    try:
+        return response.json()
+    except UnicodeDecodeError:
+        return _json.loads(response.content.decode("utf-8", errors="replace"))
 
 
 class IntervalsClient:
@@ -76,7 +108,7 @@ class IntervalsClient:
 
         response = self.session.get(url)
         response.raise_for_status()
-        return response.json()
+        return _safe_json(response)
 
     def update_athlete(self, athlete_data: dict[str, Any]) -> dict[str, Any]:
         """
@@ -103,7 +135,7 @@ class IntervalsClient:
         response = self.session.put(url, json=athlete_data)
         response.raise_for_status()
         logger.info(f"Updated athlete profile: {athlete_data}")
-        return response.json()
+        return _safe_json(response)
 
     def get_activities(
         self, oldest: str | None = None, newest: str | None = None
@@ -140,7 +172,7 @@ class IntervalsClient:
 
         response = self.session.get(url, params=params)
         response.raise_for_status()
-        return response.json()
+        return _safe_json(response)
 
     def get_activity(self, activity_id: str) -> dict[str, Any]:
         """
@@ -165,7 +197,7 @@ class IntervalsClient:
 
         response = self.session.get(url)
         response.raise_for_status()
-        return response.json()
+        return _safe_json(response)
 
     def get_activity_streams(self, activity_id: str) -> list[dict[str, Any]]:
         """
@@ -194,7 +226,7 @@ class IntervalsClient:
 
         response = self.session.get(url)
         response.raise_for_status()
-        return response.json()
+        return _safe_json(response)
 
     def get_activity_intervals(self, activity_id: str) -> list[dict[str, Any]]:
         """
@@ -220,7 +252,7 @@ class IntervalsClient:
 
         response = self.session.get(url)
         response.raise_for_status()
-        data = response.json()
+        data = _safe_json(response)
         # API returns {"id": ..., "icu_intervals": [...], "icu_groups": [...]}
         return data.get("icu_intervals", [])
 
@@ -247,7 +279,7 @@ class IntervalsClient:
 
         response = self.session.put(url, json=intervals)
         response.raise_for_status()
-        return response.json()
+        return _safe_json(response)
 
     def get_wellness(
         self, oldest: str | None = None, newest: str | None = None
@@ -289,7 +321,7 @@ class IntervalsClient:
 
         response = self.session.get(url, params=params)
         response.raise_for_status()
-        return response.json()
+        return _safe_json(response)
 
     def update_wellness(self, date: str, wellness_data: dict[str, Any]) -> dict[str, Any]:
         """Update wellness data for a specific date.
@@ -318,7 +350,7 @@ class IntervalsClient:
 
         response = self.session.put(url, json=wellness_data)
         response.raise_for_status()
-        return response.json()
+        return _safe_json(response)
 
     def get_events(
         self, oldest: str | None = None, newest: str | None = None
@@ -355,7 +387,7 @@ class IntervalsClient:
 
         response = self.session.get(url, params=params)
         response.raise_for_status()
-        return response.json()
+        return _safe_json(response)
 
     def get_planned_workout(
         self, activity_id: str, activity_date: datetime
@@ -432,7 +464,7 @@ class IntervalsClient:
             response = self.session.post(url, json=event_data)
             response.raise_for_status()
 
-            created_event = response.json()
+            created_event = _safe_json(response)
             logger.info(f"Created event: {created_event.get('id')} - {created_event.get('name')}")
             return created_event
 
@@ -440,10 +472,10 @@ class IntervalsClient:
             logger.error(f"HTTP error creating event: {e}")
             if e.response is not None:
                 try:
-                    error_detail = e.response.json()
+                    error_detail = _safe_json(e.response)
                     logger.error(f"Error detail: {error_detail}")
                 except Exception:
-                    logger.error(f"Response: {e.response.text}")
+                    logger.error(f"Response: {_safe_text(e.response)}")
             logger.error(f"Event data: {event_data}")
             return None
 
@@ -476,7 +508,7 @@ class IntervalsClient:
         except requests.exceptions.HTTPError as e:
             logger.error(f"HTTP error deleting event {event_id}: {e}")
             if e.response is not None:
-                logger.error(f"Response: {e.response.text}")
+                logger.error(f"Response: {_safe_text(e.response)}")
             return False
 
         except Exception as e:
@@ -504,7 +536,7 @@ class IntervalsClient:
             response = self.session.put(url, json=event_data)
             response.raise_for_status()
 
-            updated_event = response.json()
+            updated_event = _safe_json(response)
             logger.info(f"Updated event ID: {event_id}")
             return updated_event
 
@@ -512,10 +544,10 @@ class IntervalsClient:
             logger.error(f"HTTP error updating event {event_id}: {e}")
             if e.response is not None:
                 try:
-                    error_detail = e.response.json()
+                    error_detail = _safe_json(e.response)
                     logger.error(f"Error detail: {error_detail}")
                 except Exception:
-                    logger.error(f"Response: {e.response.text}")
+                    logger.error(f"Response: {_safe_text(e.response)}")
             return None
 
         except Exception as e:
@@ -551,7 +583,7 @@ class IntervalsClient:
         except requests.exceptions.HTTPError as e:
             logger.error(f"HTTP error posting note to {activity_id}: {e}")
             if e.response is not None:
-                logger.error(f"Response: {e.response.text}")
+                logger.error(f"Response: {_safe_text(e.response)}")
             return False
 
         except Exception as e:

--- a/tests/api/test_intervals_client.py
+++ b/tests/api/test_intervals_client.py
@@ -287,3 +287,70 @@ class TestErrorHandling:
 
         with pytest.raises(requests.exceptions.HTTPError):
             client.get_athlete()
+
+
+class TestSafeDecodeHelpers:
+    """Regression tests for BT-011 — Intervals.icu API responses with raw
+    Latin-1 bytes (notably 0xE9) in user-authored fields like notes must not
+    crash the MCP tool. The _safe_text / _safe_json helpers fall back to a
+    UTF-8 decode with errors='replace' when response.text / response.json()
+    raise UnicodeDecodeError."""
+
+    def test_safe_text_passthrough_when_clean_utf8(self):
+        from magma_cycling.api.intervals_client import _safe_text
+
+        response = Mock()
+        response.text = "no problem here"
+        assert _safe_text(response) == "no problem here"
+
+    def test_safe_text_falls_back_on_unicode_decode_error(self):
+        from magma_cycling.api.intervals_client import _safe_text
+
+        response = Mock()
+        type(response).text = property(
+            lambda self: (_ for _ in ()).throw(UnicodeDecodeError("utf-8", b"", 0, 1, "stub"))
+        )
+        # Raw body containing a stray Latin-1 byte 0xE9 in the middle of a
+        # UTF-8 string — Intervals.icu real-world payload pattern.
+        response.content = b"prefix " + bytes([0xE9]) + b" suffix"
+
+        result = _safe_text(response)
+        assert result.startswith("prefix ")
+        assert result.endswith(" suffix")
+
+    def test_safe_json_passthrough_when_clean_utf8(self):
+        from magma_cycling.api.intervals_client import _safe_json
+
+        response = Mock()
+        response.json.return_value = {"id": 42, "name": "ok"}
+        assert _safe_json(response) == {"id": 42, "name": "ok"}
+
+    def test_safe_json_falls_back_on_unicode_decode_error(self):
+        from magma_cycling.api.intervals_client import _safe_json
+
+        response = Mock()
+        response.json.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "stub")
+        # Forge a JSON body where the user-authored "name" field contains a
+        # raw Latin-1 byte 0xE9 (cp1252 'é'), invalid as UTF-8.
+        response.content = b'{"id": 42, "name": "Kin' + bytes([0xE9]) + b' midi"}'
+
+        result = _safe_json(response)
+        assert result["id"] == 42
+        assert result["name"].startswith("Kin")
+        assert result["name"].endswith(" midi")
+
+    def test_safe_helpers_used_throughout_client(self, client, mock_session):
+        """Smoke test: a get_events call where the API response would have
+        previously crashed (UnicodeDecodeError on response.json()) returns a
+        usable payload through the fallback decode path."""
+        response = Mock()
+        response.json.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "stub")
+        response.content = (
+            b'[{"id": 106796340, "name": "Insolation ' + bytes([0xE9]) + b'", "category": "NOTE"}]'
+        )
+        mock_session.get.return_value = response
+
+        events = client.get_events(oldest="2026-04-01", newest="2026-04-30")
+        assert events[0]["id"] == 106796340
+        assert events[0]["category"] == "NOTE"
+        assert events[0]["name"].startswith("Insolation ")


### PR DESCRIPTION
## Summary

Intervals.icu occasionally returns responses whose body contains a raw Latin-1 byte (notably `0xE9` for `é`) in user-authored fields like notes or descriptions, even though the `Content-Type` header advertises UTF-8. Calling `response.text` or `response.json()` then raises `UnicodeDecodeError` before any handler sees the data, crashing the MCP tool.

The crash is **sticky**: any subsequent call that reads the same byte range will keep failing until the offending note is edited or removed on Intervals.icu — making the workaround painful for users hitting it.

## Reproduction

A beta-tester running the PyInstaller bundle was adjusting a week of training plan when `update-remote-event` started failing with a `UnicodeDecodeError` around position 7529 of an API response. Root cause: a NOTE event whose description contained an `é` typed directly through the Intervals.icu UI.

## Fix

Two module-level helpers in `magma_cycling/api/intervals_client.py`:

```python
def _safe_text(response):
    try:
        return response.text
    except UnicodeDecodeError:
        return response.content.decode("utf-8", errors="replace")

def _safe_json(response):
    try:
        return response.json()
    except UnicodeDecodeError:
        return _json.loads(response.content.decode("utf-8", errors="replace"))
```

All 14 `response.json()` and 4 `response.text` call sites are routed through these helpers. Behaviour on clean UTF-8 responses is **unchanged** (passthrough), so existing tests and callers are unaffected.

## Changes

- `magma_cycling/api/intervals_client.py`: add `_safe_text` + `_safe_json` helpers; replace 18 direct call sites; preserve original behaviour for clean payloads.
- `tests/api/test_intervals_client.py`: new `TestSafeDecodeHelpers` class with 5 cases (passthrough × 2, fallback × 2, end-to-end smoke through `client.get_events`).

## Test plan

- [x] Local: `pytest tests/api/test_intervals_client.py -x` (21/21 passed)
- [ ] CI: lint + tests on PR