### PR TITLE
fix(ci): allow MCP_SKIP_STARTUP_HEALTH_CHECK=1 to bypass health check

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -56,6 +56,12 @@ jobs:
         run: dist/magma-cycling --version
 
       - name: "Smoke test: mcp-server (timeout 5s)"
+        env:
+          # Skip the data-repo startup health-check on the CI runner — it has
+          # no ~/training-logs/workouts-history.md, so the check would
+          # sys.exit(1) and the smoke test would falsely fail. Production
+          # deployments must NOT set this variable.
+          MCP_SKIP_STARTUP_HEALTH_CHECK: "1"
         run: |
           dist/magma-cycling mcp-server &
           PID=$!

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -50,6 +50,12 @@ jobs:
 
       - name: "Smoke test: mcp-server (timeout 5s)"
         shell: pwsh
+        env:
+          # Skip the data-repo startup health-check on the CI runner — it has
+          # no ~/training-logs/workouts-history.md, so the check would
+          # sys.exit(1) and the smoke test would falsely fail. Production
+          # deployments must NOT set this variable.
+          MCP_SKIP_STARTUP_HEALTH_CHECK: "1"
         run: |
           $proc = Start-Process -FilePath "dist\magma-cycling.exe" -ArgumentList "mcp-server" -PassThru -NoNewWindow
           Start-Sleep -Seconds 5

--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -183,7 +183,7 @@ def _git_head_short(path: Path) -> str | None:
     return None
 
 
-def startup_health_check() -> DataRepoConfig:
+def startup_health_check() -> DataRepoConfig | None:
     """Fail-fast startup health-check pour le serveur MCP.
 
     Validation à BOOT (vs lazy au 1er tool call) :
@@ -198,10 +198,23 @@ def startup_health_check() -> DataRepoConfig:
     En cas de succès, log INFO avec le path résolu, la taille de
     ``workouts-history.md`` et le SHA HEAD git si applicable.
 
+    The ``MCP_SKIP_STARTUP_HEALTH_CHECK=1`` env var skips the validation and
+    returns ``None`` — used by the PyInstaller smoke tests in CI where there
+    is no training-logs repo on the runner. Production deployments must NOT
+    set this variable.
+
     Returns:
         DataRepoConfig validé (peut être ré-utilisé par le caller pour éviter
-        une 2e instanciation).
+        une 2e instanciation), ou ``None`` si le check est skipped.
     """
+    if os.getenv("MCP_SKIP_STARTUP_HEALTH_CHECK", "").lower() in ("1", "true", "yes"):
+        logger.warning(
+            "data_repo_health_skipped: MCP_SKIP_STARTUP_HEALTH_CHECK=%s "
+            "(intended for PyInstaller smoke tests; do NOT set in production)",
+            os.getenv("MCP_SKIP_STARTUP_HEALTH_CHECK"),
+        )
+        return None
+
     try:
         cfg = DataRepoConfig()
         cfg.validate()

--- a/tests/config/test_data_repo_startup_health.py
+++ b/tests/config/test_data_repo_startup_health.py
@@ -76,6 +76,31 @@ class TestStartupHealthCheck:
             history.chmod(0o644)
 
 
+class TestSkipEnvVar:
+    """`MCP_SKIP_STARTUP_HEALTH_CHECK=1` bypasses the check entirely.
+
+    Used by the PyInstaller smoke tests on CI runners that have no
+    `~/training-logs/` repo. Production deployments must not set it.
+    """
+
+    def test_skip_env_returns_none_without_validation(self, tmp_path, monkeypatch, caplog):
+        # No TRAINING_DATA_REPO set, no repo on disk — would normally fail
+        monkeypatch.setenv("MCP_SKIP_STARTUP_HEALTH_CHECK", "1")
+        monkeypatch.delenv("TRAINING_DATA_REPO", raising=False)
+        reset_data_config()
+        with caplog.at_level(logging.WARNING, logger="magma_cycling.config.data_repo"):
+            result = startup_health_check()
+        assert result is None
+        assert any("data_repo_health_skipped" in r.message for r in caplog.records)
+
+    def test_skip_env_false_value_does_not_skip(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("MCP_SKIP_STARTUP_HEALTH_CHECK", "0")
+        monkeypatch.setenv("TRAINING_DATA_REPO", str(tmp_path / "nonexistent"))
+        reset_data_config()
+        with pytest.raises(SystemExit):
+            startup_health_check()
+
+
 class TestGitHeadShort:
     def test_returns_none_for_non_git_dir(self, tmp_path):
         assert _git_head_short(tmp_path) is None


### PR DESCRIPTION
## Summary

Hotfix for **v3.25.0** — the PyInstaller Windows + macOS builds failed on the post-build smoke test:

```
Build Windows EXE / Build magma-cycling.exe / Smoke test: mcp-server (timeout 5s) — FAILED
Build macOS Binary / Build magma-cycling (arm64) / Smoke test: mcp-server (timeout 5s) — FAILED
Build macOS Binary / Build magma-cycling (x86_64) / Smoke test: mcp-server (timeout 5s) — FAILED
```

Root cause: PR #298 added `startup_health_check()` which `sys.exit(1)`s when `TRAINING_DATA_REPO/workouts-history.md` is missing — a perfectly correct behaviour for production deployments, but CI runners have no `~/training-logs/`, so the smoke test (`magma-cycling.exe mcp-server` + sleep 5) sees the process exit immediately with code 1 and fails.

The Docker image build (which doesn't run the smoke test) and the macOS App Bundle build succeeded. Only the PyInstaller bundles are broken — meaning beta-testers cannot upgrade past v3.24.5 until this is fixed.

## Fix

Add an explicit opt-out env var `MCP_SKIP_STARTUP_HEALTH_CHECK=1` that makes `startup_health_check()` return `None` after a `WARNING` log line. Set it on both `build-windows.yml` and `build-macos.yml` smoke-test steps.

**Production deployments must NOT set this variable.** The WARNING line is loud enough to spot on a misconfigured deployment.

## Changes

- `magma_cycling/config/data_repo.py`: add the env var bypass + warning log; signature now `-> DataRepoConfig | None`.
- `.github/workflows/build-windows.yml`: set `MCP_SKIP_STARTUP_HEALTH_CHECK: "1"` on the smoke-test step.
- `.github/workflows/build-macos.yml`: same.
- `tests/config/test_data_repo_startup_health.py`: 2 new cases in `TestSkipEnvVar` (env=1 returns None + warning, env=0 still validates).

## Test plan

- [x] Local: `pytest tests/config/test_data_repo_startup_health.py -x` (8/8 passed)
- [ ] CI: lint + tests on PR
- [ ] CI: build-windows + build-macos must pass on the next release tag.