### PR TITLE
fix(ci): retag-stable workflow tolerates leading v in source_tag

### DIFF
--- a/.github/workflows/retag-stable.yml
+++ b/.github/workflows/retag-stable.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       source_tag:
-        description: "Version tag to promote to :stable (e.g. v3.25.5)"
+        description: "Version to promote to :stable. Both '3.25.5' and 'v3.25.5' are accepted (leading 'v' is stripped automatically)."
         required: true
         type: string
 
@@ -40,18 +40,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retag ${{ inputs.source_tag }} → :stable
+      - name: Normalize source_tag (strip leading "v" if present)
+        id: norm
         run: |
           set -eu
-          src="${REGISTRY}/${IMAGE_NAME}:${{ inputs.source_tag }}"
+          # docker-publish.yml tags images via {{version}} semver pattern,
+          # which strips the leading "v". Accept both "v3.25.5" and "3.25.5"
+          # as user input — strip the leading "v" once if present.
+          raw="${{ inputs.source_tag }}"
+          stripped="${raw#v}"
+          echo "Input: ${raw} → resolved: ${stripped}"
+          echo "tag=${stripped}" >> "${GITHUB_OUTPUT}"
+
+      - name: Retag ${{ steps.norm.outputs.tag }} → :stable
+        run: |
+          set -eu
+          src="${REGISTRY}/${IMAGE_NAME}:${{ steps.norm.outputs.tag }}"
           dst="${REGISTRY}/${IMAGE_NAME}:stable"
           echo "Promoting ${src} → ${dst}"
           docker buildx imagetools create -t "${dst}" "${src}"
 
-      - name: Verify :stable now points to ${{ inputs.source_tag }}
+      - name: Verify :stable now points to ${{ steps.norm.outputs.tag }}
         run: |
           set -eu
-          src_digest=$(docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:${{ inputs.source_tag }}" --format '{{.Manifest.Digest}}')
+          src_digest=$(docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:${{ steps.norm.outputs.tag }}" --format '{{.Manifest.Digest}}')
           dst_digest=$(docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:stable" --format '{{.Manifest.Digest}}')
           echo "source digest: ${src_digest}"
           echo "stable digest: ${dst_digest}"
@@ -59,4 +71,4 @@ jobs:
             echo "::error::Digest mismatch after retag"
             exit 1
           fi
-          echo "✓ :stable now points to ${{ inputs.source_tag }} (${dst_digest})"
+          echo "✓ :stable now points to ${{ steps.norm.outputs.tag }} (${dst_digest})"


### PR DESCRIPTION
## Contexte

Premier essai du workflow retag-stable (PR #306) en prod réel : run #1 fail avec `source_tag=v3.25.5` parce que l'image GHCR s'appelle en réalité `:3.25.5` (sans le `v`). Le pattern `docker-publish.yml` `type=semver,pattern={{version}}` strippe le `v` initial des git tags.

Run #2 avec `source_tag=3.25.5` (sans v) → success, retag fait ce matin.

## Fix

Add un step `Normalize source_tag` qui strippe le `v` initial une fois si présent. Tolère les deux formes d'input : `v3.25.5` et `3.25.5`. Update la description du `source_tag` input pour documenter les deux formes acceptées.

## Test plan

- [x] Lint workflow YAML (pre-commit yaml check passed)
- [ ] Au prochain retag (v3.26.x), tester avec les deux formes d'input

🤖 Generated with [Claude Code](https://claude.com/claude-code)