### PR TITLE
fix(daily-sync): tolerate description=None in servo evaluation (B1)

### DIFF
--- a/magma_cycling/workflows/sync/servo_evaluation.py
+++ b/magma_cycling/workflows/sync/servo_evaluation.py
@@ -215,7 +215,9 @@ class ServoEvaluationMixin:
                 return True
 
         # Criterion 3: Keywords in notes/description
-        description = activity.get("description", "").lower()
+        # `or ""` gère le cas Intervals.icu renvoyant `description: null`
+        # (la clé existe mais vaut None — `.get(default)` ne couvre que l'absence).
+        description = (activity.get("description") or "").lower()
         keywords = [
             "accompagnement",
             "accompagner",

--- a/tests/workflows/sync/test_servo_evaluation_social_ride.py
+++ b/tests/workflows/sync/test_servo_evaluation_social_ride.py
@@ -1,0 +1,71 @@
+"""Non-regression tests: _is_low_effort_social_ride must accept None description.
+
+Background
+----------
+On 2026-04-26 21:30, ``daily-sync`` started crashing with
+``AttributeError: 'NoneType' object has no attribute 'lower'`` at
+``servo_evaluation.py:218``. Root cause: Intervals.icu may return
+``description: null`` in its activity payload. ``dict.get(key, default)``
+returns ``default`` only when the key is absent — when the key is present
+with value ``None``, ``.get()`` returns ``None``, and the chained
+``.lower()`` then crashes.
+
+These tests pin the fix: ``_is_low_effort_social_ride`` must tolerate a
+``description=None`` value without crashing, and behave equivalently to
+an empty/missing description (i.e. no keyword match → returns False).
+"""
+
+from unittest.mock import MagicMock
+
+from magma_cycling.workflows.sync.servo_evaluation import ServoEvaluationMixin
+
+
+class _FakeSync(ServoEvaluationMixin):
+    def __init__(self):
+        self.client = MagicMock()
+        self.servo_criteria = {
+            "decoupling_threshold": 7.5,
+            "sleep_threshold_hours": 7.0,
+            "feel_threshold": 4,
+            "tsb_threshold": -10,
+        }
+
+
+def test_description_none_does_not_crash():
+    """Regression: activity with description=None must not raise."""
+    sync = _FakeSync()
+    activity = {
+        "icu_training_load": 20,
+        "average_watts": 100,
+        "np": 110,
+        "description": None,
+    }
+    # Must not raise AttributeError — and since no keyword matches, returns False.
+    assert sync._is_low_effort_social_ride(activity, metrics={}) is False
+
+
+def test_description_missing_key_does_not_crash():
+    """Coverage: missing key behaves like None (existing default-path).
+
+    Different code path than `description=None`, but must give the same result.
+    """
+    sync = _FakeSync()
+    activity = {
+        "icu_training_load": 20,
+        "average_watts": 100,
+        "np": 110,
+        # description key intentionally absent
+    }
+    assert sync._is_low_effort_social_ride(activity, metrics={}) is False
+
+
+def test_description_with_keyword_still_detects_social_ride():
+    """Positive: keyword detection still works after the fix."""
+    sync = _FakeSync()
+    activity = {
+        "icu_training_load": 20,
+        "average_watts": 100,
+        "np": 110,
+        "description": "Sortie d'accompagnement avec arrêts",
+    }
+    assert sync._is_low_effort_social_ride(activity, metrics={}) is True


### PR DESCRIPTION
## Contexte

`daily-sync` crashe depuis 2026-04-26 21:30 :

```
AttributeError: 'NoneType' object has no attribute 'lower'
  at magma_cycling/workflows/sync/servo_evaluation.py:218
```

Cause racine : `activity.get("description", "").lower()`. Intervals.icu peut renvoyer `description: null` (clé présente, valeur None). `dict.get(default)` ne couvre **que** l'absence de clé, pas la valeur None — donc `.get()` retourne None et `.lower()` plante.

Conséquence opérationnelle : plus aucun `daily-sync` ne tourne depuis cette date côté Mac LaunchAgent (qui était la source d'automation principale avant arrêt 20/04). Bug bloquant pour le portage MCP de `daily-sync` côté NAS si on ne le fixe pas en amont.

## Fix

`(activity.get("description") or "").lower()` — tolère absence de clé ET valeur None.

## Tests

3 tests régression dans `tests/workflows/sync/test_servo_evaluation_social_ride.py` :
- `test_description_none_does_not_crash` — pin du fix
- `test_description_missing_key_does_not_crash` — couverture chemin code default
- `test_description_with_keyword_still_detects_social_ride` — non-régression detection positive

## Test plan

- [x] `pytest tests/workflows/sync/test_servo_evaluation_social_ride.py` — 3/3 PASS
- [x] `pytest tests/workflows/sync/test_servo_evaluation_decoupling.py tests/workflows/test_servo_rest_day.py tests/workflows/test_servo_auto_rest.py` — 24/24 PASS (non-régression)
- [x] Pre-commit hooks tous green (black, ruff, isort, pydocstyle, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)