### PR TITLE
feat(mcp): handler insert-workout-history (PR8 portage legacy)

### DIFF
--- a/magma_cycling/_mcp/handlers/rest.py
+++ b/magma_cycling/_mcp/handlers/rest.py
@@ -12,7 +12,11 @@ from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
 if TYPE_CHECKING:
     from mcp.types import TextContent
 
-__all__ = ["handle_pre_session_check", "handle_patch_coach_analysis"]
+__all__ = [
+    "handle_insert_workout_history",
+    "handle_patch_coach_analysis",
+    "handle_pre_session_check",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -247,6 +251,48 @@ def _locate_entry(
     entry_end = len(content) if next_header == -1 else next_header
 
     return header_start, entry_end
+
+
+async def handle_insert_workout_history(args: dict) -> list[TextContent]:
+    """Insert a new entry into workouts-history.md at the chronologically correct position.
+
+    Wraps the legacy ``WorkoutHistoryManager.insert_analysis`` (CLI ``insert-analysis``)
+    to expose its capability via MCP. The legacy logic handles parsing, duplicate
+    detection, and chronological insertion via ``TimelineInjector``.
+
+    Use this when CD has just generated a coach analysis for a session that does
+    NOT yet exist in ``workouts-history.md``. For correcting an entry already
+    present, use ``patch-coach-analysis`` instead.
+    """
+    analysis_text = args.get("analysis_text")
+    yes_confirm = args.get("yes_confirm", False)
+
+    if not analysis_text or not isinstance(analysis_text, str):
+        raise ValueError("analysis_text is required (non-empty markdown string)")
+
+    with suppress_stdout_stderr():
+        from magma_cycling.inserter.history import WorkoutHistoryManager
+
+        manager = WorkoutHistoryManager(yes_confirm=yes_confirm)
+        success = manager.insert_analysis(analysis_text)
+
+    if success:
+        return mcp_response(
+            {
+                "status": "success",
+                "message": "Entry inserted into workouts-history.md at chronological position.",
+            }
+        )
+    return mcp_response(
+        {
+            "status": "error",
+            "message": (
+                "Insert failed — likely a duplicate entry without yes_confirm=true, "
+                "or a parsing error on the analysis_text. Check the date format "
+                "(DD/MM/YYYY required) and ensure the entry isn't already present."
+            ),
+        }
+    )
 
 
 async def handle_patch_coach_analysis(args: dict) -> list[TextContent]:

--- a/magma_cycling/_mcp/schemas/rest.py
+++ b/magma_cycling/_mcp/schemas/rest.py
@@ -40,6 +40,40 @@ def get_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="insert-workout-history",
+            description=(
+                "Insert a new entry into workouts-history.md at the chronologically "
+                "correct position. Wraps WorkoutHistoryManager.insert_analysis "
+                "(legacy CLI insert-analysis) — handles duplicate detection and "
+                "atomic write. For correcting an existing entry, use "
+                "patch-coach-analysis instead."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "analysis_text": {
+                        "type": "string",
+                        "description": (
+                            "Full markdown analysis block to insert. Must contain "
+                            "a date in DD/MM/YYYY format (used for chronological "
+                            "placement). Typically a complete `### SXXX-NN | type | "
+                            "date` entry with metrics + analysis."
+                        ),
+                    },
+                    "yes_confirm": {
+                        "type": "boolean",
+                        "description": (
+                            "Auto-confirm overwrite if a similar entry exists for "
+                            "the same date. Default false — will refuse with a "
+                            "clear error if duplicate detected."
+                        ),
+                        "default": False,
+                    },
+                },
+                "required": ["analysis_text"],
+            },
+        ),
+        Tool(
             name="patch-coach-analysis",
             description=(
                 "Patch a coach analysis entry in workouts-history.md without "

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -101,6 +101,7 @@ from magma_cycling._mcp.handlers.remote import (  # noqa: F401
 # Re-exports — all handlers importable from mcp_server
 # ---------------------------------------------------------------------------
 from magma_cycling._mcp.handlers.rest import (  # noqa: F401
+    handle_insert_workout_history,
     handle_patch_coach_analysis,
     handle_pre_session_check,
 )
@@ -235,9 +236,10 @@ TOOL_HANDLERS = {
     "sync-health-to-calendar": handle_sync_health_to_calendar,
     "analyze-health-trends": handle_analyze_health_trends,
     "enrich-session-health": handle_enrich_session_health,
-    # Rest / Recovery (2)
+    # Rest / Recovery (3)
     "pre-session-check": handle_pre_session_check,
     "patch-coach-analysis": handle_patch_coach_analysis,
+    "insert-workout-history": handle_insert_workout_history,
     # Terrain (4)
     "extract-terrain-circuit": handle_extract_terrain_circuit,
     "list-terrain-circuits": handle_list_terrain_circuits,

--- a/tests/_mcp/test_handle_insert_workout_history.py
+++ b/tests/_mcp/test_handle_insert_workout_history.py
@@ -1,0 +1,110 @@
+"""Tests for the MCP handler ``insert-workout-history``.
+
+Wraps ``WorkoutHistoryManager.insert_analysis`` (legacy CLI ``insert-analysis``)
+to expose its capability via MCP. Tests focus on the wiring (handler → manager
+→ response), not on the underlying ``insert_analysis`` logic which has its own
+test suite in ``tests/workflows/test_insert_analysis.py``.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest_plugins = ("pytest_asyncio",)
+
+MGR_PATCH = "magma_cycling.inserter.history.WorkoutHistoryManager"
+
+
+class TestHandleInsertWorkoutHistory:
+    @pytest.mark.asyncio
+    async def test_success_inserts_via_manager(self):
+        """Happy path: manager returns True → handler returns success."""
+        from magma_cycling.mcp_server import handle_insert_workout_history
+
+        mgr = MagicMock()
+        mgr.insert_analysis.return_value = True
+
+        with patch(MGR_PATCH, return_value=mgr) as mgr_cls:
+            result = await handle_insert_workout_history(
+                {"analysis_text": "### S091-02 | INT | 28/04/2026\n\nfake analysis"}
+            )
+
+        # Manager called with yes_confirm default False
+        mgr_cls.assert_called_once_with(yes_confirm=False)
+        mgr.insert_analysis.assert_called_once()
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "success"
+        assert "inserted" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_yes_confirm_propagated_to_manager(self):
+        """yes_confirm=True passes through to WorkoutHistoryManager constructor."""
+        from magma_cycling.mcp_server import handle_insert_workout_history
+
+        mgr = MagicMock()
+        mgr.insert_analysis.return_value = True
+
+        with patch(MGR_PATCH, return_value=mgr) as mgr_cls:
+            await handle_insert_workout_history(
+                {
+                    "analysis_text": "### S091-03 | TEC | 29/04/2026\n\nfake",
+                    "yes_confirm": True,
+                }
+            )
+
+        mgr_cls.assert_called_once_with(yes_confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_failure_returns_error_status(self):
+        """Manager returns False (duplicate, parse error) → handler returns error."""
+        from magma_cycling.mcp_server import handle_insert_workout_history
+
+        mgr = MagicMock()
+        mgr.insert_analysis.return_value = False
+
+        with patch(MGR_PATCH, return_value=mgr):
+            result = await handle_insert_workout_history(
+                {"analysis_text": "### dup | INT | 28/04/2026\n\nx"}
+            )
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "error"
+        assert "duplicate" in data["message"].lower() or "parsing" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_analysis_text_raises(self):
+        """Empty / missing analysis_text rejected with ValueError."""
+        from magma_cycling.mcp_server import handle_insert_workout_history
+
+        with pytest.raises(ValueError, match="analysis_text"):
+            await handle_insert_workout_history({})
+
+        with pytest.raises(ValueError, match="analysis_text"):
+            await handle_insert_workout_history({"analysis_text": ""})
+
+        with pytest.raises(ValueError, match="analysis_text"):
+            await handle_insert_workout_history({"analysis_text": None})
+
+
+class TestInsertWorkoutHistoryWiring:
+    """Verify the handler is properly wired into TOOL_HANDLERS dispatcher."""
+
+    def test_handler_registered_in_dispatcher(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS, handle_insert_workout_history
+
+        assert "insert-workout-history" in TOOL_HANDLERS
+        assert TOOL_HANDLERS["insert-workout-history"] is handle_insert_workout_history
+
+    def test_tool_count_includes_new_handler(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        # 61 = 60 (post-PR #302 baseline) + 1 (this PR)
+        assert len(TOOL_HANDLERS) == 61
+
+    def test_tool_schema_exposed(self):
+        from magma_cycling._mcp.schemas.rest import get_tools
+
+        names = [t.name for t in get_tools()]
+        assert "insert-workout-history" in names


### PR DESCRIPTION
## Contexte

Détecté par beta-tester Georges 2026-05-03 : Claude Desktop bundle peut patch des entrées existantes dans workouts-history.md (patch-coach-analysis) mais ne peut pas en créer de nouvelles. Stéphane copy-paste manuellement pour les séances pas encore dans le fichier.

La logique métier existe déjà côté Python : WorkoutHistoryManager.insert_analysis (CLI legacy insert-analysis, 218 lignes). Seule l exposition MCP manquait.

## Solution

Nouveau handler MCP insert-workout-history qui wrap WorkoutHistoryManager.insert_analysis. Réutilise la logique complète : parsing date, détection doublons, insertion chronologique via TimelineInjector, paranoid mode.

Différence vs patch-coach-analysis : create vs update. Tools complémentaires.

Bumps tool_count 60 → 61.

## Tests

7 nouveaux tests (handler + wiring TOOL_HANDLERS + schema). 151/151 passed overall (aucune régression).

## Plan migration

Part of MIGRATION_LEGACY_TO_MCP.md (PR8). Premier portage handler MCP de la migration legacy → MCP livré.