### PR TITLE
docs(env): document writer-scoped TRAINING_DATA_REPO convention

### DIFF
--- a/docker/env.example
+++ b/docker/env.example
@@ -11,6 +11,20 @@ INTERVALS_API_KEY=
 # DATA REPOSITORY
 # ============================================
 # In Docker, mapped via volume to /data/training-logs
+#
+# Writer-scoped layout (ADR v5 Phase 1) — multi-writer environments:
+# When several agents (Mac, NAS prod, NAS preprod) share the same data repo,
+# each writer should write under its own opaque-hash subdir to avoid path
+# collisions. Authority per file glob is declared in `.operators.yaml` at the
+# repo root. Set TRAINING_DATA_REPO to point at THIS writer's subdir, e.g.:
+#
+#   - NAS prod    → TRAINING_DATA_REPO=/data/training-logs/88bc132e32a0
+#   - NAS preprod → TRAINING_DATA_REPO=/data/training-logs/dd22773d9515
+#   - Solo (no multi-writer concern) → TRAINING_DATA_REPO=/data/training-logs
+#
+# A solo deployment can keep the unscoped form below. Multi-writer deployments
+# MUST point at their hash subdir, otherwise startup health-check (PR #298)
+# will fail-fast looking for `workouts-history.md` at the wrong path.
 TRAINING_DATA_REPO=/data/training-logs
 TRAINING_LOGS_PATH=/data/training-logs
 INTELLIGENCE_DATA_DIR=


### PR DESCRIPTION
## Contexte

Phase 1A ADR v5 isole les containers NAS prod (writer hash 88bc132e32a0) et NAS preprod (dd22773d9515) dans des subdirs hash dédiés. La convention est portée par .operators.yaml dans le data repo, mais env.example n'en parle pas.

Pour qu'un futur déploiement (bundle PyInstaller, un autre NAS, beta-tester) ne tombe pas dans le piège du startup-health-check fail-fast, on documente inline les 3 formes possibles de TRAINING_DATA_REPO :

- NAS prod : /data/training-logs/88bc132e32a0
- NAS preprod : /data/training-logs/dd22773d9515
- Solo : /data/training-logs (forme par défaut, pas de multi-writer)

## Suivi

- Phase 1B (NAS preprod isolation) suivra ce pattern
- Phase 1C (consumer-side authority resolution) automatisera la lecture cross-writer via .operators.yaml

## Test plan

- [x] Pre-commit hooks (yaml/markdown checks)
- [ ] Validation visuelle du commentaire dans le fichier rendu

🤖 Generated with [Claude Code](https://claude.com/claude-code)