### PR TITLE
fix(mcp): generate CSRF state in health-authorize OAuth flow

### DIFF
--- a/magma_cycling/_mcp/handlers/health.py
+++ b/magma_cycling/_mcp/handlers/health.py
@@ -80,6 +80,8 @@ async def handle_health_auth_status(args: dict) -> list[TextContent]:
 async def handle_health_authorize(args: dict) -> list[TextContent]:
     """Handle health provider OAuth authorization flow."""
     with suppress_stdout_stderr():
+        import secrets
+
         from magma_cycling.config import create_withings_client
         from magma_cycling.health import create_health_provider
 
@@ -89,8 +91,16 @@ async def handle_health_authorize(args: dict) -> list[TextContent]:
         authorization_code = args.get("authorization_code")
 
         if not authorization_code:
-            # Step 1: Return authorization URL
-            auth_url = client.get_authorization_url()
+            # Step 1: Return authorization URL.
+            # Withings durcit OAuth 2.0 et exige le param `state` (anti-CSRF) — sans
+            # ce param l'authorize endpoint répond `invalid_request — The state
+            # parameter is required` au callback. Le handler génère un nonce qu'il
+            # passe au client. Note : on ne valide pas le state retourné côté
+            # callback (le tool step 2 ne reçoit que `authorization_code`, pas
+            # `state` du callback URL) — la protection CSRF est donc cosmétique
+            # ici, suffisante pour satisfaire Withings.
+            state = secrets.token_urlsafe(32)
+            auth_url = client.get_authorization_url(state=state)
 
             result = {
                 "step": "authorization_required",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.8.1"
+version = "3.8.2"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/tests/test_mcp_new_handlers.py
+++ b/tests/test_mcp_new_handlers.py
@@ -1347,6 +1347,32 @@ class TestHandleHealthAuthorize:
         assert "instructions" in data
 
     @pytest.mark.asyncio
+    async def test_no_code_passes_csrf_state_to_client(self):
+        """Withings exige le param `state` (anti-CSRF) — handler doit le générer.
+
+        Sans `state`, Withings répond `invalid_request — The state parameter is
+        required` au callback. Régression observée 2026-05-08 lors d'un
+        re-OAuth bundle local.
+        """
+        from magma_cycling.mcp_server import handle_health_authorize
+
+        mock_client = Mock()
+        mock_client.get_authorization_url.return_value = "https://account.withings.com/...&state=x"
+
+        with patch("magma_cycling.config.create_withings_client", return_value=mock_client):
+            await handle_health_authorize({})
+            await handle_health_authorize({})
+
+        assert mock_client.get_authorization_url.call_count == 2
+        states = [
+            call.kwargs.get("state") for call in mock_client.get_authorization_url.call_args_list
+        ]
+        assert all(states), "state must be passed to get_authorization_url"
+        assert states[0] != states[1], "state must be a fresh random nonce per call"
+        for s in states:
+            assert isinstance(s, str) and len(s) >= 16, "state must be a non-trivial string"
+
+    @pytest.mark.asyncio
     async def test_with_code_exchanges_successfully(self):
         from magma_cycling.mcp_server import handle_health_authorize
 


### PR DESCRIPTION
## Why

Withings durcit OAuth 2.0 et exige le param `state` côté authorize endpoint — sans ce param, le callback retourne `invalid_request — The state parameter is required` et le flow OAuth échoue dès le premier clic browser.

Régression observée 2026-05-08 lors d'un re-OAuth bundle local (cf brief TNR LOCAL incident #1, `~/Documents/Claude/BRIEF_TNR_LOCAL_20260508.md`).

## What

`WithingsClient.get_authorization_url(state=None)` accepte déjà le param, mais le handler `handle_health_authorize` (step 1) ne le passait jamais. Fix = handler génère `secrets.token_urlsafe(32)` et passe en kwarg.

**Note de scope** : on ne valide pas le `state` retourné côté callback (le tool step 2 ne reçoit que `authorization_code`, pas `state` du callback URL). La protection CSRF reste cosmétique côté magma-cycling — suffisant pour satisfaire Withings, future-work pour CSRF stricte si besoin.

## Test plan

- [x] `test_no_code_passes_csrf_state_to_client` ajouté : vérifie state non-vide, ≥16 chars, différent entre 2 invocations (randomness, pas constante)
- [x] 4/4 `TestHandleHealthAuthorize` verts en local
- [ ] CI verte
- [ ] Validation manuelle : un re-OAuth Withings bundle local doit passer sans `&state=…` ajouté manuellement à l'URL