### PR TITLE
ci(workflows): add retag-stable workflow_dispatch

### DIFF
--- a/.github/workflows/retag-stable.yml
+++ b/.github/workflows/retag-stable.yml
@@ -1,0 +1,62 @@
+name: Retag stable
+
+# Promote an existing version tag (e.g. v3.25.5) to ":stable" on GHCR.
+#
+# Why: docker-publish.yml only emits :latest, :{version}, :{major}.{minor}.
+# The :stable tag follows a manual promotion workflow — only after the
+# corresponding image has been validated in preprod (see :stable→:latest
+# analysis ritual). This workflow performs the retag without requiring a
+# rebuild — it just rewrites the manifest pointer at the registry.
+#
+# Trigger: workflow_dispatch with `source_tag` input (e.g. "v3.25.5").
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_tag:
+        description: "Version tag to promote to :stable (e.g. v3.25.5)"
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag ${{ inputs.source_tag }} → :stable
+        run: |
+          set -eu
+          src="${REGISTRY}/${IMAGE_NAME}:${{ inputs.source_tag }}"
+          dst="${REGISTRY}/${IMAGE_NAME}:stable"
+          echo "Promoting ${src} → ${dst}"
+          docker buildx imagetools create -t "${dst}" "${src}"
+
+      - name: Verify :stable now points to ${{ inputs.source_tag }}
+        run: |
+          set -eu
+          src_digest=$(docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:${{ inputs.source_tag }}" --format '{{.Manifest.Digest}}')
+          dst_digest=$(docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:stable" --format '{{.Manifest.Digest}}')
+          echo "source digest: ${src_digest}"
+          echo "stable digest: ${dst_digest}"
+          if [ "${src_digest}" != "${dst_digest}" ]; then
+            echo "::error::Digest mismatch after retag"
+            exit 1
+          fi
+          echo "✓ :stable now points to ${{ inputs.source_tag }} (${dst_digest})"


### PR DESCRIPTION
## Contexte

`docker-publish.yml` émet automatiquement `:latest`, `:{version}` et `:{major}.{minor}` au push d'un tag `v*`. Le tag `:stable` n'est PAS produit — c'est un gate manuel de promotion, fait après validation preprod (rituel d'analyse `:stable→:latest`).

Aujourd'hui le retag se fait via `docker buildx imagetools create` depuis un poste local avec Docker installé. Big Sur (Mac dev) n'a pas Docker, donc à chaque promotion il faut faire la commande depuis une autre machine. Pas d'audit-trail.

## Solution

Workflow GHA `retag-stable.yml` déclenchable en `workflow_dispatch` avec input `source_tag` (ex. `v3.25.5`). Pas de rebuild — juste rewrite du manifest pointer côté registry.

Étape de vérification : compare le digest source vs `:stable` post-retag → erreur si mismatch silencieux.

## Test plan

- [x] Lint workflow YAML (pre-commit yaml check passed)
- [ ] Trigger workflow_dispatch avec `source_tag=v3.25.5` après merge → confirme `:stable` pointe vers v3.25.5

## Why now

Bloque le redeploy `:stable` prod demandé par Admin (msg 1745) pour shipping de v3.25.5 (49 commits, 5 fix BT critiques, INFRA-001 protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)