### PR TITLE
fix(mcp): system-info ai_providers uses AIConfig.get_available_providers

### DIFF
--- a/magma_cycling/_mcp/handlers/admin.py
+++ b/magma_cycling/_mcp/handlers/admin.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "handle_reload_server",
@@ -87,20 +90,29 @@ async def handle_system_info(args: dict) -> list[TextContent]:
         except Exception as e:
             calendar_info = {"provider": "unavailable", "status": "error", "error": str(e)}
 
-        # AI providers (list configured ones)
+        # AI providers (list configured ones).
+        #
+        # Bug d'origine : l'ancienne implémentation appelait
+        # ``AIProviderFactory.create(provider_name)`` avec **un seul argument**
+        # alors que la signature exige ``(provider: str, config: dict)``. Chaque
+        # itération levait ``TypeError: create() missing 1 required positional
+        # argument: 'config'`` qui était avalée par le ``except Exception: pass``
+        # silencieux — d'où ``ai_providers: []`` constant alors que Mistral est
+        # démontrablement actif en prod (``daily-sync`` 27/04 écrit
+        # ``ai_provider: MistralAPIAnalyzer``, ``get-coach-analysis`` produit
+        # des analyses Mistral).
+        #
+        # Fix : utiliser ``AIConfig.get_available_providers()`` qui retourne
+        # directement la liste des providers configurés (mêmes paths que
+        # ``daily_sync.py:150-155`` qui fonctionne en prod). Plus de probe via
+        # Factory à 1 arg manquant, plus de TypeError silenced.
         ai_info: list[str] = []
         try:
-            from magma_cycling.ai_providers.factory import AIProviderFactory
+            from magma_cycling.config import get_ai_config
 
-            for provider_name in ("claude_api", "mistral_api", "ollama"):
-                try:
-                    analyzer = AIProviderFactory.create(provider_name)
-                    if analyzer.validate_config():
-                        ai_info.append(provider_name)
-                except Exception:
-                    pass
-        except Exception:
-            pass
+            ai_info = get_ai_config().get_available_providers()
+        except Exception as e:
+            logger.warning("ai_provider discovery failed: %s", e)
 
         # Tool count — single source of truth = TOOL_HANDLERS (qu'on dispatche
         # en runtime). L'ancienne implémentation re-listait 10 schemas et

--- a/tests/_mcp/handlers/test_admin.py
+++ b/tests/_mcp/handlers/test_admin.py
@@ -2,7 +2,7 @@
 
 import json
 import types
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -74,3 +74,48 @@ class TestHandleSystemInfoToolCount:
         result = await handle_system_info({})
         data = json.loads(result[0].text)
         assert data["tool_count"] == len(TOOL_HANDLERS)
+
+
+class TestHandleSystemInfoAIProvidersDiscovery:
+    """ai_providers utilise AIConfig.get_available_providers (single source).
+
+    Régression du bug d'origine : ``AIProviderFactory.create(name)`` était
+    appelé avec un seul argument alors que la signature exige
+    ``(provider, config)``, levant ``TypeError`` silencieusement avalée par
+    ``except Exception: pass`` → ``ai_providers: []`` constant en prod.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_ai_config_get_available_providers(self):
+        """Le retour ai_providers vient de get_ai_config().get_available_providers()."""
+        from magma_cycling._mcp.handlers.admin import handle_system_info
+
+        fake_config = MagicMock()
+        fake_config.get_available_providers.return_value = ["mistral_api", "claude_api"]
+
+        with patch("magma_cycling.config.get_ai_config", return_value=fake_config):
+            result = await handle_system_info({})
+
+        data = json.loads(result[0].text)
+        assert data["ai_providers"] == ["mistral_api", "claude_api"]
+        fake_config.get_available_providers.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_discovery_failure_logs_warning_and_returns_empty(self, caplog):
+        """Si get_ai_config() raise, log warning et retourne []."""
+        import logging
+
+        from magma_cycling._mcp.handlers.admin import handle_system_info
+
+        with patch(
+            "magma_cycling.config.get_ai_config",
+            side_effect=RuntimeError("simulated config failure"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="magma_cycling._mcp.handlers.admin"):
+                result = await handle_system_info({})
+
+        data = json.loads(result[0].text)
+        assert data["ai_providers"] == []
+        warnings = [r for r in caplog.records if "ai_provider discovery failed" in r.message]
+        assert len(warnings) == 1
+        assert "simulated config failure" in warnings[0].message


### PR DESCRIPTION
## Summary

Real root-cause fix for `system-info.ai_providers: []` (incoherence surfaced during a J3 debate session post-S091, 2026-04-29).

PR #303 merged yesterday only added a `logger.warning` to surface the silent `except Exception: pass`. Once the warning was active, the underlying cause was identified:

> `AIProviderFactory.create(provider_name)` is called with **one positional argument** in `admin.py:97`, but the signature requires `(provider: str, config: dict)`. Each iteration raised `TypeError: create() missing 1 required positional argument: 'config'` which was swallowed silently — hence `ai_providers: []` constant despite Mistral being demonstrably active in production (`daily-sync` returns `ai_provider: MistralAPIAnalyzer`, `get-coach-analysis` produces Mistral analyses).

## Fix

Replace the broken Factory probe loop by a direct call to `AIConfig.get_available_providers()` — same code path used by `daily_sync.py:150-155` which works in production. Single source of truth, no more `TypeError` masking.

## Changes

- `magma_cycling/_mcp/handlers/admin.py`: `ai_info = get_ai_config().get_available_providers()` instead of the 3-iteration Factory probe with wrong arity. Failure mode now produces a `WARNING` log (kept from PR #303) rather than silent emptiness.
- `tests/_mcp/handlers/test_admin.py`: 2 new regression cases — `test_uses_ai_config_get_available_providers` (positive path), `test_discovery_failure_logs_warning_and_returns_empty` (negative path with WARNING assertion).

## Test plan

- [x] Local: `pytest tests/_mcp/handlers/test_admin.py -x` (8/8 passed, +2 new)
- [x] Rebase clean on main: `tool_count = len(TOOL_HANDLERS)` from PR #302 preserved (verified by grep + tests)
- [ ] CI: lint + tests on PR
- [ ] Validate on preprod after next deploy: `system-info` should now return the real list (e.g. `["mistral_api"]`) instead of `[]`.
