### PR TITLE
feat(docker): inject outillages SSH deploy key for magma-cycling-tools transitive install

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,27 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      # Deploy key SSH read-only pour cloner outillages (repo privé), dep
+      # transitive de magma-cycling-tools v0.2.0 — cf. Dockerfile commentaire
+      # "RUN --mount=type=secret,id=outillages_deploy_key". Le secret
+      # OUTILLAGES_DEPLOY_KEY est provisionné côté repo Settings → Secrets.
+      # ADR v5 prérequis Étape 1 + msg admin id=2203 + PR magma-cycling-tools #1.
+      #
+      # Garde-fou sécu (admin advice msg id=2216) : mktemp -d crée un dir
+      # 700 (lecture inaccessible aux autres users sur le runner ; même si
+      # GHA runner est éphémère mono-user, principe de défense en profondeur)
+      # + umask 077 garantit le fichier key en mode 600 dès sa création
+      # (évite la fenêtre race entre `echo > path` et `chmod 600`).
+      - name: Write outillages deploy key for build
+        id: deploy_key
+        run: |
+          KEY_DIR="$(mktemp -d)"
+          KEY_PATH="$KEY_DIR/outillages-deploy-key"
+          umask 077
+          echo "${{ secrets.OUTILLAGES_DEPLOY_KEY }}" > "$KEY_PATH"
+          echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
+          echo "key_dir=$KEY_DIR" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -55,3 +76,27 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            outillages_deploy_key=${{ steps.deploy_key.outputs.key_path }}
+
+      # NB sécu (admin advice msg id=2216 point 2) : la privkey ne doit
+      # jamais apparaître dans une layer de l'image. Le pattern Dockerfile
+      # `RUN --mount=type=secret` garantit que le secret reste tmpfs et
+      # n'est jamais layered (BuildKit gère ça). Vérification ad-hoc
+      # impractical en CI multi-arch (build-push-action ne load pas
+      # localement après push). Pour audit manuel post-déploiement :
+      #   docker pull <image>
+      #   docker history --no-trunc <image> | grep -i "PRIVATE KEY"
+      #   docker run --rm <image> sh -c 'find / -name "id_*" -o -name "*.priv" 2>/dev/null'
+      # Doit retourner vide.
+
+      # Cleanup defensive — secret tmpfs est déjà nettoyé par GHA runner à
+      # destruction du job, mais shred explicite limite la fenêtre où une
+      # étape suivante pourrait y accéder par erreur.
+      - name: Cleanup outillages deploy key
+        if: always()
+        run: |
+          if [ -n "${{ steps.deploy_key.outputs.key_path }}" ]; then
+            shred -u "${{ steps.deploy_key.outputs.key_path }}" 2>/dev/null || true
+            rm -rf "${{ steps.deploy_key.outputs.key_dir }}" 2>/dev/null || true
+          fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,8 @@
+# syntax=docker/dockerfile:1.4
+# Directive `syntax` requise pour `RUN --mount=type=secret` utilisé plus bas
+# (BuildKit feature). Avec ça, le deploy key SSH outillages est monté tmpfs
+# au build de l'étape pip install — jamais dans une layer image.
+
 # =============================================================================
 # Stage 1 : builder — export requirements via Poetry
 # =============================================================================
@@ -46,11 +51,29 @@ RUN pip install --no-cache-dir -e .
 
 # Installer magma-cycling-tools (source of truth pour data_repo_sync et futurs
 # adapters/ops, spin-off d'outillages). Repo public → pas d'auth nécessaire au
-# build. Restaure l'entry point `data-repo-sync` invoqué par supercronic au
-# tick 22:30 (cron quotidien) et 20:30 (dimanche), KO depuis le commit
-# 8e01f8d (extraction des tools vers outillages sans mise à jour du Dockerfile).
-RUN pip install --no-cache-dir \
-    git+https://github.com/stephanejouve/magma-cycling-tools.git@main
+# build de magma-cycling-tools lui-même. Restaure l'entry point `data-repo-sync`
+# invoqué par supercronic au tick 22:30 (cron quotidien) et 20:30 (dimanche),
+# KO depuis le commit 8e01f8d (extraction des tools vers outillages sans mise
+# à jour du Dockerfile).
+#
+# **Auth SSH outillages requise depuis magma-cycling-tools v0.2.0** :
+# magma-cycling-tools v0.2.0 déclare `outillages` (repo PRIVÉ) comme dep
+# transitive pour le safety net alerting Talk dans `data_repo_sync.py::_alert_talk()`.
+# Sans la clé SSH, pip échouait silencieusement à résoudre cette dep, et le
+# runtime container attrapait l'ImportError → bug 13 jours d'alertes infra-alerts
+# muettes en prod. Cf. ADR v5 prérequis Étape 1 + msg admin id=2203 sur
+# 1:1 admin-leader + PR magma-cycling-tools #1.
+#
+# Pattern Option 2 (validé Admin 2026-05-09) : BuildKit secret mount, key tmpfs
+# disponible uniquement pendant le RUN, jamais dans une layer image. Le secret
+# `outillages_deploy_key` est passé par le caller (GitHub Actions
+# build-push-action ou `docker build --secret` en local).
+RUN --mount=type=secret,id=outillages_deploy_key,target=/run/secrets/key \
+    mkdir -p /root/.ssh && \
+    ssh-keyscan -t ed25519 github.com >> /root/.ssh/known_hosts && \
+    GIT_SSH_COMMAND="ssh -i /run/secrets/key -o StrictHostKeyChecking=yes -o IdentitiesOnly=yes" \
+    pip install --no-cache-dir \
+        git+https://github.com/stephanejouve/magma-cycling-tools.git@main
 
 # Crontab + entrypoint
 COPY docker/crontab /app/crontab


### PR DESCRIPTION
## Contexte

ADR v5 prérequis Étape 1 — déploiement container support pour le safety net alerting (PR magma-cycling-tools #1, mergée v0.3.0).

**Bug 13 jours en prod** : magma-cycling-tools v0.2.0 déclare `outillages` (repo PRIVÉ `stephanejouve/outillages`) comme dep transitive pour `_alert_talk()` dans `data_repo_sync.py`. Sans clé SSH, le pip install échouait silencieusement à résoudre cette dep, et le runtime container attrapait l'ImportError → 13 jours d'alertes infra-alerts muettes en prod cron-jobs-1 stack #33.

**Pattern Option 2** (validé Admin) : BuildKit secret mount, key tmpfs disponible uniquement pendant le RUN, jamais dans une layer image.

## Changes

### `docker/Dockerfile`
- `# syntax=docker/dockerfile:1.4` (requis pour `RUN --mount=type=secret`)
- Refacto du RUN pip install magma-cycling-tools : mount du secret `outillages_deploy_key` à `/run/secrets/key`, ssh-keyscan github.com pour known_hosts, GIT_SSH_COMMAND inline (pas de cp ailleurs → garantit no-leak vers layer)

### `.github/workflows/docker-publish.yml`
- Step `Write outillages deploy key for build` : mktemp -d (700) + umask 077
- Step `Build and push` : `secrets:` block pointant vers le fichier key (BuildKit consomme par fichier)
- Step `Cleanup outillages deploy key` : `if: always()` shred + rm -rf du tempdir
- Commentaires référençant les commandes audit manuel post-déploiement

## Test plan
- [ ] CI build green (gated sur secret `OUTILLAGES_DEPLOY_KEY` provisionné par Admin)
- [ ] Image tag `:stable` poussée sur ghcr.io après tag git `v*`
- [ ] Audit post-build : `docker history | grep PRIVATE KEY` doit retourner vide
- [ ] Admin redéploie stack #33 prod → cron-jobs-1 récupère l'image avec `outillages` installé → next pull-rebase fail produit msg sur infra-alerts

## Dépend de
- `stephanejouve/magma-cycling-tools#1` (mergée v0.3.0)

## Coordination
PR proxiée par Leader (PAT devjunior read-only sur ce repo). Auteur effectif du commit : devjunior (branche `feat/build-with-outillages-ssh` poussée par Junior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)