### PR TITLE
chore(system-info): fix tool_count drift (54 -> 60) via len(TOOL_HANDLERS)

### DIFF
--- a/magma_cycling/_mcp/handlers/admin.py
+++ b/magma_cycling/_mcp/handlers/admin.py
@@ -102,34 +102,15 @@ async def handle_system_info(args: dict) -> list[TextContent]:
         except Exception:
             pass
 
-        # Tool count
+        # Tool count — single source of truth = TOOL_HANDLERS (qu'on dispatche
+        # en runtime). L'ancienne implémentation re-listait 10 schemas et
+        # oubliait `terrain` (4) + `handoff` (2), retournant 54 au lieu de 60.
+        # Avec TOOL_HANDLERS on a une garantie : ce que system-info compte
+        # est ce que le serveur peut réellement exécuter.
         try:
-            from magma_cycling._mcp.schemas import admin as _s_admin
-            from magma_cycling._mcp.schemas import analysis as _s_analysis
-            from magma_cycling._mcp.schemas import athlete as _s_athlete
-            from magma_cycling._mcp.schemas import catalog as _s_catalog
-            from magma_cycling._mcp.schemas import health as _s_health
-            from magma_cycling._mcp.schemas import planning as _s_planning
-            from magma_cycling._mcp.schemas import remote as _s_remote
-            from magma_cycling._mcp.schemas import rest as _s_rest
-            from magma_cycling._mcp.schemas import sessions as _s_sessions
-            from magma_cycling._mcp.schemas import workouts as _s_workouts
+            from magma_cycling.mcp_server import TOOL_HANDLERS
 
-            tool_count = sum(
-                len(mod.get_tools())
-                for mod in (
-                    _s_planning,
-                    _s_sessions,
-                    _s_workouts,
-                    _s_remote,
-                    _s_athlete,
-                    _s_analysis,
-                    _s_admin,
-                    _s_catalog,
-                    _s_health,
-                    _s_rest,
-                )
-            )
+            tool_count = len(TOOL_HANDLERS)
         except Exception:
             tool_count = -1
 

--- a/tests/_mcp/handlers/test_admin.py
+++ b/tests/_mcp/handlers/test_admin.py
@@ -54,3 +54,23 @@ class TestHandleReloadServer:
         data = json.loads(result[0].text)
         assert "note" in data
         assert "NOT reloaded" in data["note"]
+
+
+class TestHandleSystemInfoToolCount:
+    """tool_count est aligné avec TOOL_HANDLERS (single source of truth)."""
+
+    @pytest.mark.asyncio
+    async def test_tool_count_matches_handlers(self):
+        """`tool_count` retourné == `len(TOOL_HANDLERS)` — pas de drift possible.
+
+        Régression : avant le fix, system-info re-listait 10 schemas et
+        oubliait `terrain` + `handoff`, retournant 54 alors que TOOL_HANDLERS
+        en contient 60. Ce test pin l'invariant : ce que system-info compte
+        doit être exactement ce que le serveur peut dispatcher.
+        """
+        from magma_cycling._mcp.handlers.admin import handle_system_info
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        result = await handle_system_info({})
+        data = json.loads(result[0].text)
+        assert data["tool_count"] == len(TOOL_HANDLERS)


### PR DESCRIPTION
## Summary

Fixes the discrepancy between `system-info` `tool_count: 54` and the actual number of tools registered in the server (60).

The previous implementation in `magma_cycling/_mcp/handlers/admin.py` re-imported 10 schema modules and summed `len(mod.get_tools())`, but the tuple **omitted `terrain` (4 tools) + `handoff` (2 tools)** — explaining the 60 → 54 drift exactly.

## Fix

Drop the 10-module re-import and replace by `len(TOOL_HANDLERS)` from `mcp_server.py` — single source of truth. Any new schema module added in the future is automatically reflected, no risk of repeating the drift.

## Changes

- `magma_cycling/_mcp/handlers/admin.py`: replace 10-module sum by `len(TOOL_HANDLERS)`. Keep the `try/except → -1` fallback for robustness.
- `tests/_mcp/handlers/test_admin.py`: new regression test `test_tool_count_matches_handlers` pinning the invariant `tool_count == len(TOOL_HANDLERS)`.

## Test plan

- [x] Local: `pytest tests/_mcp/handlers/test_admin.py -x` (6/6 passed)
- [ ] CI: lint + tests on PR