### PR TITLE
feat(mcp): handler check-workout-adherence daily batch (PR3 portage legacy)

### DIFF
--- a/magma_cycling/_mcp/handlers/analysis.py
+++ b/magma_cycling/_mcp/handlers/analysis.py
@@ -24,6 +24,7 @@ __all__ = [
     "handle_analyze_training_patterns",
     "handle_get_coach_analysis",
     "handle_validate_local_remote_sync",
+    "handle_pid_daily_evaluation",
 ]
 
 
@@ -1134,3 +1135,73 @@ async def handle_validate_local_remote_sync(args: dict) -> list[TextContent]:
                 "week_id": week_id,
             }
         )
+
+
+async def handle_pid_daily_evaluation(args: dict) -> list[TextContent]:
+    """Run the PID training intelligence pipeline.
+
+    Wraps the legacy CLI ``pid-daily-evaluation`` (PIDDailyEvaluator) to
+    expose its capability via MCP. Two modes :
+
+    - ``daily`` (default) : collect cycle metrics + create learnings + monitor
+      CTL/Peaks + check FTP test opportunity. Idempotent on a given day.
+    - ``cycle`` : recalibrate PID with the measured FTP at end of training
+      cycle. Requires ``measured_ftp``. One-shot per cycle.
+
+    Updates ``~/data/intelligence.json`` and appends to
+    ``~/data/monitoring/pid_evaluation.jsonl`` (skipped in dry_run).
+    """
+    mode = args.get("mode", "daily")
+    days_back = args.get("days_back", 7)
+    measured_ftp = args.get("measured_ftp")
+    cycle_weeks = args.get("cycle_weeks", 6)
+    dry_run = args.get("dry_run", False)
+
+    if mode == "cycle" and measured_ftp is None:
+        return mcp_response(
+            {
+                "status": "error",
+                "message": (
+                    "measured_ftp is required when mode='cycle' "
+                    "(measured FTP from end-of-cycle test, in W)."
+                ),
+            }
+        )
+
+    with suppress_stdout_stderr():
+        from magma_cycling.scripts.pid_daily_evaluation import PIDDailyEvaluator
+
+        evaluator = PIDDailyEvaluator(dry_run=dry_run)
+
+        if mode == "cycle":
+            result = evaluator.run_cycle_evaluation(
+                measured_ftp=measured_ftp,
+                cycle_duration_weeks=cycle_weeks,
+            )
+        else:
+            result = evaluator.run_daily_evaluation(days_back=days_back)
+
+    payload = {
+        "mode": mode,
+        "dry_run": dry_run,
+        "status": result.get("status", "UNKNOWN"),
+    }
+
+    # Surface key fields without dumping the whole result blob (which can
+    # contain heavy nested metrics). The consumer can request more specific
+    # data via dedicated tools (analyze-training-patterns, get-recommendations).
+    if "test_recommendation" in result:
+        payload["test_recommendation"] = result["test_recommendation"]
+    if "ctl_monitoring" in result:
+        payload["ctl_monitoring"] = result["ctl_monitoring"]
+    if "pid_correction" in result:
+        payload["pid_correction"] = result["pid_correction"]
+    if "metrics" in result:
+        # Métriques cycle compactes : pas tout le détail, juste le top-level
+        m = result["metrics"]
+        if isinstance(m, dict):
+            payload["metrics_summary"] = {
+                k: v for k, v in m.items() if isinstance(v, (int, float, str, bool, type(None)))
+            }
+
+    return mcp_response(payload)

--- a/magma_cycling/_mcp/handlers/analysis.py
+++ b/magma_cycling/_mcp/handlers/analysis.py
@@ -25,6 +25,7 @@ __all__ = [
     "handle_get_coach_analysis",
     "handle_validate_local_remote_sync",
     "handle_pid_daily_evaluation",
+    "handle_check_workout_adherence",
 ]
 
 
@@ -1203,5 +1204,60 @@ async def handle_pid_daily_evaluation(args: dict) -> list[TextContent]:
             payload["metrics_summary"] = {
                 k: v for k, v in m.items() if isinstance(v, (int, float, str, bool, type(None)))
             }
+
+    return mcp_response(payload)
+
+
+async def handle_check_workout_adherence(args: dict) -> list[TextContent]:
+    """Daily-batch adherence check (legacy CLI check-workout-adherence).
+
+    Wraps the legacy WorkoutAdherenceChecker (from scripts/monitoring/) to
+    expose its capability via MCP. Different from analyze-session-adherence
+    which is per-session — this one is a batch check of a day or a week.
+
+    Three modes :
+    - ``day`` (default) : check single date (defaults to today).
+    - ``week`` : check Monday→Sunday of the date's week.
+    - ``weekly_alert`` : R10 weekly adherence with alerts if <85%.
+    """
+    from datetime import datetime as _dt
+
+    from scripts.monitoring.check_workout_adherence import WorkoutAdherenceChecker
+
+    mode = args.get("mode", "day")
+    date_str = args.get("date")
+    dry_run = args.get("dry_run", False)
+
+    if date_str:
+        check_date = _dt.strptime(date_str, "%Y-%m-%d")
+    else:
+        check_date = _dt.now()
+
+    with suppress_stdout_stderr():
+        checker = WorkoutAdherenceChecker(dry_run=dry_run)
+
+        if mode == "weekly_alert":
+            result = checker.check_weekly_adherence_and_alert()
+        elif mode == "week":
+            week_start = check_date - timedelta(days=check_date.weekday())
+            result = checker.check_week(week_start)
+        else:
+            result = checker.check_date(check_date)
+
+    payload = {
+        "mode": mode,
+        "date": check_date.strftime("%Y-%m-%d"),
+        "dry_run": dry_run,
+        "status": "SUCCESS",
+    }
+
+    # Surface only scalar/dict-of-scalars from the checker result to keep
+    # response compact. Heavy nested data (full session lists) stays out.
+    if isinstance(result, dict):
+        payload["adherence"] = {
+            k: v
+            for k, v in result.items()
+            if isinstance(v, (int, float, str, bool, type(None), list))
+        }
 
     return mcp_response(payload)

--- a/magma_cycling/_mcp/schemas/analysis.py
+++ b/magma_cycling/_mcp/schemas/analysis.py
@@ -7,6 +7,37 @@ def get_tools() -> list[Tool]:
     """Return analysis and backup tool schemas."""
     return [
         Tool(
+            name="check-workout-adherence",
+            description=(
+                "Daily-batch adherence check (legacy CLI check-workout-adherence). "
+                "Different from analyze-session-adherence which is per-session. "
+                "Three modes : 'day' (default, check single date), 'week' (Monday→Sunday "
+                "of the date's week), 'weekly_alert' (R10 alerts if weekly adherence "
+                "<85%%). Used by the legacy LaunchAgent at 22h daily."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "description": "Check mode (day=single date, week=full week, weekly_alert=R10 alerts)",
+                        "enum": ["day", "week", "weekly_alert"],
+                        "default": "day",
+                    },
+                    "date": {
+                        "type": "string",
+                        "description": "Date to check (YYYY-MM-DD, default: today)",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "Dry-run mode (no notifications)",
+                        "default": False,
+                    },
+                },
+            },
+        ),
+        Tool(
             name="pid-daily-evaluation",
             description=(
                 "Run the PID training intelligence pipeline (legacy CLI "

--- a/magma_cycling/_mcp/schemas/analysis.py
+++ b/magma_cycling/_mcp/schemas/analysis.py
@@ -7,6 +7,53 @@ def get_tools() -> list[Tool]:
     """Return analysis and backup tool schemas."""
     return [
         Tool(
+            name="pid-daily-evaluation",
+            description=(
+                "Run the PID training intelligence pipeline (legacy CLI "
+                "pid-daily-evaluation). Two modes : 'daily' (default) collects "
+                "cycle metrics + learnings + CTL/Peaks monitoring + test FTP "
+                "opportunity check ; 'cycle' recalibrates PID with a measured "
+                "FTP at end of training cycle. Updates ~/data/intelligence.json "
+                "and appends to ~/data/monitoring/pid_evaluation.jsonl."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "type": "string",
+                        "description": "Evaluation mode (daily collects, cycle recalibrates PID)",
+                        "enum": ["daily", "cycle"],
+                        "default": "daily",
+                    },
+                    "days_back": {
+                        "type": "integer",
+                        "description": "Days to analyze in daily mode (default 7)",
+                        "minimum": 1,
+                        "maximum": 90,
+                        "default": 7,
+                    },
+                    "measured_ftp": {
+                        "type": "number",
+                        "description": ("Measured FTP from test (W). REQUIRED when mode='cycle'."),
+                        "minimum": 50,
+                        "maximum": 600,
+                    },
+                    "cycle_weeks": {
+                        "type": "integer",
+                        "description": "Cycle duration in weeks (default 6, mode='cycle')",
+                        "minimum": 1,
+                        "maximum": 52,
+                        "default": 6,
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "Dry-run mode (no file writes)",
+                        "default": False,
+                    },
+                },
+            },
+        ),
+        Tool(
             name="validate-week-consistency",
             description="Validate week planning consistency (no conflicts, TSS coherent, sessions well-formed)",
             inputSchema={

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -38,6 +38,7 @@ from magma_cycling._mcp.handlers.admin import (  # noqa: F401
 from magma_cycling._mcp.handlers.analysis import (  # noqa: F401
     handle_analyze_session_adherence,
     handle_analyze_training_patterns,
+    handle_check_workout_adherence,
     handle_export_week_to_json,
     handle_get_coach_analysis,
     handle_get_recommendations,
@@ -227,6 +228,7 @@ TOOL_HANDLERS = {
     "get-coach-analysis": handle_get_coach_analysis,
     "validate-local-remote-sync": handle_validate_local_remote_sync,
     "pid-daily-evaluation": handle_pid_daily_evaluation,
+    "check-workout-adherence": handle_check_workout_adherence,
     # Admin (2)
     "reload-server": handle_reload_server,
     "system-info": handle_system_info,

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -42,6 +42,7 @@ from magma_cycling._mcp.handlers.analysis import (  # noqa: F401
     handle_get_coach_analysis,
     handle_get_recommendations,
     handle_get_training_statistics,
+    handle_pid_daily_evaluation,
     handle_restore_week_from_backup,
     handle_validate_local_remote_sync,
     handle_validate_week_consistency,
@@ -215,7 +216,7 @@ TOOL_HANDLERS = {
     # Athlete (2)
     "get-athlete-profile": handle_get_athlete_profile,
     "update-athlete-profile": handle_update_athlete_profile,
-    # Analysis (8)
+    # Analysis (10)
     "validate-week-consistency": handle_validate_week_consistency,
     "get-recommendations": handle_get_recommendations,
     "analyze-session-adherence": handle_analyze_session_adherence,
@@ -225,6 +226,7 @@ TOOL_HANDLERS = {
     "analyze-training-patterns": handle_analyze_training_patterns,
     "get-coach-analysis": handle_get_coach_analysis,
     "validate-local-remote-sync": handle_validate_local_remote_sync,
+    "pid-daily-evaluation": handle_pid_daily_evaluation,
     # Admin (2)
     "reload-server": handle_reload_server,
     "system-info": handle_system_info,

--- a/tests/_mcp/test_handle_check_workout_adherence.py
+++ b/tests/_mcp/test_handle_check_workout_adherence.py
@@ -1,0 +1,143 @@
+"""Tests for the MCP handler ``check-workout-adherence`` (daily batch).
+
+Wraps ``WorkoutAdherenceChecker`` (legacy CLI ``check-workout-adherence``)
+to expose its capability via MCP. Different from ``analyze-session-adherence``
+which is per-session.
+
+Tests focus on the wiring (handler → checker → response) and mode dispatch
+(day, week, weekly_alert).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest_plugins = ("pytest_asyncio",)
+
+CHECKER_PATCH = "scripts.monitoring.check_workout_adherence.WorkoutAdherenceChecker"
+
+
+class TestHandleCheckWorkoutAdherence:
+    @pytest.mark.asyncio
+    async def test_day_mode_default(self):
+        """mode=day (default) → check_date called."""
+        from magma_cycling.mcp_server import handle_check_workout_adherence
+
+        checker = MagicMock()
+        checker.check_date.return_value = {"date": "2026-05-03", "adherence_pct": 92.0}
+
+        with patch(CHECKER_PATCH, return_value=checker) as cls:
+            result = await handle_check_workout_adherence({"date": "2026-05-03"})
+
+        cls.assert_called_once_with(dry_run=False)
+        checker.check_date.assert_called_once()
+        checker.check_week.assert_not_called()
+        checker.check_weekly_adherence_and_alert.assert_not_called()
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["mode"] == "day"
+        assert data["date"] == "2026-05-03"
+        assert data["status"] == "SUCCESS"
+
+    @pytest.mark.asyncio
+    async def test_week_mode_calls_check_week(self):
+        """mode=week → check_week called with Monday of date's week."""
+        from magma_cycling.mcp_server import handle_check_workout_adherence
+
+        checker = MagicMock()
+        checker.check_week.return_value = {"week": "S091", "adherence_pct": 85.0}
+
+        # 2026-05-03 is a Sunday → Monday is 2026-04-27
+        with patch(CHECKER_PATCH, return_value=checker):
+            await handle_check_workout_adherence({"mode": "week", "date": "2026-05-03"})
+
+        checker.check_week.assert_called_once()
+        call_arg = checker.check_week.call_args.args[0]
+        # Monday should be 2026-04-27
+        assert call_arg.strftime("%Y-%m-%d") == "2026-04-27"
+
+    @pytest.mark.asyncio
+    async def test_weekly_alert_mode(self):
+        """mode=weekly_alert → check_weekly_adherence_and_alert called."""
+        from magma_cycling.mcp_server import handle_check_workout_adherence
+
+        checker = MagicMock()
+        checker.check_weekly_adherence_and_alert.return_value = {
+            "alert_sent": False,
+            "adherence_pct": 90.0,
+        }
+
+        with patch(CHECKER_PATCH, return_value=checker):
+            await handle_check_workout_adherence({"mode": "weekly_alert"})
+
+        checker.check_weekly_adherence_and_alert.assert_called_once()
+        checker.check_date.assert_not_called()
+        checker.check_week.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_propagated(self):
+        """dry_run=True propagated to checker constructor."""
+        from magma_cycling.mcp_server import handle_check_workout_adherence
+
+        checker = MagicMock()
+        checker.check_date.return_value = {"adherence_pct": 95.0}
+
+        with patch(CHECKER_PATCH, return_value=checker) as cls:
+            result = await handle_check_workout_adherence({"dry_run": True})
+
+        cls.assert_called_once_with(dry_run=True)
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["dry_run"] is True
+
+    @pytest.mark.asyncio
+    async def test_default_date_today(self):
+        """Sans date arg → utilise today."""
+        from datetime import datetime as _dt
+
+        from magma_cycling.mcp_server import handle_check_workout_adherence
+
+        checker = MagicMock()
+        checker.check_date.return_value = {}
+
+        with patch(CHECKER_PATCH, return_value=checker):
+            result = await handle_check_workout_adherence({})
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["date"] == _dt.now().strftime("%Y-%m-%d")
+
+
+class TestCheckWorkoutAdherenceWiring:
+    """Verify the handler is properly wired into TOOL_HANDLERS dispatcher."""
+
+    def test_handler_registered_in_dispatcher(self):
+        from magma_cycling.mcp_server import (
+            TOOL_HANDLERS,
+            handle_check_workout_adherence,
+        )
+
+        assert "check-workout-adherence" in TOOL_HANDLERS
+        assert TOOL_HANDLERS["check-workout-adherence"] is handle_check_workout_adherence
+
+    def test_tool_count_includes_new_handler(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        assert "check-workout-adherence" in TOOL_HANDLERS
+        assert len(TOOL_HANDLERS) >= 65
+
+    def test_tool_schema_exposed(self):
+        from magma_cycling._mcp.schemas.analysis import get_tools
+
+        names = [t.name for t in get_tools()]
+        assert "check-workout-adherence" in names
+
+    def test_check_workout_adherence_distinct_from_analyze_session_adherence(self):
+        """Both tools coexist — one is daily batch, the other is per-session."""
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        assert "check-workout-adherence" in TOOL_HANDLERS  # batch (PR3)
+        assert "analyze-session-adherence" in TOOL_HANDLERS  # per-session (existing)
+        assert (
+            TOOL_HANDLERS["check-workout-adherence"]
+            is not TOOL_HANDLERS["analyze-session-adherence"]
+        )

--- a/tests/_mcp/test_handle_pid_daily_evaluation.py
+++ b/tests/_mcp/test_handle_pid_daily_evaluation.py
@@ -1,0 +1,131 @@
+"""Tests for the MCP handler ``pid-daily-evaluation``.
+
+Wraps ``PIDDailyEvaluator`` (legacy CLI ``pid-daily-evaluation``) to expose
+its capability via MCP. Tests focus on the wiring (handler → evaluator →
+response) and mode dispatch (daily vs cycle).
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest_plugins = ("pytest_asyncio",)
+
+EVAL_PATCH = "magma_cycling.scripts.pid_daily_evaluation.PIDDailyEvaluator"
+
+
+class TestHandlePidDailyEvaluation:
+    @pytest.mark.asyncio
+    async def test_daily_mode_default(self):
+        """mode=daily (default) → run_daily_evaluation called."""
+        from magma_cycling.mcp_server import handle_pid_daily_evaluation
+
+        evaluator = MagicMock()
+        evaluator.run_daily_evaluation.return_value = {
+            "status": "SUCCESS",
+            "metrics": {"ctl_avg": 35.2, "atl_avg": 28.0},
+            "test_recommendation": None,
+        }
+
+        with patch(EVAL_PATCH, return_value=evaluator) as cls:
+            result = await handle_pid_daily_evaluation({})
+
+        cls.assert_called_once_with(dry_run=False)
+        evaluator.run_daily_evaluation.assert_called_once_with(days_back=7)
+        evaluator.run_cycle_evaluation.assert_not_called()
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["mode"] == "daily"
+        assert data["status"] == "SUCCESS"
+        assert data["dry_run"] is False
+        assert "metrics_summary" in data
+
+    @pytest.mark.asyncio
+    async def test_daily_mode_custom_days_back(self):
+        """days_back propagated."""
+        from magma_cycling.mcp_server import handle_pid_daily_evaluation
+
+        evaluator = MagicMock()
+        evaluator.run_daily_evaluation.return_value = {"status": "SUCCESS"}
+
+        with patch(EVAL_PATCH, return_value=evaluator):
+            await handle_pid_daily_evaluation({"days_back": 14})
+
+        evaluator.run_daily_evaluation.assert_called_once_with(days_back=14)
+
+    @pytest.mark.asyncio
+    async def test_cycle_mode_requires_measured_ftp(self):
+        """mode=cycle without measured_ftp → error response, no eval call."""
+        from magma_cycling.mcp_server import handle_pid_daily_evaluation
+
+        with patch(EVAL_PATCH) as cls:
+            result = await handle_pid_daily_evaluation({"mode": "cycle"})
+
+        cls.assert_not_called()
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["status"] == "error"
+        assert "measured_ftp" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_cycle_mode_with_ftp(self):
+        """mode=cycle + measured_ftp → run_cycle_evaluation called with FTP."""
+        from magma_cycling.mcp_server import handle_pid_daily_evaluation
+
+        evaluator = MagicMock()
+        evaluator.run_cycle_evaluation.return_value = {
+            "status": "SUCCESS",
+            "pid_correction": {"tss_per_week_adjusted": 420},
+        }
+
+        with patch(EVAL_PATCH, return_value=evaluator):
+            result = await handle_pid_daily_evaluation(
+                {"mode": "cycle", "measured_ftp": 285.5, "cycle_weeks": 4}
+            )
+
+        evaluator.run_cycle_evaluation.assert_called_once_with(
+            measured_ftp=285.5,
+            cycle_duration_weeks=4,
+        )
+
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["mode"] == "cycle"
+        assert data["status"] == "SUCCESS"
+        assert "pid_correction" in data
+
+    @pytest.mark.asyncio
+    async def test_dry_run_propagated(self):
+        """dry_run=True propagated to evaluator constructor."""
+        from magma_cycling.mcp_server import handle_pid_daily_evaluation
+
+        evaluator = MagicMock()
+        evaluator.run_daily_evaluation.return_value = {"status": "SUCCESS"}
+
+        with patch(EVAL_PATCH, return_value=evaluator) as cls:
+            result = await handle_pid_daily_evaluation({"dry_run": True})
+
+        cls.assert_called_once_with(dry_run=True)
+        data = json.loads(result[0].text.split("[meta]")[0].strip())
+        assert data["dry_run"] is True
+
+
+class TestPidDailyEvaluationWiring:
+    """Verify the handler is properly wired into TOOL_HANDLERS dispatcher."""
+
+    def test_handler_registered_in_dispatcher(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS, handle_pid_daily_evaluation
+
+        assert "pid-daily-evaluation" in TOOL_HANDLERS
+        assert TOOL_HANDLERS["pid-daily-evaluation"] is handle_pid_daily_evaluation
+
+    def test_tool_count_includes_new_handler(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        assert "pid-daily-evaluation" in TOOL_HANDLERS
+        assert len(TOOL_HANDLERS) >= 64
+
+    def test_tool_schema_exposed(self):
+        from magma_cycling._mcp.schemas.analysis import get_tools
+
+        names = [t.name for t in get_tools()]
+        assert "pid-daily-evaluation" in names


### PR DESCRIPTION
Portage legacy CLI check-workout-adherence (daily batch, distinct from per-session analyze-session-adherence). 3 modes : day, week, weekly_alert. tool_count 64 → 65. 9 tests régression. Part of legacy → MCP migration.