### PR TITLE
fix(ci): align docker-publish secret-write pattern with magma-cycling-tools workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,11 +57,21 @@ jobs:
       # (évite la fenêtre race entre `echo > path` et `chmod 600`).
       - name: Write outillages deploy key for build
         id: deploy_key
+        env:
+          # Pattern aligné sur magma-cycling-tools/.github/workflows/lint-and-test.yml
+          # qui passe vert : exposer le secret via env: + écrire avec
+          # `printf '%s\n'` qui garantit exactement un trailing newline (vs
+          # `echo` qui peut interpréter backslashes selon le shell, et la
+          # forme inline `${{ secrets.X }}` interpolée par GitHub Actions
+          # peut introduire des CR/LF mal formés). Diff cosmétique vs
+          # fonctionnel : sans ce pattern, `Load key: error in libcrypto`
+          # (vu sur run 25609550440 du tag v3.34.0).
+          OUTILLAGES_DEPLOY_KEY: ${{ secrets.OUTILLAGES_DEPLOY_KEY }}
         run: |
           KEY_DIR="$(mktemp -d)"
           KEY_PATH="$KEY_DIR/outillages-deploy-key"
           umask 077
-          echo "${{ secrets.OUTILLAGES_DEPLOY_KEY }}" > "$KEY_PATH"
+          printf '%s\n' "$OUTILLAGES_DEPLOY_KEY" | tr -d '\r' > "$KEY_PATH"
           echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
           echo "key_dir=$KEY_DIR" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Contexte

Le run docker-publish.yml sur tag `v3.34.0` (run id 25609550440) a failed avec :

```
Load key "/run/secrets/key": error in libcrypto
git@github.com: Permission denied (publickey).
```

## Cause

Le step `Write outillages deploy key for build` utilise `echo "${{ secrets.OUTILLAGES_DEPLOY_KEY }}" > $KEY_PATH` — interpolation inline GHA + `echo` peut malformer la key (backslash interprété, CR/LF mal positionnés).

Diagnostic transmis Admin (msg id≈2228) qui confirme l'hypothèse 1 (newlines workflow shell) plutôt que mismatch privkey/pubkey.

## Fix

Aligne sur le pattern qui passe vert côté magma-cycling-tools (workflow `lint-and-test.yml` mergé dans v0.3.0) :
- expose le secret via `env:` (évite l'interpolation inline)
- `printf '%s\n' "$VAR"` (un seul trailing newline garanti, pas d'interprétation backslash)
- `| tr -d '\r'` (defensive — strip CR si secret stockage CRLF)

Bug-fix pur, aucune behavior change ni regression possible.

## Test plan

- [ ] CI build green sur cette PR (workflow `docker-publish.yml` ne tourne pas sur PR mais l'inspection visuelle suffit pour ce niveau de patch)
- [ ] Une fois mergé, semantic-release crée nouveau tag (probable v3.34.1)
- [ ] docker-publish.yml re-tourne sur le tag, build green, image `:stable` push ghcr.io
- [ ] Admin redéploie stack #33 prod, safety net alerting actif

## Coordination

PR proxiée par Leader (PAT devjunior 403 sur magma-cycling). Auteur effectif : devjunior (branche `fix/build-secret-write-pattern` poussée par Junior msg id≈2229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)