### PR TITLE
fix(health): log probe failures instead of swallowing them silently

### DIFF
--- a/magma_cycling/health/factory.py
+++ b/magma_cycling/health/factory.py
@@ -28,8 +28,8 @@ def create_health_provider() -> HealthProvider:
         if config.is_configured():
             client = create_withings_client()
             return WithingsProvider(client)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Withings provider probe failed: %s", e)
 
     # 2. Try Intervals.icu wellness (Garmin/other watch).
     # Probe a 7-day window (not just yesterday) so that a single missing day
@@ -49,8 +49,8 @@ def create_health_provider() -> HealthProvider:
 
             logger.info("Using IntervalsHealthProvider (sleep data found in last 7 days)")
             return IntervalsHealthProvider(client)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning("Intervals provider probe failed: %s", e)
 
     # 3. Fallback
     from magma_cycling.health.null_provider import NullProvider

--- a/tests/health/test_factory.py
+++ b/tests/health/test_factory.py
@@ -36,6 +36,50 @@ class TestCreateHealthProvider:
         assert isinstance(provider, NullProvider)
 
 
+class TestSilentExceptionLogging:
+    """Probe failures must be logged at WARNING level so the cause of an
+    unexpected NullProvider fallback is recoverable from the MCP log,
+    instead of being swallowed by a silent `except Exception: pass`."""
+
+    def _withings_unconfigured(self):
+        cfg = Mock()
+        cfg.is_configured.return_value = False
+        return cfg
+
+    def test_withings_probe_exception_is_logged(self, caplog):
+        """A raised exception during the Withings probe must produce a
+        WARNING log entry, not a silent fallthrough."""
+        import logging
+
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                side_effect=RuntimeError("withings config broken"),
+            ),
+            caplog.at_level(logging.WARNING, logger="magma_cycling.health.factory"),
+        ):
+            create_health_provider()
+        assert any("Withings provider probe failed" in r.message for r in caplog.records)
+
+    def test_intervals_probe_exception_is_logged(self, caplog):
+        """A raised exception during the Intervals probe must produce a
+        WARNING log entry, not a silent fallthrough."""
+        import logging
+
+        client = Mock()
+        client.get_wellness.side_effect = RuntimeError("api timeout")
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                return_value=self._withings_unconfigured(),
+            ),
+            patch("magma_cycling.config.create_intervals_client", return_value=client),
+            caplog.at_level(logging.WARNING, logger="magma_cycling.health.factory"),
+        ):
+            create_health_provider()
+        assert any("Intervals provider probe failed" in r.message for r in caplog.records)
+
+
 class TestIntervalsHealthProviderProbeWindow:
     """The Intervals provider probe must accept any sleep entry within a 7-day
     window. A single missing day (late Garmin sync, day off, weekend without


### PR DESCRIPTION
## Summary

`create_health_provider()` swallowed every exception from the Withings and Intervals probes via `except Exception: pass`. When a beta-tester ended up with `NullProvider` despite valid wellness data, there was no way to recover the underlying cause from the MCP log — the exception was simply gone.

## Fix

Replace `pass` with `logger.warning("... probe failed: %s", e)` in both probe blocks. Behaviour is **unchanged**: the factory still falls back to `NullProvider` on any exception. Only the log now contains a recoverable trace of what went wrong (timeout, 401, parse error, etc.).

## Why this matters

Companion to the probe-window widening (PR merged separately). If a future `NullProvider` fallback persists despite that fix, the WARNING log entry will tell us exactly which probe failed and why — instead of the silent void we had until now.

## Changes

- `magma_cycling/health/factory.py`: `pass` → `logger.warning("... probe failed: %s", e)` for both Withings and Intervals probes.
- `tests/health/test_factory.py`: new `TestSilentExceptionLogging` class with 2 cases (Withings probe exception logged, Intervals probe exception logged).

## Test plan

- [x] Local: `pytest tests/health/test_factory.py -x` (10/10 passed)
- [ ] CI: lint + tests on PR