### PR TITLE
fix(scripts): setup-withings redact OAuth URL via outillages helper

### DIFF
--- a/magma_cycling/scripts/setup_withings.py
+++ b/magma_cycling/scripts/setup_withings.py
@@ -38,7 +38,10 @@ import os
 import sys
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse
+
+from outillages.oauth import redact_url_secrets
 
 from magma_cycling.config import create_withings_client, get_withings_config
 from magma_cycling.utils.cli import cli_main
@@ -287,16 +290,52 @@ def main():
         print(f"\n❌ Error generating URL: {e}")
         sys.exit(1)
 
+    # Stdout never sees the full URL (it leaks `client_id` etc.). Write the
+    # full URL to a 600-mode file under the user's cache so they can open it
+    # manually if the browser fails to auto-open. An atexit handler cleans
+    # the file up at process exit (success, sys.exit, or KeyboardInterrupt).
+    oauth_url_file = Path.home() / ".cache" / "magma-cycling" / "oauth_url.txt"
+    try:
+        oauth_url_file.parent.mkdir(parents=True, exist_ok=True)
+        oauth_url_file.write_text(auth_url, encoding="utf-8")
+        oauth_url_file.chmod(0o600)
+    except OSError as e:
+        print(f"   ⚠ Could not write {oauth_url_file}: {e} — continuing anyway")
+        oauth_url_file = None
+
+    if oauth_url_file is not None:
+        import atexit
+
+        def _cleanup_oauth_url_file(path=oauth_url_file):
+            try:
+                if path.exists():
+                    path.unlink()
+            except OSError:
+                pass
+
+        atexit.register(_cleanup_oauth_url_file)
+
     # Open browser
     print("\n4. Opening browser for authorization...")
-    print(f"   URL: {auth_url}")
+    print(f"   URL (redacted): {redact_url_secrets(auth_url)}")
+    if oauth_url_file is not None:
+        print(f"   Full URL (read-only to you, chmod 600) → {oauth_url_file}")
 
     try:
         webbrowser.open(auth_url)
         print("   ✓ Browser opened")
     except Exception as e:
         print(f"\n⚠️  Could not open browser automatically: {e}")
-        print(f"\nPlease manually visit:\n{auth_url}\n")
+        if oauth_url_file is not None:
+            print(f"\nPlease manually visit the URL stored in {oauth_url_file}.")
+            print("   You can copy it to your browser address bar with:")
+            print(f"     cat {oauth_url_file} | pbcopy   # macOS")
+            print("     # then ⌘V into your browser")
+        else:
+            print(f"\nPlease manually visit (redacted): {redact_url_secrets(auth_url)}")
+            print(
+                "   (full URL not persisted to disk — see logs of magma_cycling.api.withings.oauth)"
+            )
 
     # Start callback server
     print("\n5. Waiting for authorization...")

--- a/tests/scripts/test_setup_withings_url_redaction.py
+++ b/tests/scripts/test_setup_withings_url_redaction.py
@@ -1,0 +1,81 @@
+"""Non-regression tests: setup_withings.py must never print the raw OAuth URL.
+
+Background
+----------
+On 2026-05-01, ``print(f"   URL: {auth_url}")`` at line 292 of
+``setup_withings.py`` exposed the Withings preprod ``CLIENT_ID`` in the
+Bash output of an automated session. Although ``CLIENT_ID`` alone is
+semi-public (it appears in any OAuth flow's browser address bar), printing
+it in stdout/log persistents was identified as a source-code-level pattern
+to harden structurally. The fix routes every print of the URL through
+``outillages.oauth.redact_url_secrets`` and writes the full URL to a
+``chmod 600`` file (``~/.cache/magma-cycling/oauth_url.txt``) for the rare
+case where the user must open it manually.
+
+These tests are static checks on the source file. They will fail if a
+future refactor reintroduces a raw ``print(... auth_url ...)`` without the
+redaction helper.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "magma_cycling" / "scripts" / "setup_withings.py"
+
+
+def test_imports_redact_url_secrets_from_outillages():
+    """The hardened version must import the redaction helper."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert "from outillages.oauth import redact_url_secrets" in src, (
+        "setup_withings.py must import redact_url_secrets — regression of the "
+        "2026-05-01 OAuth URL leak fix."
+    )
+
+
+def test_does_not_print_raw_auth_url_in_url_label():
+    """The original line `print(f"   URL: {auth_url}")` is forbidden."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    forbidden = 'print(f"   URL: {auth_url}")'
+    assert forbidden not in src, (
+        f"Forbidden pattern still present: {forbidden!r}. "
+        "Use redact_url_secrets(auth_url) instead."
+    )
+
+
+def test_does_not_print_raw_auth_url_in_manual_visit_fallback():
+    """The original fallback line printing the raw URL is forbidden."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    forbidden = 'print(f"\\nPlease manually visit:\\n{auth_url}\\n")'
+    assert forbidden not in src, (
+        f"Forbidden pattern still present: {forbidden!r}. "
+        "Use redact_url_secrets(auth_url) or the oauth_url_file pointer."
+    )
+
+
+def test_uses_redact_url_secrets_at_least_once():
+    """Positive: redact_url_secrets must actually be called on auth_url."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert (
+        "redact_url_secrets(auth_url)" in src
+    ), "redact_url_secrets must be applied to auth_url before printing."
+
+
+def test_full_url_written_to_user_cache_file():
+    """Positive: the full URL is persisted to a user-cache file (chmod 600)."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert 'oauth_url_file = Path.home() / ".cache" / "magma-cycling" / "oauth_url.txt"' in src, (
+        "Expected the full URL to be persisted to ~/.cache/magma-cycling/oauth_url.txt "
+        "as a fallback for manual browser open."
+    )
+    assert (
+        "oauth_url_file.chmod(0o600)" in src
+    ), "Expected oauth_url_file.chmod(0o600) for owner-only readability."
+
+
+def test_atexit_cleanup_registered():
+    """Positive: an atexit handler must clean up the URL file at process exit."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    assert (
+        "atexit.register" in src
+    ), "Expected atexit.register(...) to clean up the oauth_url_file at process exit."


### PR DESCRIPTION
## Summary

Hardens `setup_withings.py` against the 2026-05-01 incident where `print(f"   URL: {auth_url}")` (line 292) exposed the Withings preprod `CLIENT_ID` in the Bash output of an automated agent session.

Although `CLIENT_ID` alone is semi-public (visible in any browser address bar during a normal OAuth flow), printing it in persistent stdout/log was identified as a structural pattern to fix at source, not just at the agent-runtime rule level. Future agents launching the script — including in non-TTY backgrounds — can no longer leak the value.

## Fix

- Import `redact_url_secrets` from outillages (helper merged in outillages PR #49).
- Replace the two `print(... auth_url ...)` lines with the redacted version (`<param>=<REDACTED>` for `client_id`, `code`, `state`, tokens).
- Persist the full URL to `~/.cache/magma-cycling/oauth_url.txt` (chmod 600), readable only by the user. Fallback for the rare case where `webbrowser.open` fails and the user must paste the URL manually.
- `atexit.register` a cleanup handler so the file is removed at process exit (success, `sys.exit`, `KeyboardInterrupt`).

## Changes

- `magma_cycling/scripts/setup_withings.py`: imports + new file-fallback block + redacted prints.
- `tests/scripts/test_setup_withings_url_redaction.py`: 6 static non-regression tests on the source file (forbid raw `print(... auth_url ...)`, require helper import + use, require user-cache file + chmod 600, require atexit cleanup).

## Why static tests

`setup_withings.py` is a heavily interactive script (browser, HTTP callback server on port 8080, exchange code for tokens). Functional tests require mocking `webbrowser`, `HTTPServer`, network roundtrips. The static tests check the **structure** of the source file, which is exactly what we want to protect: a future refactor that reintroduces a raw `print(auth_url)` will fail CI immediately, regardless of whether the rest of the runtime works.

## Test plan

- [x] Local: `pytest tests/scripts/test_setup_withings_url_redaction.py -x` (6/6 passed)
- [ ] CI: lint + tests on PR
- [ ] Manual validation by Stéphane on the next setup-withings flow (preprod and/or prod): URL stdout shows `<REDACTED>`, `~/.cache/magma-cycling/oauth_url.txt` exists during the flow and is removed at exit.

## Dependencies

- outillages PR #49 (`outillages.oauth.redact_url_secrets`) merged 2026-05-01 19:59 UTC. Already in `~/Projects/outillages/main` and reinstalled in the magma-cycling venv before this PR.