### PR TITLE
fix(ai): default fallback priority to mistral_api first

### DIFF
--- a/magma_cycling/config/ai_providers.py
+++ b/magma_cycling/config/ai_providers.py
@@ -22,11 +22,13 @@ class AIProvidersConfig:
         ['claude_api', 'mistral_api', 'clipboard']
     """
 
+    DEFAULT_FALLBACK_PRIORITY = ["mistral_api", "claude_api", "openai", "ollama", "clipboard"]
+
     def __init__(self):
         """Initialize AI providers configuration from environment variables."""
         self.default_provider = os.getenv("DEFAULT_AI_PROVIDER", "clipboard")
         self.enable_fallback = os.getenv("ENABLE_AI_FALLBACK", "true").lower() == "true"
-        self.fallback_priority = ["claude_api", "mistral_api", "openai", "ollama", "clipboard"]
+        self.fallback_priority = self._resolve_fallback_priority()
 
         # Mistral AI
         self.mistral_api_key = os.getenv("MISTRAL_API_KEY")
@@ -64,6 +66,20 @@ class AIProvidersConfig:
             "openai": {"openai_api_key": self.openai_api_key, "openai_model": self.openai_model},
             "ollama": {"ollama_base_url": self.ollama_base_url, "ollama_model": self.ollama_model},
         }
+
+    @classmethod
+    def _resolve_fallback_priority(cls) -> list[str]:
+        """Return fallback priority list, honoring AI_FALLBACK_PRIORITY env override.
+
+        Falls back to DEFAULT_FALLBACK_PRIORITY when the env var is unset, blank,
+        or contains no recognized provider names.
+        """
+        raw = os.getenv("AI_FALLBACK_PRIORITY", "")
+        if not raw.strip():
+            return list(cls.DEFAULT_FALLBACK_PRIORITY)
+        valid = set(cls.DEFAULT_FALLBACK_PRIORITY)
+        parsed = [p.strip() for p in raw.split(",") if p.strip() in valid]
+        return parsed or list(cls.DEFAULT_FALLBACK_PRIORITY)
 
     def is_provider_configured(self, provider: str) -> bool:
         """Check if provider has valid configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.7.0"
+version = "3.7.1"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/tests/integration/test_fallback_chain.py
+++ b/tests/integration/test_fallback_chain.py
@@ -68,8 +68,8 @@ class TestFallbackChain:
 
             chain = config.get_fallback_chain()
 
-            # Should have all 5 providers in priority order
-            expected = ["claude_api", "mistral_api", "openai", "ollama", "clipboard"]
+            # Should have all 5 providers in priority order (mistral first, magma-cycling strategy)
+            expected = ["mistral_api", "claude_api", "openai", "ollama", "clipboard"]
             assert chain == expected
 
     def test_fallback_skips_unconfigured_providers(self):
@@ -168,11 +168,13 @@ class TestFallbackChain:
 
     def test_custom_fallback_priority(self):
         """Test that fallback priority is respected from config."""
-        config = get_ai_config()
+        with patch.dict(os.environ, {}, clear=True):
+            reset_ai_config()
+            config = get_ai_config()
 
-        # Check that priority list is as expected
-        expected_priority = ["claude_api", "mistral_api", "openai", "ollama", "clipboard"]
-        assert config.fallback_priority == expected_priority
+            # Default priority puts mistral_api first (magma-cycling strategy)
+            expected_priority = ["mistral_api", "claude_api", "openai", "ollama", "clipboard"]
+            assert config.fallback_priority == expected_priority
 
     def test_fallback_with_all_api_providers_unavailable(self):
         """Test fallback when all API providers are unavailable."""
@@ -221,8 +223,8 @@ class TestFallbackScenarios:
             # Should have multiple fallbacks
             assert len(chain) >= 3
 
-            # If first fails, has backup
-            assert chain[0] == "claude_api"
+            # claude_api is configured (key set, even if expired) and openai is also there
+            assert "claude_api" in chain
             assert "openai" in chain
             assert "clipboard" in chain
 
@@ -276,3 +278,86 @@ class TestFallbackScenarios:
             # Clipboard always available as final fallback
             chain = config.get_fallback_chain()
             assert "clipboard" in chain
+
+
+class TestFallbackPriorityOverride:
+    """Tests for AI_FALLBACK_PRIORITY env var override."""
+
+    def setup_method(self):
+        """Reset config before each test."""
+        reset_ai_config()
+
+    def teardown_method(self):
+        """Reset config after each test."""
+        reset_ai_config()
+
+    def test_default_priority_puts_mistral_first(self):
+        """Default fallback priority should put mistral_api first (magma-cycling strategy)."""
+        with patch.dict(os.environ, {}, clear=True):
+            reset_ai_config()
+            config = get_ai_config()
+
+            assert config.fallback_priority[0] == "mistral_api"
+            assert config.fallback_priority == [
+                "mistral_api",
+                "claude_api",
+                "openai",
+                "ollama",
+                "clipboard",
+            ]
+
+    def test_env_override_replaces_default_order(self):
+        """AI_FALLBACK_PRIORITY env var overrides the default order."""
+        with patch.dict(
+            os.environ,
+            {"AI_FALLBACK_PRIORITY": "claude_api,mistral_api,clipboard"},
+            clear=True,
+        ):
+            reset_ai_config()
+            config = get_ai_config()
+
+            assert config.fallback_priority == ["claude_api", "mistral_api", "clipboard"]
+
+    def test_env_override_with_whitespace_is_trimmed(self):
+        """Whitespace around provider names in env var is stripped."""
+        with patch.dict(
+            os.environ,
+            {"AI_FALLBACK_PRIORITY": " mistral_api , clipboard "},
+            clear=True,
+        ):
+            reset_ai_config()
+            config = get_ai_config()
+
+            assert config.fallback_priority == ["mistral_api", "clipboard"]
+
+    def test_env_override_filters_unknown_providers(self):
+        """Unknown provider names in env var are silently dropped."""
+        with patch.dict(
+            os.environ,
+            {"AI_FALLBACK_PRIORITY": "mistral_api,bogus_provider,clipboard"},
+            clear=True,
+        ):
+            reset_ai_config()
+            config = get_ai_config()
+
+            assert config.fallback_priority == ["mistral_api", "clipboard"]
+
+    def test_env_override_blank_falls_back_to_default(self):
+        """Blank or empty env var falls back to default priority."""
+        with patch.dict(os.environ, {"AI_FALLBACK_PRIORITY": "   "}, clear=True):
+            reset_ai_config()
+            config = get_ai_config()
+
+            assert config.fallback_priority[0] == "mistral_api"
+
+    def test_env_override_only_unknown_falls_back_to_default(self):
+        """Env var with only unknown providers falls back to default."""
+        with patch.dict(
+            os.environ,
+            {"AI_FALLBACK_PRIORITY": "bogus1,bogus2"},
+            clear=True,
+        ):
+            reset_ai_config()
+            config = get_ai_config()
+
+            assert config.fallback_priority[0] == "mistral_api"

--- a/tests/integration/test_provider_integration.py
+++ b/tests/integration/test_provider_integration.py
@@ -222,7 +222,7 @@ class TestProviderIntegration:
             # Clipboard should be last (fallback of last resort)
             assert chain[-1] == "clipboard"
 
-            # Should maintain priority order
-            expected_order = ["claude_api", "mistral_api", "openai", "ollama", "clipboard"]
+            # Default order has mistral_api first (magma-cycling strategy)
+            expected_order = ["mistral_api", "claude_api", "openai", "ollama", "clipboard"]
             available_in_order = [p for p in expected_order if p in chain]
             assert chain == available_in_order


### PR DESCRIPTION
## Why

Bug détecté end-of-week prod 2026-05-03 18:53 : l'orchestrateur a échoué avec `401 invalid x-api-key` sur `claude_api`. Root cause : `AIProvidersConfig.fallback_priority = ["claude_api", "mistral_api", ...]` et `mcp_direct` prend `api_providers[0]` sans tester la connectivité. Une `ANTHROPIC_API_KEY` stale dans l'env container masque la disponibilité de Mistral pourtant correctement configurée.

La stratégie magma-cycling est explicitement `mistral_api` en priorité + auto-consommation du prompt via Claude Desktop. L'ordre par défaut reflète maintenant cette stratégie.

## What

- `magma_cycling/config/ai_providers.py` :
  - Constante `DEFAULT_FALLBACK_PRIORITY = ["mistral_api", "claude_api", "openai", "ollama", "clipboard"]`
  - Méthode `_resolve_fallback_priority()` honorant l'env var `AI_FALLBACK_PRIORITY=p1,p2,...`
  - Whitespace stripped, providers inconnus filtrés, fallback default si blank ou garbage only

- Tests :
  - 6 nouveaux tests dans `TestFallbackPriorityOverride` (default order, env override, whitespace, unknown filter, blank/garbage fallback)
  - 4 tests existants alignés sur le nouvel ordre default

## Test plan

- [x] AI provider tests ciblés → 46/46 PASS
- [x] Tests unit (sans integration) → 3550 PASS, 4 skipped intentionnels
- [x] Tests integration → 52 PASS, 1 skipped intentionnel
- [x] Pre-commit hooks (black, ruff, isort, pydocstyle, safe I/O, etc.) → all PASS
- [ ] Post-merge prod : retag :stable + redeploy + retry end-of-week(S091) → status=success attendu

🤖 Generated with [Claude Code](https://claude.com/claude-code)