### PR TITLE
fix(mcp): update-remote-event rejects workout_doc with actionable message

### DIFF
--- a/magma_cycling/_mcp/handlers/remote_events.py
+++ b/magma_cycling/_mcp/handlers/remote_events.py
@@ -193,6 +193,31 @@ async def handle_update_remote_event(args: dict) -> list[TextContent]:
     event_id = args["event_id"]
     updates = args["updates"]
 
+    # Pre-check: fields known to be rejected by Intervals.icu's PUT /events
+    # endpoint (returns 400 "JSON parse error" with no useful detail). Reject
+    # early with an actionable message instead of letting the silent failure
+    # surface as "Failed to update event <id>" with no clue for the caller.
+    _UNSUPPORTED_UPDATE_FIELDS = {
+        "workout_doc": (
+            "structured workout content is not editable through update-remote-event; "
+            "use modify-session-details to change the workout, then "
+            "sync-week-to-calendar to push it to Intervals.icu"
+        ),
+    }
+    for _field, _reason in _UNSUPPORTED_UPDATE_FIELDS.items():
+        if _field in updates:
+            return mcp_response(
+                {
+                    "success": False,
+                    "event_id": event_id,
+                    "rejected_field": _field,
+                    "reason": _reason,
+                    "message": (
+                        f"❌ field '{_field}' not supported by update-remote-event — " f"{_reason}"
+                    ),
+                }
+            )
+
     try:
         with suppress_stdout_stderr():
             target_week_id = None

--- a/tests/_mcp/handlers/test_remote_events.py
+++ b/tests/_mcp/handlers/test_remote_events.py
@@ -303,6 +303,38 @@ class TestHandleUpdateRemoteEvent:
         assert "error" in data
         assert "completed" in data["error"].lower() or "COMPLETED" in data.get("message", "")
 
+    @pytest.mark.asyncio
+    async def test_workout_doc_field_rejected_with_actionable_message(self):
+        """Reject `workout_doc` early with a clear, actionable message
+        before hitting the Intervals.icu API (which rejects with an opaque
+        400 'JSON parse error'). Suggested workaround documented in the
+        response so the caller can self-recover."""
+        result = await handle_update_remote_event(
+            {
+                "event_id": 105661265,
+                "updates": {"workout_doc": "warmup\n3 ramp...\nmain\n25 46 50 90"},
+            }
+        )
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["rejected_field"] == "workout_doc"
+        assert "modify-session-details" in data["reason"]
+        assert "modify-session-details" in data["message"]
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_workout_doc_check_runs_before_api_call(self, mock_factory):
+        """The pre-check must short-circuit BEFORE create_intervals_client is
+        invoked — no network round-trip for a request we already know will
+        fail."""
+        result = await handle_update_remote_event(
+            {"event_id": 42, "updates": {"workout_doc": "warmup\nmain\ncooldown"}}
+        )
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert data["rejected_field"] == "workout_doc"
+        mock_factory.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # handle_create_remote_note


### PR DESCRIPTION
## Summary

Reported on v3.24.5 — `update-remote-event` with `updates.workout_doc=...` fails with the opaque message `❌ Failed to update event <id>` and no further detail. Workaround required 3 calls (`modify-session-details` + `validate-workout` + `sync-week-to-calendar`) but nothing in the response told the caller to do that.

Root cause: the Intervals.icu PUT `/events` endpoint rejects `workout_doc` payloads with `400 'JSON parse error'`. The MCP `update_event` client logs the detail but converts the failure to `None`, and the handler surfaces only the generic message.

## Fix

Pre-check `updates` for fields known to be rejected by the upstream API and short-circuit with an actionable response **before** the network round-trip:

```json
{
  "success": false,
  "event_id": 105661265,
  "rejected_field": "workout_doc",
  "reason": "structured workout content is not editable through update-remote-event; use modify-session-details to change the workout, then sync-week-to-calendar to push it to Intervals.icu",
  "message": "❌ field 'workout_doc' not supported by update-remote-event — ..."
}
```

Only `workout_doc` is hard-coded for now. A broader refactor (declaring an explicit allow-list of update fields, or propagating API error detail from `update_event` to the caller) is out of scope here.

## Changes

- `magma_cycling/_mcp/handlers/remote_events.py:handle_update_remote_event`: pre-check `_UNSUPPORTED_UPDATE_FIELDS` map, fail-fast with `rejected_field` + `reason` payload before the API call.
- `tests/_mcp/handlers/test_remote_events.py`: 2 new cases — actionable message content + pre-check ordering (`create_intervals_client` is never invoked when the field is rejected).

## Test plan

- [x] Local: `pytest tests/_mcp/handlers/test_remote_events.py::TestHandleUpdateRemoteEvent -x` (5/5 passed)
- [ ] CI: lint + tests on PR