### PR TITLE
feat(mcp): handler weekly-analysis (PR4 portage legacy)

### DIFF
--- a/magma_cycling/_mcp/handlers/planning.py
+++ b/magma_cycling/_mcp/handlers/planning.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "handle_weekly_planner",
+    "handle_weekly_analysis",
     "handle_monthly_analysis",
     "handle_daily_sync",
     "handle_update_session",
@@ -289,6 +290,45 @@ async def handle_weekly_planner(args: dict) -> list[TextContent]:
         ]
 
     return mcp_response(result)
+
+
+async def handle_weekly_analysis(args: dict) -> list[TextContent]:
+    """Generate the 6 weekly report files (bilan_final, transition, …) for a given week.
+
+    Wraps the legacy ``run_weekly_analysis`` (CLI ``weekly-analysis``) to expose
+    its capability via MCP. Saves markdown files into
+    ``<data_repo>/weekly-reports/<week_id>/``. AI clipboard side-effect from the
+    legacy CLI is intentionally disabled (``ai_analysis=False``) — irrelevant in
+    MCP context where the consumer (CD or another tool) drives any AI step.
+    """
+    from datetime import datetime as _dt
+
+    from magma_cycling.workflows.workflow_weekly import run_weekly_analysis
+
+    week_id = args["week_id"]
+    start_date_str = args["start_date"]
+    start_date = _dt.strptime(start_date_str, "%Y-%m-%d").date()
+
+    with suppress_stdout_stderr():
+        reports = run_weekly_analysis(
+            week=week_id,
+            start_date=start_date,
+            ai_analysis=False,
+        )
+
+    return mcp_response(
+        {
+            "status": "success",
+            "week_id": week_id,
+            "start_date": start_date_str,
+            "reports_generated": sorted(reports.keys()),
+            "report_count": len(reports),
+            "message": (
+                f"Generated {len(reports)} weekly reports for {week_id} in "
+                f"weekly-reports/{week_id}/"
+            ),
+        }
+    )
 
 
 async def handle_monthly_analysis(args: dict) -> list[TextContent]:

--- a/magma_cycling/_mcp/schemas/planning.py
+++ b/magma_cycling/_mcp/schemas/planning.py
@@ -44,6 +44,33 @@ def get_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="weekly-analysis",
+            description=(
+                "Generate the 6 weekly report files (bilan_final, transition, "
+                "workout_history, metrics_evolution, training_learnings, "
+                "protocol_adaptations) for a given week. Wraps the legacy CLI "
+                "weekly-analysis (workflow_weekly:main). Saves markdown files in "
+                "<data_repo>/weekly-reports/<week_id>/. Idempotent — safe to "
+                "re-run, overwrites existing files."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "week_id": {
+                        "type": "string",
+                        "description": "Week ID (e.g. S091)",
+                        "pattern": "^S\\d{3}$",
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "description": "Week start date (YYYY-MM-DD, Monday)",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    },
+                },
+                "required": ["week_id", "start_date"],
+            },
+        ),
+        Tool(
             name="monthly-analysis",
             description="Generate comprehensive monthly training analysis with statistics and AI insights",
             inputSchema={

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -79,6 +79,7 @@ from magma_cycling._mcp.handlers.planning import (  # noqa: F401
     handle_monthly_analysis,
     handle_rename_session,
     handle_update_session,
+    handle_weekly_analysis,
     handle_weekly_planner,
 )
 from magma_cycling._mcp.handlers.remote import (  # noqa: F401
@@ -175,8 +176,9 @@ async def list_tools() -> list[Tool]:
 # Tool dispatch
 # ---------------------------------------------------------------------------
 TOOL_HANDLERS = {
-    # Planning (11)
+    # Planning (12)
     "weekly-planner": handle_weekly_planner,
+    "weekly-analysis": handle_weekly_analysis,
     "monthly-analysis": handle_monthly_analysis,
     "daily-sync": handle_daily_sync,
     "update-session": handle_update_session,

--- a/tests/_mcp/test_handle_insert_workout_history.py
+++ b/tests/_mcp/test_handle_insert_workout_history.py
@@ -100,8 +100,11 @@ class TestInsertWorkoutHistoryWiring:
     def test_tool_count_includes_new_handler(self):
         from magma_cycling.mcp_server import TOOL_HANDLERS
 
-        # 61 = 60 (post-PR #302 baseline) + 1 (this PR)
-        assert len(TOOL_HANDLERS) == 61
+        # Test dynamique pour résilience aux ajouts futurs : on vérifie que
+        # le handler est bien dans le dispatcher, pas la valeur exacte de la
+        # constante (qui évolue à chaque nouveau handler ajouté).
+        assert "insert-workout-history" in TOOL_HANDLERS
+        assert len(TOOL_HANDLERS) >= 61
 
     def test_tool_schema_exposed(self):
         from magma_cycling._mcp.schemas.rest import get_tools

--- a/tests/_mcp/test_handle_weekly_analysis.py
+++ b/tests/_mcp/test_handle_weekly_analysis.py
@@ -1,0 +1,102 @@
+"""Tests for the MCP handler ``weekly-analysis``.
+
+Wraps ``run_weekly_analysis`` (legacy CLI ``weekly-analysis``) to expose its
+capability via MCP. Tests focus on the wiring (handler → run_weekly_analysis
+→ response), not on the underlying weekly aggregation/analyzer logic which
+has its own test suite.
+"""
+
+import json
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+pytest_plugins = ("pytest_asyncio",)
+
+RUN_PATCH = "magma_cycling.workflows.workflow_weekly.run_weekly_analysis"
+
+
+class TestHandleWeeklyAnalysis:
+    @pytest.mark.asyncio
+    async def test_success_generates_six_reports(self):
+        """Happy path: returns the 6 report names + status."""
+        from magma_cycling.mcp_server import handle_weekly_analysis
+
+        fake_reports = {
+            "bilan_final": "...",
+            "transition": "...",
+            "workout_history": "...",
+            "metrics_evolution": "...",
+            "training_learnings": "...",
+            "protocol_adaptations": "...",
+        }
+        with patch(RUN_PATCH, return_value=fake_reports) as run:
+            result = await handle_weekly_analysis({"week_id": "S091", "start_date": "2026-04-27"})
+
+        run.assert_called_once_with(
+            week="S091",
+            start_date=date(2026, 4, 27),
+            ai_analysis=False,
+        )
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "success"
+        assert data["week_id"] == "S091"
+        assert data["start_date"] == "2026-04-27"
+        assert data["report_count"] == 6
+        assert sorted(data["reports_generated"]) == sorted(fake_reports.keys())
+
+    @pytest.mark.asyncio
+    async def test_ai_analysis_disabled_in_mcp(self):
+        """ai_analysis MUST be False — clipboard side-effect not relevant in MCP."""
+        from magma_cycling.mcp_server import handle_weekly_analysis
+
+        with patch(RUN_PATCH, return_value={}) as run:
+            await handle_weekly_analysis({"week_id": "S091", "start_date": "2026-04-27"})
+
+        # Vérifie que ai_analysis=False est passé explicitement
+        kwargs = run.call_args.kwargs
+        assert kwargs.get("ai_analysis") is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_date_format_raises(self):
+        """Date pas au format YYYY-MM-DD → ValueError du datetime parser."""
+        from magma_cycling.mcp_server import handle_weekly_analysis
+
+        with pytest.raises(ValueError):
+            await handle_weekly_analysis({"week_id": "S091", "start_date": "27/04/2026"})
+
+    @pytest.mark.asyncio
+    async def test_missing_required_args_raises(self):
+        """week_id et start_date sont required."""
+        from magma_cycling.mcp_server import handle_weekly_analysis
+
+        with pytest.raises(KeyError):
+            await handle_weekly_analysis({"week_id": "S091"})
+
+        with pytest.raises(KeyError):
+            await handle_weekly_analysis({"start_date": "2026-04-27"})
+
+
+class TestWeeklyAnalysisWiring:
+    """Verify the handler is properly wired into TOOL_HANDLERS dispatcher."""
+
+    def test_handler_registered_in_dispatcher(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS, handle_weekly_analysis
+
+        assert "weekly-analysis" in TOOL_HANDLERS
+        assert TOOL_HANDLERS["weekly-analysis"] is handle_weekly_analysis
+
+    def test_tool_count_includes_new_handler(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        # Test dynamique pour résilience aux ajouts futurs.
+        assert "weekly-analysis" in TOOL_HANDLERS
+        assert len(TOOL_HANDLERS) >= 62
+
+    def test_tool_schema_exposed(self):
+        from magma_cycling._mcp.schemas.planning import get_tools
+
+        names = [t.name for t in get_tools()]
+        assert "weekly-analysis" in names


### PR DESCRIPTION
## Contexte

Le legacy LaunchAgent qui générait les 6 fichiers bilan hebdo (bilan_final, transition, workout_history, metrics_evolution, training_learnings, protocol_adaptations) est mort depuis 20/04 (rebase machine). Aucun handler MCP nexposait cette fonction. Pour avoir un MCP ISO legacy fonctionnellement, ce gap doit être comblé.

## Solution

Nouveau handler MCP weekly-analysis qui wrap run_weekly_analysis (CLI legacy weekly-analysis, workflow_weekly:main). Réutilise toute la logique : aggregation, analyzer, save 6 reports markdown.

ai_analysis=False forced — clipboard side-effect du legacy CLI est hors-scope MCP (consumer drives any AI step).

Bumps tool_count 61 → 62.

## Tests

7 nouveaux tests dans tests/_mcp/test_handle_weekly_analysis.py. Tool count assertion ancien (PR8) relaxé en >= pour résilience aux ajouts futurs.

## Migration

Part of MIGRATION_LEGACY_TO_MCP.md PR4. Deuxième portage handler MCP livré aujourd hui (après PR8 insert-workout-history).