### PR TITLE
feat(mcp): handler upload-workouts (PR5 portage legacy)

### DIFF
--- a/magma_cycling/_mcp/handlers/workouts.py
+++ b/magma_cycling/_mcp/handlers/workouts.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "handle_get_workout",
+    "handle_upload_workouts",
     "handle_validate_workout",
 ]
 
@@ -155,3 +156,110 @@ async def handle_validate_workout(args: dict) -> list[TextContent]:
 
     except Exception as e:
         return mcp_response({"error": f"Validation error: {str(e)}"})
+
+
+async def handle_upload_workouts(args: dict) -> list[TextContent]:
+    """Upload structured workouts to Intervals.icu calendar.
+
+    Wraps the legacy CLI ``upload-workouts`` (``WorkoutUploader.upload_all``)
+    to expose its capability via MCP. Reads workouts from a file relative to
+    the data repo (path traversal is rejected for safety). Auto-backup before
+    real upload (skipped in dry_run).
+
+    The clipboard parsing path of the legacy CLI is intentionally not
+    exposed — irrelevant in MCP context.
+    """
+    from datetime import datetime as _dt
+    from pathlib import Path
+
+    from magma_cycling.config import get_data_config
+    from magma_cycling.upload_workouts import (
+        WorkoutUploader,
+        calculate_week_start_date,
+    )
+
+    week_id = args["week_id"]
+    workouts_file_path = args["workouts_file_path"]
+    start_date_str = args.get("start_date")
+    dry_run = args.get("dry_run", False)
+    auto_backup = args.get("auto_backup", True)
+
+    # Resolve and validate path stays within data_repo (no traversal)
+    config = get_data_config()
+    data_repo = config.data_repo_path.resolve()
+    candidate = (data_repo / workouts_file_path).resolve()
+    try:
+        candidate.relative_to(data_repo)
+    except ValueError:
+        return mcp_response(
+            {
+                "status": "error",
+                "message": (
+                    f"workouts_file_path must stay within the data repo. "
+                    f"Got '{workouts_file_path}' which resolves outside."
+                ),
+            }
+        )
+    if not candidate.is_file():
+        return mcp_response(
+            {
+                "status": "error",
+                "message": f"workouts file not found: {workouts_file_path}",
+            }
+        )
+
+    # Compute start_date (auto if absent)
+    if start_date_str:
+        start_date = _dt.strptime(start_date_str, "%Y-%m-%d")
+    else:
+        try:
+            start_date = calculate_week_start_date(week_id)
+        except (FileNotFoundError, ValueError) as exc:
+            return mcp_response(
+                {
+                    "status": "error",
+                    "message": (
+                        f"Cannot auto-compute start_date for {week_id}: {exc}. "
+                        "Provide start_date explicitly."
+                    ),
+                }
+            )
+
+    with suppress_stdout_stderr():
+        # Auto-backup before real upload (skipped in dry_run)
+        if not dry_run and auto_backup:
+            try:
+                from magma_cycling.planning.backup import auto_backup as _do_backup
+
+                _do_backup(week_id)
+            except Exception:
+                # Non-blocking — backup failure shouldn't stop upload
+                pass
+
+        uploader = WorkoutUploader(week_id, start_date)
+        workouts = uploader.parse_workouts_file(Path(candidate))
+
+    if not workouts:
+        return mcp_response(
+            {
+                "status": "error",
+                "message": "No workouts parsed from file (empty or malformed format).",
+            }
+        )
+
+    with suppress_stdout_stderr():
+        stats = uploader.upload_all(workouts, dry_run=dry_run)
+
+    return mcp_response(
+        {
+            "status": "success" if stats.get("failed", 0) == 0 else "partial_failure",
+            "week_id": week_id,
+            "dry_run": dry_run,
+            "workout_count": len(workouts),
+            "stats": stats,
+            "message": (
+                f"Uploaded {stats.get('success', 0)}/{len(workouts)} workouts "
+                f"for {week_id}" + (" (dry_run)" if dry_run else "")
+            ),
+        }
+    )

--- a/magma_cycling/_mcp/schemas/workouts.py
+++ b/magma_cycling/_mcp/schemas/workouts.py
@@ -22,6 +22,53 @@ def get_tools() -> list[Tool]:
             },
         ),
         Tool(
+            name="upload-workouts",
+            description=(
+                "Upload structured workouts to Intervals.icu calendar for a "
+                "given week. Wraps the legacy CLI upload-workouts. Reads "
+                "workouts from a file relative to the data repo (typically "
+                "data/week_planning/{week_id}_workouts.txt). Auto-backup before "
+                "real upload. Use dry_run=true for a no-op simulation."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "week_id": {
+                        "type": "string",
+                        "description": "Week ID (e.g., S091)",
+                        "pattern": "^S\\d{3}$",
+                    },
+                    "workouts_file_path": {
+                        "type": "string",
+                        "description": (
+                            "Path to workouts file, relative to data repo root "
+                            "(e.g., data/week_planning/S091_workouts.txt). "
+                            "Path traversal is rejected — must stay within data repo."
+                        ),
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "description": (
+                            "Week start date YYYY-MM-DD (Monday). If absent, "
+                            "auto-computed from week_id via planning data."
+                        ),
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "Simulation mode, no real upload (default: false)",
+                        "default": False,
+                    },
+                    "auto_backup": {
+                        "type": "boolean",
+                        "description": "Auto-backup planning files before upload (default: true)",
+                        "default": True,
+                    },
+                },
+                "required": ["week_id", "workouts_file_path"],
+            },
+        ),
+        Tool(
             name="validate-workout",
             description="Validate structured workout format syntax and optionally fix common errors",
             inputSchema={

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -118,6 +118,7 @@ from magma_cycling._mcp.handlers.terrain import (  # noqa: F401
 )
 from magma_cycling._mcp.handlers.workouts import (  # noqa: F401
     handle_get_workout,
+    handle_upload_workouts,
     handle_validate_workout,
 )
 
@@ -191,9 +192,10 @@ TOOL_HANDLERS = {
     "duplicate-session": handle_duplicate_session,
     "swap-sessions": handle_swap_sessions,
     "attach-workout": handle_attach_workout,
-    # Workouts (2)
+    # Workouts (3)
     "get-workout": handle_get_workout,
     "validate-workout": handle_validate_workout,
+    "upload-workouts": handle_upload_workouts,
     # Remote / Calendar (13)
     "sync-week-to-calendar": handle_sync_week_to_calendar,
     "delete-remote-event": handle_delete_remote_event,

--- a/tests/_mcp/test_handle_upload_workouts.py
+++ b/tests/_mcp/test_handle_upload_workouts.py
@@ -1,0 +1,181 @@
+"""Tests for the MCP handler ``upload-workouts``.
+
+Wraps ``WorkoutUploader.upload_all`` (legacy CLI ``upload-workouts``) to
+expose its capability via MCP. Tests focus on the wiring (handler →
+WorkoutUploader → response) plus the path-traversal guard.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest_plugins = ("pytest_asyncio",)
+
+
+@pytest.fixture
+def fake_data_repo(tmp_path):
+    """Build a fake data_repo with a workouts file inside."""
+    repo = tmp_path / "training-logs"
+    week_planning = repo / "data" / "week_planning"
+    week_planning.mkdir(parents=True)
+    workouts_file = week_planning / "S091_workouts.txt"
+    workouts_file.write_text(
+        "=== WORKOUT S091-01-END-X-V001 ===\nfake content\n=== FIN WORKOUT ===\n"
+    )
+    return repo
+
+
+def _patch_data_config(repo_path):
+    """Helper: patch get_data_config to return a config pointing at repo_path."""
+    cfg = MagicMock()
+    cfg.data_repo_path = repo_path
+    return patch("magma_cycling.config.get_data_config", return_value=cfg)
+
+
+class TestHandleUploadWorkouts:
+    @pytest.mark.asyncio
+    async def test_success_dry_run(self, fake_data_repo):
+        """dry_run=true: parses file, calls upload_all dry, returns stats."""
+        from magma_cycling.mcp_server import handle_upload_workouts
+
+        uploader = MagicMock()
+        uploader.parse_workouts_file.return_value = [{"name": "S091-01-END-X-V001"}]
+        uploader.upload_all.return_value = {"success": 1, "failed": 0, "total": 1}
+
+        with (
+            _patch_data_config(fake_data_repo),
+            patch("magma_cycling.upload_workouts.WorkoutUploader", return_value=uploader),
+        ):
+            result = await handle_upload_workouts(
+                {
+                    "week_id": "S091",
+                    "workouts_file_path": "data/week_planning/S091_workouts.txt",
+                    "start_date": "2026-04-27",
+                    "dry_run": True,
+                }
+            )
+
+        uploader.upload_all.assert_called_once()
+        call_kwargs = uploader.upload_all.call_args
+        # dry_run propagated
+        assert call_kwargs.kwargs.get("dry_run") is True
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "success"
+        assert data["dry_run"] is True
+        assert data["workout_count"] == 1
+        assert data["stats"]["success"] == 1
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_rejected(self, fake_data_repo):
+        """Path with ../ outside data_repo MUST be rejected."""
+        from magma_cycling.mcp_server import handle_upload_workouts
+
+        with _patch_data_config(fake_data_repo):
+            result = await handle_upload_workouts(
+                {
+                    "week_id": "S091",
+                    "workouts_file_path": "../../../etc/passwd",
+                    "start_date": "2026-04-27",
+                }
+            )
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "error"
+        assert "outside" in data["message"].lower() or "stay within" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error(self, fake_data_repo):
+        """File that doesn't exist → error, no crash."""
+        from magma_cycling.mcp_server import handle_upload_workouts
+
+        with _patch_data_config(fake_data_repo):
+            result = await handle_upload_workouts(
+                {
+                    "week_id": "S091",
+                    "workouts_file_path": "data/week_planning/S099_workouts.txt",
+                    "start_date": "2026-04-27",
+                }
+            )
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "error"
+        assert "not found" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_workouts_returns_error(self, fake_data_repo):
+        """parse returns empty → error, doesn't call upload_all."""
+        from magma_cycling.mcp_server import handle_upload_workouts
+
+        uploader = MagicMock()
+        uploader.parse_workouts_file.return_value = []
+
+        with (
+            _patch_data_config(fake_data_repo),
+            patch("magma_cycling.upload_workouts.WorkoutUploader", return_value=uploader),
+        ):
+            result = await handle_upload_workouts(
+                {
+                    "week_id": "S091",
+                    "workouts_file_path": "data/week_planning/S091_workouts.txt",
+                    "start_date": "2026-04-27",
+                    "dry_run": True,
+                }
+            )
+
+        uploader.upload_all.assert_not_called()
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "error"
+        assert "no workouts" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_status(self, fake_data_repo):
+        """failed > 0 → status=partial_failure."""
+        from magma_cycling.mcp_server import handle_upload_workouts
+
+        uploader = MagicMock()
+        uploader.parse_workouts_file.return_value = [
+            {"name": "S091-01-END-X-V001"},
+            {"name": "S091-02-INT-Y-V001"},
+        ]
+        uploader.upload_all.return_value = {"success": 1, "failed": 1, "total": 2}
+
+        with (
+            _patch_data_config(fake_data_repo),
+            patch("magma_cycling.upload_workouts.WorkoutUploader", return_value=uploader),
+        ):
+            result = await handle_upload_workouts(
+                {
+                    "week_id": "S091",
+                    "workouts_file_path": "data/week_planning/S091_workouts.txt",
+                    "start_date": "2026-04-27",
+                    "dry_run": True,
+                }
+            )
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "partial_failure"
+        assert data["stats"]["failed"] == 1
+
+
+class TestUploadWorkoutsWiring:
+    """Verify the handler is properly wired into TOOL_HANDLERS dispatcher."""
+
+    def test_handler_registered_in_dispatcher(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS, handle_upload_workouts
+
+        assert "upload-workouts" in TOOL_HANDLERS
+        assert TOOL_HANDLERS["upload-workouts"] is handle_upload_workouts
+
+    def test_tool_count_includes_new_handler(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        assert "upload-workouts" in TOOL_HANDLERS
+        assert len(TOOL_HANDLERS) >= 63
+
+    def test_tool_schema_exposed(self):
+        from magma_cycling._mcp.schemas.workouts import get_tools
+
+        names = [t.name for t in get_tools()]
+        assert "upload-workouts" in names


### PR DESCRIPTION
Portage legacy CLI upload-workouts. Path traversal rejected, auto-backup, dry_run support. tool_count 62 → 63. 8 tests régression. Part of legacy → MCP migration.