### PR TITLE
fix(ci): switch deploy key secret to base64 single-line workaround

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,32 +46,31 @@ jobs:
 
       # Deploy key SSH read-only pour cloner outillages (repo privé), dep
       # transitive de magma-cycling-tools v0.2.0 — cf. Dockerfile commentaire
-      # "RUN --mount=type=secret,id=outillages_deploy_key". Le secret
-      # OUTILLAGES_DEPLOY_KEY est provisionné côté repo Settings → Secrets.
-      # ADR v5 prérequis Étape 1 + msg admin id=2203 + PR magma-cycling-tools #1.
+      # "RUN --mount=type=secret,id=outillages_deploy_key".
       #
-      # Garde-fou sécu (admin advice msg id=2216) : mktemp -d crée un dir
-      # 700 (lecture inaccessible aux autres users sur le runner ; même si
-      # GHA runner est éphémère mono-user, principe de défense en profondeur)
-      # + umask 077 garantit le fichier key en mode 600 dès sa création
-      # (évite la fenêtre race entre `echo > path` et `chmod 600`).
+      # Pattern base64 (workaround multilignes GHA secret) : après les
+      # 2 fails consécutifs des runs v3.34.0 + v3.34.1 avec
+      # `Load key "/run/secrets/key": error in libcrypto`, le constat est
+      # que GHA expose mal une privkey OpenSSH multilignes via
+      # `${{ secrets.X }}` (un quelconque étage de la chaîne storage→runtime
+      # introduit du mangling). Workaround robuste : Admin re-poste la
+      # privkey en base64 single-line (zéro newline → zéro mangling
+      # possible) sous un nouveau secret `OUTILLAGES_DEPLOY_KEY_B64`, et
+      # le workflow décode au moment d'écrire le fichier.
+      # Cf. msg admin id≈2243 (déploiement nocturne 2026-05-09).
+      #
+      # Garde-fou sécu : mktemp -d 700 (défense en profondeur sur runner
+      # éphémère) + install -m 600 garantit fichier en mode safe avant écriture
+      # (évite race condition vs chmod après).
       - name: Write outillages deploy key for build
         id: deploy_key
         env:
-          # Pattern aligné sur magma-cycling-tools/.github/workflows/lint-and-test.yml
-          # qui passe vert : exposer le secret via env: + écrire avec
-          # `printf '%s\n'` qui garantit exactement un trailing newline (vs
-          # `echo` qui peut interpréter backslashes selon le shell, et la
-          # forme inline `${{ secrets.X }}` interpolée par GitHub Actions
-          # peut introduire des CR/LF mal formés). Diff cosmétique vs
-          # fonctionnel : sans ce pattern, `Load key: error in libcrypto`
-          # (vu sur run 25609550440 du tag v3.34.0).
-          OUTILLAGES_DEPLOY_KEY: ${{ secrets.OUTILLAGES_DEPLOY_KEY }}
+          OUTILLAGES_DEPLOY_KEY_B64: ${{ secrets.OUTILLAGES_DEPLOY_KEY_B64 }}
         run: |
           KEY_DIR="$(mktemp -d)"
           KEY_PATH="$KEY_DIR/outillages-deploy-key"
-          umask 077
-          printf '%s\n' "$OUTILLAGES_DEPLOY_KEY" | tr -d '\r' > "$KEY_PATH"
+          install -m 600 /dev/null "$KEY_PATH"
+          printf '%s' "$OUTILLAGES_DEPLOY_KEY_B64" | base64 -d > "$KEY_PATH"
           echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
           echo "key_dir=$KEY_DIR" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Contexte

Après 2 fails consécutifs docker-publish (v3.34.0 + v3.34.1) avec le même `Load key: error in libcrypto`, le diagnostic est posé : GitHub Actions ne préserve pas fiablement une privkey OpenSSH multiligne à travers `${{ secrets.X }}` — un étage de la chaîne storage→runtime introduit du mangling, même avec le pattern env: + printf '%s\n' + tr -d '\r' qui passe vert côté magma-cycling-tools/lint-and-test.yml.

## Workaround Admin (msg id≈2243)

1. ✅ Ancien deploy key id 150997744 révoqué sur outillages
2. ✅ Nouveau keypair généré (fingerprint `SHA256:4SO0uQT/SSbnvXhFYW67RM6Jfy4Pmj6yh1C0ZMDQkYI`, deploy key id 151001393, read-only verified)
3. ✅ Privkey postée en **base64 single-line** (592 chars, zéro newline → zéro risque mangling) sous secret `OUTILLAGES_DEPLOY_KEY_B64` sur les 2 repos via API libsodium SealedBox
4. ✅ Cleanup admin (shred privkey + base64 + headers)

## Changes côté workflow

- `OUTILLAGES_DEPLOY_KEY` → `OUTILLAGES_DEPLOY_KEY_B64`
- `printf '%s\n' "$KEY" | tr -d '\r'` → `printf '%s' "$KEY_B64" | base64 -d`
- `umask 077` → `install -m 600 /dev/null "$KEY_PATH"` (atomic mode 600)
- Commentaire mis à jour avec post-mortem v3.34.0 + v3.34.1 et référence msg admin id≈2243

## Verdict attendu

- Si build green → safety net alerting unblocked, Admin redéploie stack #33 demain matin → ADR v5 Étape 1 done full
- Si build encore failed → preuve définitive que c'est pas un mangling secret mais un autre étage (Dockerfile mount semantics, openssh-client image, ssh-keyscan, etc.) à investiguer demain

## Cleanup TODO post-stabilisation

- Supprimer ancien secret `OUTILLAGES_DEPLOY_KEY` (multiligne, inutilisable car pubkey révoquée) sur les 2 repos
- Aligner workflow `lint-and-test.yml` magma-cycling-tools sur le même pattern base64 (Junior — quand l'ancien secret sera désactivé)

## Coordination

PR Leader autonome (commit signé via PAT Leader pour préserver pre-commit hooks). Stéphane et Junior ont coupé pour la nuit, Admin standby. CronDelete déjà fait (msg id≈2241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)