### PR TITLE
feat(adr-v5-phase2): writer-scoping + provision-writer + linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,3 +40,7 @@ jobs:
 
     - name: Check safe I/O conformity (encoding=utf-8 enforcement)
       run: python scripts/lint/check_safe_io.py magma_cycling/
+
+    - name: Lint authority-coherence (ADR v5 Phase 2, WARN-only)
+      run: poetry run lint-authority-coherence --self-test
+      continue-on-error: true

--- a/docker/env.example
+++ b/docker/env.example
@@ -12,20 +12,33 @@ INTERVALS_API_KEY=
 # ============================================
 # In Docker, mapped via volume to /data/training-logs
 #
-# Writer-scoped layout (ADR v5 Phase 1) — multi-writer environments:
+# Writer-scoped layout (ADR v5 Phase 2) — multi-writer environments:
 # When several agents (Mac, NAS prod, NAS preprod) share the same data repo,
-# each writer should write under its own opaque-hash subdir to avoid path
+# each writer can write under its own opaque-hash subdir to avoid path
 # collisions. Authority per file glob is declared in `.operators.yaml` at the
-# repo root. Set TRAINING_DATA_REPO to point at THIS writer's subdir, e.g.:
+# repo root.
 #
-#   - NAS prod    → TRAINING_DATA_REPO=/data/training-logs/88bc132e32a0
-#   - NAS preprod → TRAINING_DATA_REPO=/data/training-logs/dd22773d9515
-#   - Solo (no multi-writer concern) → TRAINING_DATA_REPO=/data/training-logs
+# RECOMMENDED PATTERN (v5 Phase 2 onwards) — separate root + writer ID:
+#   TRAINING_DATA_ROOT=/data/training-logs
+#   TRAINING_DATA_WRITER_ID=88bc132e32a0
+#   TRAINING_DATA_WRITER_SCOPED=1   # opt-in feature flag, default OFF
+# When the flag is ON, the code resolves writes/reads to
+#   $TRAINING_DATA_ROOT/$TRAINING_DATA_WRITER_ID
+# and refuses writes outside that subdir except for the whitelist defined
+# in `.operators.yaml::shared_root_files`.
+# Use `provision-writer <alias>` to allocate a new writer ID + register it
+# in `.operators.yaml`.
 #
-# A solo deployment can keep the unscoped form below. Multi-writer deployments
-# MUST point at their hash subdir, otherwise startup health-check (PR #298)
-# will fail-fast looking for `workouts-history.md` at the wrong path.
-TRAINING_DATA_REPO=/data/training-logs
+# DEFAULT (flag OFF, flat layout — same as before ADR v5 Phase 2):
+#   TRAINING_DATA_ROOT=/data/training-logs
+# Equivalent to the legacy TRAINING_DATA_REPO; kept for retro-compat.
+#
+# DEPRECATED (still supported with DeprecationWarning):
+#   TRAINING_DATA_REPO=/data/training-logs    # legacy alias for TRAINING_DATA_ROOT
+# Will be removed one sprint after the writer-scoped wave goes prod.
+TRAINING_DATA_ROOT=/data/training-logs
+# TRAINING_DATA_WRITER_ID=
+# TRAINING_DATA_WRITER_SCOPED=0
 TRAINING_LOGS_PATH=/data/training-logs
 INTELLIGENCE_DATA_DIR=
 

--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -1,6 +1,23 @@
 """Data repository configuration.
 
 Manages paths to the external training-logs data repository.
+
+Phase 2 (ADR v5 — ticket #39) : ajout du writer-scoping. Le repo
+training-logs peut être organisé en subdirs par writer (hash 12-char
+opaque par operator), résolus via ``TRAINING_DATA_WRITER_ID``. Activé
+par feature flag ``TRAINING_DATA_WRITER_SCOPED=1`` (défaut OFF =
+rétro-compat layout flat legacy).
+
+Variables d'environnement :
+
+- ``TRAINING_DATA_ROOT`` (nouveau, ADR v5) : path racine du repo
+  training-logs. Remplace ``TRAINING_DATA_REPO`` (deprecated avec
+  fallback + DeprecationWarning).
+- ``TRAINING_DATA_WRITER_ID`` (nouveau, ADR v5 Phase 2) : hash 12-char
+  identifiant le writer courant. Requis si ``TRAINING_DATA_WRITER_SCOPED=1``.
+- ``TRAINING_DATA_WRITER_SCOPED`` (nouveau, feature flag, défaut ``0``) :
+  si ``1``/``true`` activé, ``data_repo_path = ROOT/<WRITER_ID>``.
+  Sinon (défaut), ``data_repo_path = ROOT`` (layout flat legacy).
 """
 
 import json
@@ -10,6 +27,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import yaml
 from dotenv import load_dotenv
 
 from magma_cycling.paths import get_env_path
@@ -22,41 +40,239 @@ else:
 
 logger = logging.getLogger(__name__)
 
+#: Nom de la var d'env (nouvelle) pour le path racine du repo training-logs.
+ROOT_ENV = "TRAINING_DATA_ROOT"
+
+#: Var d'env legacy, deprecated. Fallback toléré + DeprecationWarning.
+#: Sera supprimée dans une PR future post-wave finale (cf. ADR v5).
+LEGACY_ROOT_ENV = "TRAINING_DATA_REPO"
+
+#: Var d'env du hash 12-char identifiant le writer courant. Requis si
+#: ``TRAINING_DATA_WRITER_SCOPED=1``.
+WRITER_ID_ENV = "TRAINING_DATA_WRITER_ID"
+
+#: Feature flag (défaut OFF). Si ``1``/``true``, active le writer-scoping
+#: (subdirs par writer). Permet rollback instantané via flag (filet de
+#: sécurité #1 du protocole niveau diamant).
+WRITER_SCOPED_ENV = "TRAINING_DATA_WRITER_SCOPED"
+
+#: Nom du fichier d'index `.operators.yaml` à la racine du repo.
+OPERATORS_FILE = ".operators.yaml"
+
+#: Whitelist par défaut des fichiers racine autorisés (utilisée si
+#: ``.operators.yaml`` absent ou ne définit pas ``shared_root_files``).
+DEFAULT_SHARED_ROOT_FILES = [
+    ".gitignore",
+    "README.md",
+    OPERATORS_FILE,
+]
+
+
+def _writer_scoped_enabled() -> bool:
+    """Lit le feature flag ``TRAINING_DATA_WRITER_SCOPED``.
+
+    Returns:
+        ``True`` si ``1``/``true``/``yes`` (case-insensitive), sinon ``False``.
+    """
+    return os.getenv(WRITER_SCOPED_ENV, "0").strip().lower() in ("1", "true", "yes")
+
+
+def _resolve_root_from_env() -> Path | None:
+    """Lit le path racine du repo depuis les vars d'env.
+
+    Priorité :
+    1. ``TRAINING_DATA_ROOT`` (nouvelle var, recommandée)
+    2. ``TRAINING_DATA_REPO`` (deprecated, fallback avec DeprecationWarning)
+
+    Returns:
+        ``Path`` résolu si une des vars est définie, sinon ``None``.
+    """
+    root = os.getenv(ROOT_ENV)
+    legacy = os.getenv(LEGACY_ROOT_ENV)
+    if root:
+        return Path(root).expanduser()
+    if legacy:
+        logger.warning(
+            "%s is deprecated, please rename to %s. "
+            "Fallback will be removed in a future release.",
+            LEGACY_ROOT_ENV,
+            ROOT_ENV,
+        )
+        return Path(legacy).expanduser()
+    return None
+
+
+def _load_operators_yaml(root: Path) -> dict | None:
+    """Charge ``.operators.yaml`` à la racine du repo si présent.
+
+    Args:
+        root: Path racine du repo training-logs.
+
+    Returns:
+        Dict parsé du yaml, ou ``None`` si fichier absent / parse error.
+        Un parse error log un warning mais retourne ``None`` (pas fatal —
+        le caller décide).
+    """
+    yaml_path = root / OPERATORS_FILE
+    if not yaml_path.is_file():
+        return None
+    try:
+        with yaml_path.open(encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        logger.warning("Failed to parse %s: %s", yaml_path, exc)
+        return None
+
 
 class DataRepoConfig:
-    """Configuration for external data repository paths."""
+    """Configuration for external data repository paths.
 
-    def __init__(self, data_repo_path: Path | None = None):
+    En mode legacy (flag OFF, défaut), ``data_repo_path = ROOT``. En mode
+    writer-scoped (``TRAINING_DATA_WRITER_SCOPED=1``),
+    ``data_repo_path = ROOT/<WRITER_ID>`` et ``ROOT`` reste accessible
+    via :attr:`root_path` pour le scope racine (writes whitelist).
+    """
+
+    def __init__(
+        self,
+        data_repo_path: Path | None = None,
+        *,
+        writer_scoped: bool | None = None,
+        writer_id: str | None = None,
+    ):
         """Initialize data repository configuration.
 
         Args:
-            data_repo_path: Path to external data repository.
-                           If None, will try TRAINING_DATA_REPO env var,
-                           then default to ~/training-logs
+            data_repo_path: Override explicite (back-compat tests). Si fourni,
+                bypass la résolution env vars + writer-scoping. Le path est
+                à la fois ``root_path`` et ``data_repo_path``.
+            writer_scoped: Override le feature flag (sinon lu depuis env).
+            writer_id: Override le writer ID (sinon lu depuis env). Requis
+                si ``writer_scoped=True`` et pas d'override ``data_repo_path``.
 
         Raises:
-            FileNotFoundError: If data repository path doesn't exist
+            FileNotFoundError: si data repository path n'existe pas.
+            RuntimeError: si writer-scoped activé mais ``WRITER_ID`` absent.
         """
-        if data_repo_path is None:
-            env_path = os.getenv("TRAINING_DATA_REPO")
-            if env_path:
-                data_repo_path = Path(env_path).expanduser()
+        if data_repo_path is not None:
+            # Override explicite : data_repo_path = root_path (back-compat).
+            self.root_path = Path(data_repo_path).resolve()
+            self.data_repo_path = self.root_path
+            self.writer_id = writer_id
+            self.writer_scoped = bool(writer_scoped) if writer_scoped is not None else False
+        else:
+            root = _resolve_root_from_env()
+            if root is None:
+                root = Path.home() / "training-logs"
+            self.root_path = root.resolve()
+            self.writer_scoped = (
+                writer_scoped if writer_scoped is not None else _writer_scoped_enabled()
+            )
+            if self.writer_scoped:
+                resolved_writer_id = writer_id or os.getenv(WRITER_ID_ENV)
+                if not resolved_writer_id:
+                    raise RuntimeError(
+                        f"{WRITER_ID_ENV} is required when {WRITER_SCOPED_ENV}=1. "
+                        f"Run `provision-writer <alias>` to provision a writer, "
+                        f"or unset {WRITER_SCOPED_ENV} to fall back to flat layout."
+                    )
+                self.writer_id = resolved_writer_id
+                self.data_repo_path = self.root_path / resolved_writer_id
             else:
-                data_repo_path = Path.home() / "training-logs"
-
-        self.data_repo_path = Path(data_repo_path).resolve()
+                self.writer_id = None
+                self.data_repo_path = self.root_path
 
         if not self.data_repo_path.exists():
             raise FileNotFoundError(
                 f"Data repo not found: {self.data_repo_path}\n"
-                f"Set TRAINING_DATA_REPO env var or clone:\n"
+                f"Set {ROOT_ENV} env var or clone:\n"
                 f"  git clone https://github.com/YOUR_USERNAME/training-logs.git ~/training-logs"
             )
+
+        # Cache .operators.yaml content (lazy via property)
+        self._operators_yaml_cache: dict | None = None
+        self._operators_yaml_loaded = False
 
         # Duplicate detection settings (paranoid mode for backfill testing)
         self.paranoid_duplicate_check = True
         self.auto_fix_duplicates = False
         self.duplicate_check_window = 50
+
+    @property
+    def operators_yaml(self) -> dict | None:
+        """Contenu parsé de ``.operators.yaml`` (lazy-loaded, cached)."""
+        if not self._operators_yaml_loaded:
+            self._operators_yaml_cache = _load_operators_yaml(self.root_path)
+            self._operators_yaml_loaded = True
+        return self._operators_yaml_cache
+
+    @property
+    def shared_root_files(self) -> list[str]:
+        """Liste des paths racine autorisés en write (whitelist).
+
+        Lue depuis ``.operators.yaml::shared_root_files`` si défini,
+        sinon retourne :data:`DEFAULT_SHARED_ROOT_FILES`.
+        """
+        ops = self.operators_yaml
+        if ops and isinstance(ops.get("shared_root_files"), list):
+            return list(ops["shared_root_files"])
+        return list(DEFAULT_SHARED_ROOT_FILES)
+
+    def is_safe_write_path(self, path: Path | str) -> bool:
+        """Vérifie qu'un path est autorisé en écriture sous le layout courant.
+
+        En mode legacy (writer_scoped=False) : tout path sous root est OK
+        (rétro-compat).
+
+        En mode writer-scoped : path doit être :
+        - Sous ``data_repo_path`` (= ``root/<writer_id>``), OU
+        - Dans la whitelist ``shared_root_files`` à la racine du repo.
+
+        Tout autre write hors subdir + hors whitelist = refus (guard-rail
+        contre pollution racine).
+
+        Args:
+            path: Path absolu (ou résolvable) à vérifier.
+
+        Returns:
+            ``True`` si write autorisé, ``False`` sinon.
+        """
+        try:
+            p = Path(path).resolve()
+        except (OSError, RuntimeError):
+            return False
+
+        if not self.writer_scoped:
+            # Legacy : tout sous root OK (comportement avant ADR Phase 2)
+            return self._is_under(p, self.root_path)
+
+        # Mode scoped : sous data_repo_path (= root/<writer_id>) OK
+        if self._is_under(p, self.data_repo_path):
+            return True
+
+        # Sinon, doit matcher la whitelist shared_root_files à la racine
+        if not self._is_under(p, self.root_path):
+            return False
+        rel = p.relative_to(self.root_path)
+        rel_str = str(rel)
+        # Compare avec chaque entrée de la whitelist (matching exact ou prefix
+        # pour les patterns dossier comme "docs/architecture/**")
+        for entry in self.shared_root_files:
+            entry_clean = entry.rstrip("/").rstrip("*").rstrip("/")
+            if rel_str == entry or rel_str == entry_clean:
+                return True
+            if entry_clean and rel_str.startswith(entry_clean + "/"):
+                return True
+        return False
+
+    @staticmethod
+    def _is_under(child: Path, parent: Path) -> bool:
+        """``True`` si ``child`` est ``parent`` ou descendant."""
+        try:
+            child.relative_to(parent)
+            return True
+        except ValueError:
+            return False
 
     @property
     def workouts_history_path(self) -> Path:
@@ -187,8 +403,11 @@ def startup_health_check() -> DataRepoConfig | None:
     """Fail-fast startup health-check pour le serveur MCP.
 
     Validation à BOOT (vs lazy au 1er tool call) :
-    - ``TRAINING_DATA_REPO`` env existe et pointe vers un dossier
-    - ``workouts-history.md`` présent à la racine (file à plat post-rollback ADR v5)
+    - ``TRAINING_DATA_ROOT`` (ou legacy ``TRAINING_DATA_REPO``) env existe
+      et pointe vers un dossier
+    - Si ``TRAINING_DATA_WRITER_SCOPED=1`` : ``TRAINING_DATA_WRITER_ID`` set
+      et le subdir existe
+    - ``workouts-history.md`` présent dans ``data_repo_path``
     - Lecture autorisée
 
     En cas d'échec, log FATAL puis ``sys.exit(1)`` avec message clair —
@@ -224,7 +443,7 @@ def startup_health_check() -> DataRepoConfig | None:
             raise PermissionError(f"workouts-history.md not readable: {cfg.workouts_history_path}")
         with cfg.workouts_history_path.open("rb") as fh:
             fh.read(1)
-    except (FileNotFoundError, PermissionError, OSError) as exc:
+    except (FileNotFoundError, PermissionError, OSError, RuntimeError) as exc:
         msg = f"FATAL: training data repo invalid: {exc}"
         logger.error(msg)
         print(msg, file=sys.stderr)
@@ -232,8 +451,11 @@ def startup_health_check() -> DataRepoConfig | None:
 
     head_sha = _git_head_short(cfg.data_repo_path)
     logger.info(
-        "data_repo_health_ok: path=%s workouts_history_bytes=%d head_sha=%s",
+        "data_repo_health_ok: path=%s scoped=%s writer_id=%s "
+        "workouts_history_bytes=%d head_sha=%s",
         cfg.data_repo_path,
+        cfg.writer_scoped,
+        cfg.writer_id or "n/a",
         cfg.workouts_history_path.stat().st_size,
         head_sha or "n/a",
     )

--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -254,7 +254,9 @@ class DataRepoConfig:
         if not self._is_under(p, self.root_path):
             return False
         rel = p.relative_to(self.root_path)
-        rel_str = str(rel)
+        # POSIX-style separator pour matching cross-platform (les patterns
+        # dans .operators.yaml utilisent toujours `/`, jamais `\` Windows).
+        rel_str = rel.as_posix()
         # Compare avec chaque entrée de la whitelist (matching exact ou prefix
         # pour les patterns dossier comme "docs/architecture/**")
         for entry in self.shared_root_files:

--- a/magma_cycling/scripts/lint_authority_coherence.py
+++ b/magma_cycling/scripts/lint_authority_coherence.py
@@ -1,0 +1,285 @@
+"""Lint authority coherence between ``.operators.yaml`` and the actual
+training-logs repo state (ADR v5 Phase 2).
+
+Vérifications :
+
+1. Toute entrée ``writers[<hash>]`` dans ``.operators.yaml`` a son subdir
+   correspondant à la racine du repo.
+2. Tout subdir nommé en hex 12-char (forme writer_hash) à la racine est
+   déclaré dans ``writers``.
+3. Tout fichier/dir à la racine du repo est soit dans la whitelist
+   ``shared_root_files``, soit dans un subdir writer enregistré.
+4. Tout subdir d'un writer marqué ``decommissioned_at != null`` qui contient
+   encore des fichiers tracked → WARN (devrait être archivé/purgé).
+
+Usage ::
+
+    poetry run lint-authority-coherence [PATH]
+    poetry run lint-authority-coherence --self-test
+
+Si ``PATH`` absent, fallback sur ``TRAINING_DATA_ROOT`` env var.
+``--self-test`` exécute un check minimaliste (instantiation OK) sans
+dépendre d'un repo training-logs réel — utile en CI.
+
+Output : violations sur stdout au format GitHub Actions ``::warning ::``.
+Exit code TOUJOURS 0 (WARN-only pendant la transition ADR v5 ; le passage
+en fail-PR sera décidé après stabilisation, cf. ADR v5 §4).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from magma_cycling.config.data_repo import (
+    DEFAULT_SHARED_ROOT_FILES,
+    OPERATORS_FILE,
+    _resolve_root_from_env,
+)
+
+WRITER_HASH_RE = re.compile(r"^[0-9a-f]{12}$")
+
+
+@dataclass(frozen=True)
+class Violation:
+    """Une violation de cohérence détectée par le linter."""
+
+    code: str
+    message: str
+
+    def format_gha(self) -> str:
+        """Format GitHub Actions ``::warning title=<code>::<message>``."""
+        return f"::warning title={self.code}::{self.message}"
+
+    def format_plain(self) -> str:
+        """Format plain text (non-CI)."""
+        return f"[{self.code}] {self.message}"
+
+
+def _load_yaml(path: Path) -> dict | None:
+    if not path.is_file():
+        return None
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except yaml.YAMLError as exc:
+        return {"__parse_error__": str(exc)}
+    if not isinstance(data, dict):
+        return {"__parse_error__": "root is not a mapping"}
+    return data
+
+
+def _whitelist_matches(rel: str, entry: str) -> bool:
+    """``True`` si ``rel`` matche une entrée whitelist (exact ou prefix dir)."""
+    cleaned = entry.rstrip("/").rstrip("*").rstrip("/")
+    if rel == entry or rel == cleaned:
+        return True
+    if cleaned and rel.startswith(cleaned + "/"):
+        return True
+    return False
+
+
+def lint(root: Path) -> list[Violation]:
+    """Lint le repo training-logs à ``root`` et retourne la liste des violations."""
+    violations: list[Violation] = []
+
+    if not root.is_dir():
+        violations.append(
+            Violation("ROOT_MISSING", f"root path does not exist or is not a dir: {root}")
+        )
+        return violations
+
+    yaml_path = root / OPERATORS_FILE
+    operators = _load_yaml(yaml_path)
+
+    if operators is None:
+        # Pas de yaml = layout flat legacy, pas de check à faire.
+        # On émet juste un INFO discret.
+        violations.append(
+            Violation(
+                "OPERATORS_YAML_ABSENT",
+                f"{OPERATORS_FILE} absent — flat layout assumed (no scoping check).",
+            )
+        )
+        return violations
+
+    if "__parse_error__" in operators:
+        violations.append(
+            Violation(
+                "OPERATORS_YAML_PARSE_ERROR",
+                f"{yaml_path}: {operators['__parse_error__']}",
+            )
+        )
+        return violations
+
+    writers = operators.get("writers") or {}
+    if not isinstance(writers, dict):
+        violations.append(
+            Violation(
+                "OPERATORS_YAML_INVALID",
+                f"{yaml_path}: 'writers' must be a mapping",
+            )
+        )
+        writers = {}
+
+    whitelist = operators.get("shared_root_files")
+    if not isinstance(whitelist, list):
+        whitelist = list(DEFAULT_SHARED_ROOT_FILES)
+
+    # Check 1 : chaque writer déclaré a son subdir
+    for writer_hash, meta in writers.items():
+        subdir = root / writer_hash
+        if not subdir.is_dir():
+            alias = meta.get("alias", "?") if isinstance(meta, dict) else "?"
+            violations.append(
+                Violation(
+                    "WRITER_SUBDIR_MISSING",
+                    f"writer {writer_hash} (alias={alias}) declared in {OPERATORS_FILE} "
+                    f"but subdir not found at {subdir}",
+                )
+            )
+
+    # Check 2 : chaque subdir hex 12-char est déclaré
+    declared_hashes = set(writers.keys())
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        name = entry.name
+        if name.startswith("."):
+            continue
+        if WRITER_HASH_RE.match(name) and name not in declared_hashes:
+            violations.append(
+                Violation(
+                    "WRITER_SUBDIR_UNDECLARED",
+                    f"subdir {name} matches writer-hash format but is not declared "
+                    f"in {OPERATORS_FILE}::writers",
+                )
+            )
+
+    # Check 3 : fichiers/dirs racine hors whitelist + hors writer subdirs
+    for entry in root.iterdir():
+        name = entry.name
+        if name == ".git":
+            continue
+        # Subdir writer déclaré → OK
+        if entry.is_dir() and name in declared_hashes:
+            continue
+        # Match whitelist ?
+        rel = name
+        if any(_whitelist_matches(rel, w) for w in whitelist):
+            continue
+        # Pour les dirs, on regarde aussi si la whitelist contient un pattern
+        # qui couvre leur contenu (ex. docs/architecture/**)
+        if entry.is_dir():
+            covered = any(
+                w.rstrip("/").rstrip("*").rstrip("/").startswith(name + "/")
+                or w.rstrip("/").rstrip("*").rstrip("/") == name
+                for w in whitelist
+            )
+            if covered:
+                continue
+        violations.append(
+            Violation(
+                "ROOT_ENTRY_UNAUTHORIZED",
+                f"{name} at repo root is not in shared_root_files whitelist "
+                f"and not a declared writer subdir",
+            )
+        )
+
+    # Check 4 : writer décommissionné avec subdir non-vide
+    for writer_hash, meta in writers.items():
+        if not isinstance(meta, dict):
+            continue
+        decom = meta.get("decommissioned_at")
+        if decom in (None, "", "null"):
+            continue
+        subdir = root / writer_hash
+        if not subdir.is_dir():
+            continue
+        contents = [p for p in subdir.iterdir() if p.name != ".gitkeep"]
+        if contents:
+            violations.append(
+                Violation(
+                    "DECOMMISSIONED_WRITER_NOT_EMPTY",
+                    f"writer {writer_hash} (alias={meta.get('alias', '?')}) decommissioned "
+                    f"at {decom} but subdir still contains {len(contents)} entries",
+                )
+            )
+
+    return violations
+
+
+def _self_test() -> int:
+    """Sanity check : instantiation + import OK. Pour CI sans repo réel."""
+    print("lint-authority-coherence: self-test OK", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="lint-authority-coherence",
+        description="Lint .operators.yaml ↔ training-logs repo state coherence (ADR v5 Phase 2).",
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        help="Training-logs repo root (default: $TRAINING_DATA_ROOT or $TRAINING_DATA_REPO).",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Sanity check sans dépendre d'un repo réel (mode CI).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("gha", "plain"),
+        default="gha",
+        help="Output format: GitHub Actions warning (default) or plain.",
+    )
+    args = parser.parse_args()
+
+    if args.self_test:
+        return _self_test()
+
+    if args.path:
+        root = Path(args.path).expanduser().resolve()
+    else:
+        env_root = _resolve_root_from_env()
+        if env_root is None:
+            print(
+                "Error: no path provided and TRAINING_DATA_ROOT (or "
+                "TRAINING_DATA_REPO) env var not set. Use --self-test for CI.",
+                file=sys.stderr,
+            )
+            return 0
+        root = env_root.resolve()
+
+    violations = lint(root)
+
+    if not violations:
+        print(
+            f"lint-authority-coherence: OK — no violations found at {root}",
+            file=sys.stderr,
+        )
+        return 0
+
+    formatter = (
+        Violation.format_gha if args.format == "gha" else Violation.format_plain
+    )
+    for v in violations:
+        print(formatter(v))
+    print(
+        f"lint-authority-coherence: {len(violations)} violation(s) at {root} "
+        f"(WARN-only — exit 0 during ADR v5 transition)",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/magma_cycling/scripts/lint_authority_coherence.py
+++ b/magma_cycling/scripts/lint_authority_coherence.py
@@ -1,5 +1,6 @@
-"""Lint authority coherence between ``.operators.yaml`` and the actual
-training-logs repo state (ADR v5 Phase 2).
+"""Lint authority coherence between ``.operators.yaml`` and training-logs repo state.
+
+ADR v5 Phase 2.
 
 Vérifications :
 
@@ -221,6 +222,7 @@ def _self_test() -> int:
 
 
 def main() -> int:
+    """Entry point for the ``lint-authority-coherence`` CLI."""
     parser = argparse.ArgumentParser(
         prog="lint-authority-coherence",
         description="Lint .operators.yaml ↔ training-logs repo state coherence (ADR v5 Phase 2).",
@@ -268,9 +270,7 @@ def main() -> int:
         )
         return 0
 
-    formatter = (
-        Violation.format_gha if args.format == "gha" else Violation.format_plain
-    )
+    formatter = Violation.format_gha if args.format == "gha" else Violation.format_plain
     for v in violations:
         print(formatter(v))
     print(

--- a/magma_cycling/scripts/provision_writer.py
+++ b/magma_cycling/scripts/provision_writer.py
@@ -1,0 +1,283 @@
+"""Provision a new writer for the training-logs repo (ADR v5 Phase 2).
+
+Calcule un hash 12-char opaque depuis ``sha256("<timestamp_utc_z>#<alias>")``,
+ajoute l'entrée dans ``.operators.yaml`` à la racine du repo, crée la subdir
+correspondante, commit + push.
+
+Usage scriptable (CI, setup_wizard) ::
+
+    poetry run provision-writer mac
+    poetry run provision-writer nas-prod --root ~/training-logs
+
+Usage interactif (humain) ::
+
+    poetry run provision-writer --interactive
+    # → prompt l'alias, default = hostname
+
+Format strict du timestamp : ISO 8601 UTC avec suffixe ``Z`` (pas d'offset
+local, secondes sans fraction). Garantit la reproductibilité du hash si un
+provisioning doit être rejoué.
+
+Sortie sur stdout : le hash 12-char (pour scriptability — pipe-friendly).
+Logs INFO + diagnostics sur stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+import os
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from magma_cycling.config.data_repo import (
+    DEFAULT_SHARED_ROOT_FILES,
+    OPERATORS_FILE,
+    _resolve_root_from_env,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_timestamp_z() -> str:
+    """Génère un timestamp UTC strict ISO 8601 avec suffixe ``Z``.
+
+    Format exigé par l'ADR v5 (lignes 60-62) : pas d'offset local, secondes
+    sans fraction. Reproductible.
+    """
+    now = datetime.now(timezone.utc)
+    return now.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _compute_writer_hash(timestamp: str, alias: str) -> str:
+    """Calcule le hash 12-char depuis ``timestamp#alias``.
+
+    Args:
+        timestamp: ISO 8601 UTC strict avec suffixe ``Z``.
+        alias: Nom court humain (ex. ``mac``, ``nas-prod``).
+
+    Returns:
+        Premiers 12 hex chars du SHA256.
+    """
+    payload = f"{timestamp}#{alias}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:12]
+
+
+def _load_or_init_operators(yaml_path: Path) -> dict:
+    """Lit ``.operators.yaml`` ou initialise un squelette par défaut."""
+    if yaml_path.is_file():
+        with yaml_path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"{yaml_path} ne contient pas un mapping YAML valide"
+            )
+        data.setdefault("shared_root_files", list(DEFAULT_SHARED_ROOT_FILES))
+        data.setdefault("writers", {})
+        return data
+    return {
+        "shared_root_files": list(DEFAULT_SHARED_ROOT_FILES),
+        "writers": {},
+    }
+
+
+def _write_operators(yaml_path: Path, data: dict) -> None:
+    """Écrit ``.operators.yaml`` (atomic via tmp + rename, format YAML lisible)."""
+    tmp = yaml_path.with_suffix(yaml_path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, default_flow_style=False, sort_keys=False)
+    tmp.replace(yaml_path)
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    """Wrapper subprocess.run pour git, avec capture + check OFF (caller decide)."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def provision_writer(
+    alias: str,
+    root: Path,
+    *,
+    host: str | None = None,
+    push: bool = True,
+) -> str:
+    """Provisionne un writer dans le repo training-logs.
+
+    Args:
+        alias: Nom court humain du writer (ex. ``mac``, ``nas-prod``).
+        root: Path racine du repo training-logs.
+        host: Hostname de la machine (default = socket.gethostname()).
+        push: Si ``True``, ``git push origin main`` après commit. ``False``
+            pour les tests locaux ou setups offline.
+
+    Returns:
+        Le hash 12-char du writer provisionné.
+
+    Raises:
+        FileNotFoundError: si ``root`` n'existe pas ou n'est pas un git repo.
+        RuntimeError: si l'alias est déjà présent dans ``.operators.yaml``.
+    """
+    if not root.is_dir():
+        raise FileNotFoundError(f"Root path does not exist: {root}")
+    if not (root / ".git").is_dir():
+        raise FileNotFoundError(
+            f"{root} is not a git repository — initialize with `git init` first"
+        )
+
+    timestamp = _utc_timestamp_z()
+    writer_hash = _compute_writer_hash(timestamp, alias)
+    host = host or socket.gethostname()
+
+    yaml_path = root / OPERATORS_FILE
+    operators = _load_or_init_operators(yaml_path)
+
+    # Refus si l'alias existe déjà (active) — éviter écrasement silencieux
+    for existing_hash, meta in (operators.get("writers") or {}).items():
+        if not isinstance(meta, dict):
+            continue
+        if (
+            meta.get("alias") == alias
+            and meta.get("decommissioned_at") in (None, "", "null")
+        ):
+            raise RuntimeError(
+                f"Writer alias {alias!r} already provisioned and active "
+                f"(hash={existing_hash}). Decommission it first or pick a different alias."
+            )
+
+    operators.setdefault("writers", {})[writer_hash] = {
+        "alias": alias,
+        "host": host,
+        "provisioned_at": timestamp,
+        "decommissioned_at": None,
+    }
+
+    _write_operators(yaml_path, operators)
+
+    subdir = root / writer_hash
+    subdir.mkdir(parents=True, exist_ok=True)
+    # Garde-le présent dans git via un .gitkeep (sinon le subdir vide
+    # n'apparaît pas — git ignore les dossiers vides). Créé seulement si
+    # le subdir est vide pour ne pas masquer un usage existant.
+    if not any(subdir.iterdir()):
+        (subdir / ".gitkeep").touch()
+
+    msg = (
+        f"chore(training-logs): provision writer {alias} ({writer_hash})\n\n"
+        f"timestamp_utc: {timestamp}\nhost: {host}\n"
+    )
+    add = _git(["add", OPERATORS_FILE, writer_hash], cwd=root)
+    if add.returncode != 0:
+        raise RuntimeError(f"git add failed: {add.stderr.strip()}")
+    commit = _git(["commit", "-m", msg], cwd=root)
+    if commit.returncode != 0:
+        raise RuntimeError(f"git commit failed: {commit.stderr.strip()}")
+
+    if push:
+        push_res = _git(["push", "origin", "HEAD"], cwd=root)
+        if push_res.returncode != 0:
+            logger.warning(
+                "git push failed (writer provisioned locally only): %s",
+                push_res.stderr.strip(),
+            )
+
+    print(
+        f"Writer provisioned: alias={alias} hash={writer_hash} "
+        f"host={host} timestamp={timestamp}",
+        file=sys.stderr,
+    )
+    return writer_hash
+
+
+def _resolve_root_or_exit(arg_root: str | None) -> Path:
+    """Résolve le root depuis arg CLI ou env var, exit si introuvable."""
+    if arg_root:
+        return Path(arg_root).expanduser().resolve()
+    env_root = _resolve_root_from_env()
+    if env_root is None:
+        print(
+            "Error: --root not provided and TRAINING_DATA_ROOT (or "
+            "TRAINING_DATA_REPO) env var not set.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return env_root.resolve()
+
+
+def main() -> int:
+    """Entry point CLI ``provision-writer``."""
+    parser = argparse.ArgumentParser(
+        prog="provision-writer",
+        description="Provision a new training-logs writer (ADR v5 Phase 2).",
+    )
+    parser.add_argument(
+        "alias",
+        nargs="?",
+        help="Writer alias (e.g. mac, nas-prod). Required unless --interactive.",
+    )
+    parser.add_argument(
+        "--root",
+        help="Override the training-logs repo root (default: env var).",
+    )
+    parser.add_argument(
+        "--host",
+        help="Hostname to record (default: socket.gethostname()).",
+    )
+    parser.add_argument(
+        "--no-push",
+        action="store_true",
+        help="Skip git push origin (commit local only).",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="Prompt for alias if not provided in argv.",
+    )
+    args = parser.parse_args()
+
+    alias = args.alias
+    if not alias:
+        if not args.interactive:
+            print(
+                "Error: alias required. Pass as positional argv or use --interactive.",
+                file=sys.stderr,
+            )
+            return 1
+        default = socket.gethostname() or "local"
+        try:
+            alias = input(f"Writer alias [{default}]: ").strip() or default
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.", file=sys.stderr)
+            return 1
+
+    root = _resolve_root_or_exit(args.root)
+
+    try:
+        writer_hash = provision_writer(
+            alias,
+            root,
+            host=args.host,
+            push=not args.no_push,
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    # Hash sur stdout pour scriptability (eval `provision-writer mac`)
+    print(writer_hash)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/magma_cycling/scripts/provision_writer.py
+++ b/magma_cycling/scripts/provision_writer.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import logging
-import os
 import socket
 import subprocess
 import sys
@@ -75,9 +74,7 @@ def _load_or_init_operators(yaml_path: Path) -> dict:
         with yaml_path.open(encoding="utf-8") as fh:
             data = yaml.safe_load(fh) or {}
         if not isinstance(data, dict):
-            raise RuntimeError(
-                f"{yaml_path} ne contient pas un mapping YAML valide"
-            )
+            raise RuntimeError(f"{yaml_path} ne contient pas un mapping YAML valide")
         data.setdefault("shared_root_files", list(DEFAULT_SHARED_ROOT_FILES))
         data.setdefault("writers", {})
         return data
@@ -147,10 +144,7 @@ def provision_writer(
     for existing_hash, meta in (operators.get("writers") or {}).items():
         if not isinstance(meta, dict):
             continue
-        if (
-            meta.get("alias") == alias
-            and meta.get("decommissioned_at") in (None, "", "null")
-        ):
+        if meta.get("alias") == alias and meta.get("decommissioned_at") in (None, "", "null"):
             raise RuntimeError(
                 f"Writer alias {alias!r} already provisioned and active "
                 f"(hash={existing_hash}). Decommission it first or pick a different alias."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ daily-sync = "magma_cycling.daily_sync:main"
 insert-analysis = "magma_cycling.insert_analysis:main"
 manage-state = "magma_cycling.manage_workflow_state:main"
 backfill-history = "magma_cycling.scripts.backfill_history:main"
+provision-writer = "magma_cycling.scripts.provision_writer:main"
 
 # === Utilitaires ===
 sync-intervals = "magma_cycling.sync_intervals:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ insert-analysis = "magma_cycling.insert_analysis:main"
 manage-state = "magma_cycling.manage_workflow_state:main"
 backfill-history = "magma_cycling.scripts.backfill_history:main"
 provision-writer = "magma_cycling.scripts.provision_writer:main"
+lint-authority-coherence = "magma_cycling.scripts.lint_authority_coherence:main"
 
 # === Utilitaires ===
 sync-intervals = "magma_cycling.sync_intervals:main"

--- a/tests/config/test_data_repo_writer_scoped.py
+++ b/tests/config/test_data_repo_writer_scoped.py
@@ -1,0 +1,345 @@
+"""Tests pour le writer-scoping ADR v5 Phase 2 (ticket #39).
+
+Couvre :
+- Feature flag ``TRAINING_DATA_WRITER_SCOPED`` (default OFF = legacy flat)
+- Résolution ``TRAINING_DATA_ROOT`` + fallback legacy ``TRAINING_DATA_REPO``
+- Mode writer-scoped : ``data_repo_path = ROOT/<WRITER_ID>``
+- Guard-rail ``writer_id`` manquant en mode scoped → RuntimeError
+- ``is_safe_write_path`` legacy permissif vs scoped strict + whitelist
+- Lazy-load ``.operators.yaml`` + parse ``shared_root_files``
+
+Pattern fixture pytest ``temp_training_repo()`` : tmp_path + ``git init`` +
+arborescence templated (workouts-history.md, .operators.yaml, subdirs).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from magma_cycling.config.data_repo import (
+    DEFAULT_SHARED_ROOT_FILES,
+    LEGACY_ROOT_ENV,
+    OPERATORS_FILE,
+    ROOT_ENV,
+    WRITER_ID_ENV,
+    WRITER_SCOPED_ENV,
+    DataRepoConfig,
+)
+
+
+@pytest.fixture
+def temp_training_repo(tmp_path):
+    """Crée un repo training-logs minimal avec git init + arborescence.
+
+    Layout créé :
+    - .git/ (init)
+    - workouts-history.md (vide)
+    - bilans/, data/ (dirs)
+    - .operators.yaml (squelette avec shared_root_files par défaut + 2 writers)
+    - <hash_a>/workouts-history.md, <hash_a>/bilans/, ... (subdir writer A)
+    - <hash_b>/ (subdir writer B vide)
+
+    Returns:
+        Tuple ``(root_path, writer_a_hash, writer_b_hash)``.
+    """
+    repo = tmp_path / "training-logs"
+    repo.mkdir()
+
+    subprocess.run(
+        ["git", "init", "-q", "--initial-branch=main"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.email", "test@magma"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+
+    # Layout flat (legacy compat)
+    (repo / "workouts-history.md").touch()
+    (repo / "bilans").mkdir()
+    (repo / "data").mkdir()
+    (repo / "data" / "week_planning").mkdir()
+    (repo / ".gitignore").write_text("*.pyc\n")
+    (repo / "README.md").write_text("# training-logs\n")
+
+    # 2 subdirs writers fictifs
+    writer_a = "a3f7c1b2c4d5"
+    writer_b = "9d4e2c117a8b"
+    (repo / writer_a).mkdir()
+    (repo / writer_a / "workouts-history.md").touch()
+    (repo / writer_a / "bilans").mkdir()
+    (repo / writer_a / "data").mkdir()
+    (repo / writer_a / "data" / "week_planning").mkdir()
+    (repo / writer_b).mkdir()
+    (repo / writer_b / ".gitkeep").touch()
+
+    # .operators.yaml minimal
+    operators = {
+        "shared_root_files": [
+            ".gitignore",
+            "README.md",
+            ".operators.yaml",
+            "docs/architecture/**",
+        ],
+        "writers": {
+            writer_a: {
+                "alias": "mac",
+                "host": "tiresias",
+                "provisioned_at": "2026-04-20T08:00:00Z",
+                "decommissioned_at": None,
+            },
+            writer_b: {
+                "alias": "nas-prod",
+                "host": "synology",
+                "provisioned_at": "2026-04-20T08:05:00Z",
+                "decommissioned_at": None,
+            },
+        },
+    }
+    with (repo / OPERATORS_FILE).open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(operators, fh)
+
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "initial training-logs fixture"],
+        cwd=repo,
+        check=True,
+    )
+
+    return repo, writer_a, writer_b
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """S'assure qu'aucune var d'env writer-scoping ne fuit entre tests."""
+    for v in (ROOT_ENV, LEGACY_ROOT_ENV, WRITER_ID_ENV, WRITER_SCOPED_ENV):
+        monkeypatch.delenv(v, raising=False)
+
+
+class TestFeatureFlagDefault:
+    """Flag default OFF = layout flat legacy (no-regression critique)."""
+
+    def test_flag_off_data_repo_path_equals_root(self, temp_training_repo, monkeypatch):
+        repo, _, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        cfg = DataRepoConfig()
+        assert cfg.data_repo_path == repo.resolve()
+        assert cfg.root_path == repo.resolve()
+        assert cfg.writer_id is None
+        assert cfg.writer_scoped is False
+
+    def test_flag_unset_treated_as_off(self, temp_training_repo, monkeypatch):
+        repo, _, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        # WRITER_SCOPED unset
+        cfg = DataRepoConfig()
+        assert cfg.writer_scoped is False
+        assert cfg.data_repo_path == repo.resolve()
+
+    def test_flag_zero_treated_as_off(self, temp_training_repo, monkeypatch):
+        repo, _, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(WRITER_SCOPED_ENV, "0")
+        cfg = DataRepoConfig()
+        assert cfg.writer_scoped is False
+
+
+class TestWriterScopedMode:
+    """Flag ON + WRITER_ID → data_repo_path = root/<writer_id>."""
+
+    def test_flag_on_with_writer_id_resolves_subdir(
+        self, temp_training_repo, monkeypatch
+    ):
+        repo, writer_a, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
+        monkeypatch.setenv(WRITER_ID_ENV, writer_a)
+        cfg = DataRepoConfig()
+        assert cfg.writer_scoped is True
+        assert cfg.writer_id == writer_a
+        assert cfg.root_path == repo.resolve()
+        assert cfg.data_repo_path == (repo / writer_a).resolve()
+
+    def test_flag_on_without_writer_id_raises(self, temp_training_repo, monkeypatch):
+        repo, _, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
+        # WRITER_ID volontairement absent
+        with pytest.raises(RuntimeError, match=WRITER_ID_ENV):
+            DataRepoConfig()
+
+    def test_flag_off_via_constructor_overrides_env(
+        self, temp_training_repo, monkeypatch
+    ):
+        """``writer_scoped=False`` constructeur force OFF même si env=1."""
+        repo, writer_a, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
+        monkeypatch.setenv(WRITER_ID_ENV, writer_a)
+        cfg = DataRepoConfig(writer_scoped=False)
+        assert cfg.writer_scoped is False
+        assert cfg.data_repo_path == repo.resolve()
+
+    def test_workouts_history_path_in_subdir_when_scoped(
+        self, temp_training_repo, monkeypatch
+    ):
+        repo, writer_a, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
+        monkeypatch.setenv(WRITER_ID_ENV, writer_a)
+        cfg = DataRepoConfig()
+        assert cfg.workouts_history_path == (repo / writer_a / "workouts-history.md").resolve()
+        assert cfg.bilans_dir == (repo / writer_a / "bilans").resolve()
+        assert cfg.week_planning_dir == (repo / writer_a / "data" / "week_planning").resolve()
+
+
+class TestLegacyEnvFallback:
+    """``TRAINING_DATA_REPO`` deprecated mais fallback obligatoire avec warning."""
+
+    def test_legacy_env_used_when_root_absent(self, temp_training_repo, monkeypatch, caplog):
+        repo, _, _ = temp_training_repo
+        monkeypatch.setenv(LEGACY_ROOT_ENV, str(repo))
+        with caplog.at_level(logging.WARNING, logger="magma_cycling.config.data_repo"):
+            cfg = DataRepoConfig()
+        assert cfg.root_path == repo.resolve()
+        assert any("deprecated" in rec.message.lower() for rec in caplog.records)
+
+    def test_root_takes_priority_over_legacy(
+        self, tmp_path, temp_training_repo, monkeypatch, caplog
+    ):
+        repo, _, _ = temp_training_repo
+        legacy = tmp_path / "legacy-repo"
+        legacy.mkdir()
+        (legacy / "workouts-history.md").touch()
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(LEGACY_ROOT_ENV, str(legacy))
+        with caplog.at_level(logging.WARNING, logger="magma_cycling.config.data_repo"):
+            cfg = DataRepoConfig()
+        assert cfg.root_path == repo.resolve()
+        # Pas de warning quand ROOT prend priorité (même si LEGACY défini)
+        assert not any("deprecated" in rec.message.lower() for rec in caplog.records)
+
+
+class TestIsSafeWritePath:
+    """Guard-rail write : legacy permissif, scoped strict + whitelist."""
+
+    def _config_legacy(self, repo, monkeypatch):
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        return DataRepoConfig()
+
+    def _config_scoped(self, repo, writer, monkeypatch):
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
+        monkeypatch.setenv(WRITER_ID_ENV, writer)
+        return DataRepoConfig()
+
+    def test_legacy_allows_any_path_under_root(
+        self, temp_training_repo, monkeypatch
+    ):
+        repo, _, _ = temp_training_repo
+        cfg = self._config_legacy(repo, monkeypatch)
+        # Tout sous root OK en legacy
+        assert cfg.is_safe_write_path(repo / "workouts-history.md")
+        assert cfg.is_safe_write_path(repo / "bilans" / "S091.md")
+        assert cfg.is_safe_write_path(repo / "data" / "week_planning" / "S091.json")
+
+    def test_legacy_refuses_path_outside_root(
+        self, tmp_path, temp_training_repo, monkeypatch
+    ):
+        repo, _, _ = temp_training_repo
+        cfg = self._config_legacy(repo, monkeypatch)
+        outside = tmp_path / "elsewhere" / "leak.txt"
+        assert cfg.is_safe_write_path(outside) is False
+
+    def test_scoped_allows_under_writer_subdir(
+        self, temp_training_repo, monkeypatch
+    ):
+        repo, writer_a, _ = temp_training_repo
+        cfg = self._config_scoped(repo, writer_a, monkeypatch)
+        assert cfg.is_safe_write_path(repo / writer_a / "workouts-history.md")
+        assert cfg.is_safe_write_path(repo / writer_a / "bilans" / "S091.md")
+
+    def test_scoped_refuses_other_writer_subdir(
+        self, temp_training_repo, monkeypatch
+    ):
+        repo, writer_a, writer_b = temp_training_repo
+        cfg = self._config_scoped(repo, writer_a, monkeypatch)
+        # writer_b est un autre writer — refus de write
+        assert cfg.is_safe_write_path(repo / writer_b / "leak.md") is False
+
+    def test_scoped_refuses_root_write_outside_whitelist(
+        self, temp_training_repo, monkeypatch
+    ):
+        repo, writer_a, _ = temp_training_repo
+        cfg = self._config_scoped(repo, writer_a, monkeypatch)
+        # Pas dans whitelist → refus
+        assert cfg.is_safe_write_path(repo / "leak.md") is False
+        assert cfg.is_safe_write_path(repo / "secret.txt") is False
+
+    def test_scoped_allows_shared_root_files_whitelist(
+        self, temp_training_repo, monkeypatch
+    ):
+        repo, writer_a, _ = temp_training_repo
+        cfg = self._config_scoped(repo, writer_a, monkeypatch)
+        # Dans whitelist (.operators.yaml::shared_root_files)
+        assert cfg.is_safe_write_path(repo / ".gitignore")
+        assert cfg.is_safe_write_path(repo / "README.md")
+        assert cfg.is_safe_write_path(repo / OPERATORS_FILE)
+
+    def test_scoped_allows_shared_root_dir_glob_pattern(
+        self, temp_training_repo, monkeypatch
+    ):
+        """Pattern ``docs/architecture/**`` matche les fichiers sous ce dossier."""
+        repo, writer_a, _ = temp_training_repo
+        cfg = self._config_scoped(repo, writer_a, monkeypatch)
+        assert cfg.is_safe_write_path(repo / "docs" / "architecture" / "x.md")
+
+    def test_scoped_refuses_path_outside_root(
+        self, tmp_path, temp_training_repo, monkeypatch
+    ):
+        repo, writer_a, _ = temp_training_repo
+        cfg = self._config_scoped(repo, writer_a, monkeypatch)
+        assert cfg.is_safe_write_path(tmp_path / "leak.txt") is False
+
+
+class TestOperatorsYaml:
+    """``.operators.yaml`` lazy-loaded, ``shared_root_files`` parsing."""
+
+    def test_operators_yaml_loaded_when_present(
+        self, temp_training_repo, monkeypatch
+    ):
+        repo, _, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        cfg = DataRepoConfig()
+        ops = cfg.operators_yaml
+        assert ops is not None
+        assert "writers" in ops
+        assert "shared_root_files" in ops
+
+    def test_operators_yaml_absent_returns_none(self, tmp_path, monkeypatch):
+        bare = tmp_path / "bare-repo"
+        bare.mkdir()
+        (bare / "workouts-history.md").touch()
+        monkeypatch.setenv(ROOT_ENV, str(bare))
+        cfg = DataRepoConfig()
+        assert cfg.operators_yaml is None
+
+    def test_shared_root_files_from_yaml(self, temp_training_repo, monkeypatch):
+        repo, _, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        cfg = DataRepoConfig()
+        whitelist = cfg.shared_root_files
+        assert ".gitignore" in whitelist
+        assert "README.md" in whitelist
+        assert OPERATORS_FILE in whitelist
+
+    def test_shared_root_files_default_when_yaml_absent(self, tmp_path, monkeypatch):
+        bare = tmp_path / "bare-repo"
+        bare.mkdir()
+        (bare / "workouts-history.md").touch()
+        monkeypatch.setenv(ROOT_ENV, str(bare))
+        cfg = DataRepoConfig()
+        whitelist = cfg.shared_root_files
+        assert sorted(whitelist) == sorted(DEFAULT_SHARED_ROOT_FILES)

--- a/tests/config/test_data_repo_writer_scoped.py
+++ b/tests/config/test_data_repo_writer_scoped.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import logging
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
@@ -50,9 +49,7 @@ def temp_training_repo(tmp_path):
     repo = tmp_path / "training-logs"
     repo.mkdir()
 
-    subprocess.run(
-        ["git", "init", "-q", "--initial-branch=main"], cwd=repo, check=True
-    )
+    subprocess.run(["git", "init", "-q", "--initial-branch=main"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.email", "test@magma"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
 
@@ -149,9 +146,7 @@ class TestFeatureFlagDefault:
 class TestWriterScopedMode:
     """Flag ON + WRITER_ID → data_repo_path = root/<writer_id>."""
 
-    def test_flag_on_with_writer_id_resolves_subdir(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_flag_on_with_writer_id_resolves_subdir(self, temp_training_repo, monkeypatch):
         repo, writer_a, _ = temp_training_repo
         monkeypatch.setenv(ROOT_ENV, str(repo))
         monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
@@ -170,9 +165,7 @@ class TestWriterScopedMode:
         with pytest.raises(RuntimeError, match=WRITER_ID_ENV):
             DataRepoConfig()
 
-    def test_flag_off_via_constructor_overrides_env(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_flag_off_via_constructor_overrides_env(self, temp_training_repo, monkeypatch):
         """``writer_scoped=False`` constructeur force OFF même si env=1."""
         repo, writer_a, _ = temp_training_repo
         monkeypatch.setenv(ROOT_ENV, str(repo))
@@ -182,9 +175,7 @@ class TestWriterScopedMode:
         assert cfg.writer_scoped is False
         assert cfg.data_repo_path == repo.resolve()
 
-    def test_workouts_history_path_in_subdir_when_scoped(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_workouts_history_path_in_subdir_when_scoped(self, temp_training_repo, monkeypatch):
         repo, writer_a, _ = temp_training_repo
         monkeypatch.setenv(ROOT_ENV, str(repo))
         monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
@@ -235,9 +226,7 @@ class TestIsSafeWritePath:
         monkeypatch.setenv(WRITER_ID_ENV, writer)
         return DataRepoConfig()
 
-    def test_legacy_allows_any_path_under_root(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_legacy_allows_any_path_under_root(self, temp_training_repo, monkeypatch):
         repo, _, _ = temp_training_repo
         cfg = self._config_legacy(repo, monkeypatch)
         # Tout sous root OK en legacy
@@ -245,42 +234,32 @@ class TestIsSafeWritePath:
         assert cfg.is_safe_write_path(repo / "bilans" / "S091.md")
         assert cfg.is_safe_write_path(repo / "data" / "week_planning" / "S091.json")
 
-    def test_legacy_refuses_path_outside_root(
-        self, tmp_path, temp_training_repo, monkeypatch
-    ):
+    def test_legacy_refuses_path_outside_root(self, tmp_path, temp_training_repo, monkeypatch):
         repo, _, _ = temp_training_repo
         cfg = self._config_legacy(repo, monkeypatch)
         outside = tmp_path / "elsewhere" / "leak.txt"
         assert cfg.is_safe_write_path(outside) is False
 
-    def test_scoped_allows_under_writer_subdir(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_scoped_allows_under_writer_subdir(self, temp_training_repo, monkeypatch):
         repo, writer_a, _ = temp_training_repo
         cfg = self._config_scoped(repo, writer_a, monkeypatch)
         assert cfg.is_safe_write_path(repo / writer_a / "workouts-history.md")
         assert cfg.is_safe_write_path(repo / writer_a / "bilans" / "S091.md")
 
-    def test_scoped_refuses_other_writer_subdir(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_scoped_refuses_other_writer_subdir(self, temp_training_repo, monkeypatch):
         repo, writer_a, writer_b = temp_training_repo
         cfg = self._config_scoped(repo, writer_a, monkeypatch)
         # writer_b est un autre writer — refus de write
         assert cfg.is_safe_write_path(repo / writer_b / "leak.md") is False
 
-    def test_scoped_refuses_root_write_outside_whitelist(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_scoped_refuses_root_write_outside_whitelist(self, temp_training_repo, monkeypatch):
         repo, writer_a, _ = temp_training_repo
         cfg = self._config_scoped(repo, writer_a, monkeypatch)
         # Pas dans whitelist → refus
         assert cfg.is_safe_write_path(repo / "leak.md") is False
         assert cfg.is_safe_write_path(repo / "secret.txt") is False
 
-    def test_scoped_allows_shared_root_files_whitelist(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_scoped_allows_shared_root_files_whitelist(self, temp_training_repo, monkeypatch):
         repo, writer_a, _ = temp_training_repo
         cfg = self._config_scoped(repo, writer_a, monkeypatch)
         # Dans whitelist (.operators.yaml::shared_root_files)
@@ -288,17 +267,13 @@ class TestIsSafeWritePath:
         assert cfg.is_safe_write_path(repo / "README.md")
         assert cfg.is_safe_write_path(repo / OPERATORS_FILE)
 
-    def test_scoped_allows_shared_root_dir_glob_pattern(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_scoped_allows_shared_root_dir_glob_pattern(self, temp_training_repo, monkeypatch):
         """Pattern ``docs/architecture/**`` matche les fichiers sous ce dossier."""
         repo, writer_a, _ = temp_training_repo
         cfg = self._config_scoped(repo, writer_a, monkeypatch)
         assert cfg.is_safe_write_path(repo / "docs" / "architecture" / "x.md")
 
-    def test_scoped_refuses_path_outside_root(
-        self, tmp_path, temp_training_repo, monkeypatch
-    ):
+    def test_scoped_refuses_path_outside_root(self, tmp_path, temp_training_repo, monkeypatch):
         repo, writer_a, _ = temp_training_repo
         cfg = self._config_scoped(repo, writer_a, monkeypatch)
         assert cfg.is_safe_write_path(tmp_path / "leak.txt") is False
@@ -307,9 +282,7 @@ class TestIsSafeWritePath:
 class TestOperatorsYaml:
     """``.operators.yaml`` lazy-loaded, ``shared_root_files`` parsing."""
 
-    def test_operators_yaml_loaded_when_present(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_operators_yaml_loaded_when_present(self, temp_training_repo, monkeypatch):
         repo, _, _ = temp_training_repo
         monkeypatch.setenv(ROOT_ENV, str(repo))
         cfg = DataRepoConfig()

--- a/tests/scripts/test_lint_authority_coherence.py
+++ b/tests/scripts/test_lint_authority_coherence.py
@@ -1,0 +1,205 @@
+"""Tests pour le linter authority-coherence (ADR v5 Phase 2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from magma_cycling.config.data_repo import OPERATORS_FILE
+from magma_cycling.scripts.lint_authority_coherence import (
+    Violation,
+    lint,
+)
+
+
+def _make_repo(tmp_path: Path, operators: dict | None) -> Path:
+    """Crée un repo training-logs minimal avec optionnellement .operators.yaml."""
+    repo = tmp_path / "training-logs"
+    repo.mkdir()
+    (repo / "workouts-history.md").touch()
+    (repo / ".gitignore").write_text("*.pyc\n")
+    if operators is not None:
+        with (repo / OPERATORS_FILE).open("w", encoding="utf-8") as fh:
+            yaml.safe_dump(operators, fh)
+    return repo
+
+
+class TestLintBasics:
+    def test_root_missing_emits_violation(self, tmp_path):
+        violations = lint(tmp_path / "nope")
+        assert any(v.code == "ROOT_MISSING" for v in violations)
+
+    def test_no_operators_yaml_returns_info(self, tmp_path):
+        repo = _make_repo(tmp_path, None)
+        violations = lint(repo)
+        assert any(v.code == "OPERATORS_YAML_ABSENT" for v in violations)
+
+    def test_clean_repo_no_violations(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE],
+            "writers": {
+                "a3f7c1b2c4d5": {
+                    "alias": "mac",
+                    "host": "tiresias",
+                    "provisioned_at": "2026-04-20T08:00:00Z",
+                    "decommissioned_at": None,
+                },
+            },
+        }
+        repo = _make_repo(tmp_path, operators)
+        (repo / "a3f7c1b2c4d5").mkdir()
+        (repo / "a3f7c1b2c4d5" / ".gitkeep").touch()
+        violations = lint(repo)
+        assert violations == []
+
+
+class TestWriterSubdirChecks:
+    def test_writer_declared_but_subdir_missing(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE],
+            "writers": {
+                "ffffffffffff": {
+                    "alias": "ghost",
+                    "provisioned_at": "2026-04-20T08:00:00Z",
+                    "decommissioned_at": None,
+                },
+            },
+        }
+        repo = _make_repo(tmp_path, operators)
+        violations = lint(repo)
+        assert any(v.code == "WRITER_SUBDIR_MISSING" for v in violations)
+        msg = next(v.message for v in violations if v.code == "WRITER_SUBDIR_MISSING")
+        assert "ffffffffffff" in msg
+        assert "ghost" in msg
+
+    def test_subdir_undeclared_emits_violation(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE],
+            "writers": {},
+        }
+        repo = _make_repo(tmp_path, operators)
+        # Subdir hash 12-char mais non déclaré
+        (repo / "deadbeef1234").mkdir()
+        violations = lint(repo)
+        assert any(v.code == "WRITER_SUBDIR_UNDECLARED" for v in violations)
+
+    def test_non_hash_subdir_not_flagged_as_undeclared(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE, "bilans"],
+            "writers": {},
+        }
+        repo = _make_repo(tmp_path, operators)
+        # bilans = subdir non-hash, OK car dans whitelist
+        (repo / "bilans").mkdir()
+        violations = lint(repo)
+        assert not any(v.code == "WRITER_SUBDIR_UNDECLARED" for v in violations)
+
+
+class TestRootEntryWhitelist:
+    def test_unauthorized_root_file_flagged(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE],
+            "writers": {},
+        }
+        repo = _make_repo(tmp_path, operators)
+        (repo / "leak.txt").write_text("oops")
+        violations = lint(repo)
+        assert any(
+            v.code == "ROOT_ENTRY_UNAUTHORIZED" and "leak.txt" in v.message
+            for v in violations
+        )
+
+    def test_whitelist_dir_pattern_allows_subtree(self, tmp_path):
+        operators = {
+            "shared_root_files": [
+                ".gitignore",
+                "workouts-history.md",
+                OPERATORS_FILE,
+                "docs/architecture/**",
+            ],
+            "writers": {},
+        }
+        repo = _make_repo(tmp_path, operators)
+        (repo / "docs").mkdir()
+        (repo / "docs" / "architecture").mkdir()
+        (repo / "docs" / "architecture" / "adr-v5.md").write_text("# ADR")
+        violations = lint(repo)
+        assert not any(v.code == "ROOT_ENTRY_UNAUTHORIZED" for v in violations)
+
+    def test_git_dir_skipped(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE],
+            "writers": {},
+        }
+        repo = _make_repo(tmp_path, operators)
+        (repo / ".git").mkdir()
+        violations = lint(repo)
+        assert not any(".git" in v.message for v in violations)
+
+
+class TestDecommissionedWriter:
+    def test_decommissioned_writer_with_files_warns(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE],
+            "writers": {
+                "abc123def456": {
+                    "alias": "old-mac",
+                    "provisioned_at": "2025-01-01T00:00:00Z",
+                    "decommissioned_at": "2026-04-15T00:00:00Z",
+                },
+            },
+        }
+        repo = _make_repo(tmp_path, operators)
+        sub = repo / "abc123def456"
+        sub.mkdir()
+        (sub / "lingering.md").write_text("data still here")
+        violations = lint(repo)
+        assert any(v.code == "DECOMMISSIONED_WRITER_NOT_EMPTY" for v in violations)
+
+    def test_decommissioned_writer_only_gitkeep_no_warn(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE],
+            "writers": {
+                "abc123def456": {
+                    "alias": "old-mac",
+                    "provisioned_at": "2025-01-01T00:00:00Z",
+                    "decommissioned_at": "2026-04-15T00:00:00Z",
+                },
+            },
+        }
+        repo = _make_repo(tmp_path, operators)
+        sub = repo / "abc123def456"
+        sub.mkdir()
+        (sub / ".gitkeep").touch()
+        violations = lint(repo)
+        assert not any(v.code == "DECOMMISSIONED_WRITER_NOT_EMPTY" for v in violations)
+
+
+class TestParseErrors:
+    def test_invalid_yaml_emits_parse_error(self, tmp_path):
+        repo = tmp_path / "training-logs"
+        repo.mkdir()
+        (repo / OPERATORS_FILE).write_text("not: valid: yaml: [")
+        violations = lint(repo)
+        assert any(v.code == "OPERATORS_YAML_PARSE_ERROR" for v in violations)
+
+    def test_writers_not_a_dict_emits_invalid(self, tmp_path):
+        operators = {
+            "shared_root_files": [".gitignore", "workouts-history.md", OPERATORS_FILE],
+            "writers": "should-be-a-dict",
+        }
+        repo = _make_repo(tmp_path, operators)
+        violations = lint(repo)
+        assert any(v.code == "OPERATORS_YAML_INVALID" for v in violations)
+
+
+class TestViolationFormat:
+    def test_gha_format(self):
+        v = Violation("CODE_X", "something off")
+        assert v.format_gha() == "::warning title=CODE_X::something off"
+
+    def test_plain_format(self):
+        v = Violation("CODE_X", "something off")
+        assert v.format_plain() == "[CODE_X] something off"

--- a/tests/scripts/test_lint_authority_coherence.py
+++ b/tests/scripts/test_lint_authority_coherence.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 import yaml
 
 from magma_cycling.config.data_repo import OPERATORS_FILE
@@ -107,8 +106,7 @@ class TestRootEntryWhitelist:
         (repo / "leak.txt").write_text("oops")
         violations = lint(repo)
         assert any(
-            v.code == "ROOT_ENTRY_UNAUTHORIZED" and "leak.txt" in v.message
-            for v in violations
+            v.code == "ROOT_ENTRY_UNAUTHORIZED" and "leak.txt" in v.message for v in violations
         )
 
     def test_whitelist_dir_pattern_allows_subtree(self, tmp_path):

--- a/tests/scripts/test_provision_writer.py
+++ b/tests/scripts/test_provision_writer.py
@@ -1,0 +1,152 @@
+"""Tests pour le helper provision-writer (ADR v5 Phase 2)."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from magma_cycling.scripts.provision_writer import (
+    _compute_writer_hash,
+    _utc_timestamp_z,
+    provision_writer,
+)
+
+
+@pytest.fixture
+def empty_training_repo(tmp_path):
+    """Repo training-logs vide initialisé git, prêt pour 1er provision."""
+    repo = tmp_path / "training-logs"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "--initial-branch=main"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.email", "test@magma"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "README.md").write_text("# training-logs\n")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=repo, check=True)
+    return repo
+
+
+class TestUtcTimestampZ:
+    def test_format_strict_z_suffix(self):
+        ts = _utc_timestamp_z()
+        # Format ISO 8601 avec Z (pas +00:00, pas d'offset)
+        assert ts.endswith("Z")
+        # Exact regex : YYYY-MM-DDTHH:MM:SSZ (no fractional seconds)
+        assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", ts)
+        assert "+" not in ts
+
+    def test_no_offset_local_time(self):
+        ts = _utc_timestamp_z()
+        # Pas de signe d'offset local
+        assert "+00:00" not in ts
+
+
+class TestComputeWriterHash:
+    def test_hash_is_12_hex_chars(self):
+        h = _compute_writer_hash("2026-04-20T08:00:00Z", "mac")
+        assert len(h) == 12
+        assert re.match(r"^[0-9a-f]{12}$", h)
+
+    def test_hash_reproducible_for_same_inputs(self):
+        h1 = _compute_writer_hash("2026-04-20T08:00:00Z", "mac")
+        h2 = _compute_writer_hash("2026-04-20T08:00:00Z", "mac")
+        assert h1 == h2
+
+    def test_different_alias_different_hash(self):
+        h1 = _compute_writer_hash("2026-04-20T08:00:00Z", "mac")
+        h2 = _compute_writer_hash("2026-04-20T08:00:00Z", "nas-prod")
+        assert h1 != h2
+
+    def test_different_timestamp_different_hash(self):
+        h1 = _compute_writer_hash("2026-04-20T08:00:00Z", "mac")
+        h2 = _compute_writer_hash("2026-04-20T08:00:01Z", "mac")
+        assert h1 != h2
+
+
+class TestProvisionWriter:
+    def test_creates_yaml_with_writer_entry(self, empty_training_repo):
+        h = provision_writer(
+            "mac",
+            empty_training_repo,
+            host="tiresias",
+            push=False,
+        )
+        yaml_path = empty_training_repo / ".operators.yaml"
+        assert yaml_path.is_file()
+        ops = yaml.safe_load(yaml_path.read_text())
+        assert h in ops["writers"]
+        entry = ops["writers"][h]
+        assert entry["alias"] == "mac"
+        assert entry["host"] == "tiresias"
+        assert entry["provisioned_at"].endswith("Z")
+        assert entry["decommissioned_at"] is None
+
+    def test_creates_subdir_with_gitkeep(self, empty_training_repo):
+        h = provision_writer("mac", empty_training_repo, push=False)
+        subdir = empty_training_repo / h
+        assert subdir.is_dir()
+        # Pour que git tracke le subdir vide, .gitkeep créé
+        assert (subdir / ".gitkeep").is_file()
+
+    def test_default_shared_root_files_seeded(self, empty_training_repo):
+        provision_writer("mac", empty_training_repo, push=False)
+        ops = yaml.safe_load(
+            (empty_training_repo / ".operators.yaml").read_text()
+        )
+        assert "shared_root_files" in ops
+        assert ".gitignore" in ops["shared_root_files"]
+        assert ".operators.yaml" in ops["shared_root_files"]
+
+    def test_commit_created_with_writer_metadata(self, empty_training_repo):
+        h = provision_writer(
+            "mac", empty_training_repo, host="tiresias", push=False
+        )
+        # Vérifier le commit log
+        result = subprocess.run(
+            ["git", "log", "-1", "--pretty=%B"],
+            cwd=empty_training_repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        commit_msg = result.stdout
+        assert "provision writer mac" in commit_msg
+        assert h in commit_msg
+        assert "tiresias" in commit_msg
+
+    def test_appends_to_existing_yaml(self, empty_training_repo):
+        h1 = provision_writer("mac", empty_training_repo, push=False)
+        h2 = provision_writer("nas-prod", empty_training_repo, push=False)
+        ops = yaml.safe_load(
+            (empty_training_repo / ".operators.yaml").read_text()
+        )
+        assert h1 in ops["writers"]
+        assert h2 in ops["writers"]
+        assert ops["writers"][h1]["alias"] == "mac"
+        assert ops["writers"][h2]["alias"] == "nas-prod"
+
+    def test_refuses_duplicate_active_alias(self, empty_training_repo):
+        provision_writer("mac", empty_training_repo, push=False)
+        with pytest.raises(RuntimeError, match="already provisioned and active"):
+            provision_writer("mac", empty_training_repo, push=False)
+
+    def test_returns_hash_for_scriptability(self, empty_training_repo):
+        h = provision_writer("mac", empty_training_repo, push=False)
+        assert len(h) == 12
+        assert re.match(r"^[0-9a-f]{12}$", h)
+
+    def test_raises_if_root_not_a_git_repo(self, tmp_path):
+        not_git = tmp_path / "not-git"
+        not_git.mkdir()
+        with pytest.raises(FileNotFoundError, match="not a git repository"):
+            provision_writer("mac", not_git, push=False)
+
+    def test_raises_if_root_does_not_exist(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            provision_writer("mac", tmp_path / "nope", push=False)

--- a/tests/scripts/test_provision_writer.py
+++ b/tests/scripts/test_provision_writer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
@@ -21,9 +20,7 @@ def empty_training_repo(tmp_path):
     """Repo training-logs vide initialisé git, prêt pour 1er provision."""
     repo = tmp_path / "training-logs"
     repo.mkdir()
-    subprocess.run(
-        ["git", "init", "-q", "--initial-branch=main"], cwd=repo, check=True
-    )
+    subprocess.run(["git", "init", "-q", "--initial-branch=main"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.email", "test@magma"], cwd=repo, check=True)
     subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
     (repo / "README.md").write_text("# training-logs\n")
@@ -96,17 +93,13 @@ class TestProvisionWriter:
 
     def test_default_shared_root_files_seeded(self, empty_training_repo):
         provision_writer("mac", empty_training_repo, push=False)
-        ops = yaml.safe_load(
-            (empty_training_repo / ".operators.yaml").read_text()
-        )
+        ops = yaml.safe_load((empty_training_repo / ".operators.yaml").read_text())
         assert "shared_root_files" in ops
         assert ".gitignore" in ops["shared_root_files"]
         assert ".operators.yaml" in ops["shared_root_files"]
 
     def test_commit_created_with_writer_metadata(self, empty_training_repo):
-        h = provision_writer(
-            "mac", empty_training_repo, host="tiresias", push=False
-        )
+        h = provision_writer("mac", empty_training_repo, host="tiresias", push=False)
         # Vérifier le commit log
         result = subprocess.run(
             ["git", "log", "-1", "--pretty=%B"],
@@ -123,9 +116,7 @@ class TestProvisionWriter:
     def test_appends_to_existing_yaml(self, empty_training_repo):
         h1 = provision_writer("mac", empty_training_repo, push=False)
         h2 = provision_writer("nas-prod", empty_training_repo, push=False)
-        ops = yaml.safe_load(
-            (empty_training_repo / ".operators.yaml").read_text()
-        )
+        ops = yaml.safe_load((empty_training_repo / ".operators.yaml").read_text())
         assert h1 in ops["writers"]
         assert h2 in ops["writers"]
         assert ops["writers"][h1]["alias"] == "mac"


### PR DESCRIPTION
## Summary
PR Phase 2 ADR v5 — wave couplée 1A+1C (livraison Junior, apply Leader).

3 commits appliqués from `feat/training-logs-phase2` :
1. `79a4efc` feat(data-repo): writer-scoping + feature flag (default OFF, retro-compat layout flat)
2. `a4f23f1` feat(scripts): provision-writer entry point (argv `<alias>` + `--interactive`)
3. `d3dc37d` feat(scripts): lint-authority-coherence + step CI WARN-only (continue-on-error)

## Feature flag

- `TRAINING_DATA_WRITER_SCOPED=0` (default) → comportement legacy flat (zéro régression)
- `TRAINING_DATA_WRITER_SCOPED=1` → résolution via `TRAINING_DATA_ROOT + TRAINING_DATA_WRITER_ID` + lecture `.operators.yaml`

## Env vars

- `TRAINING_DATA_ROOT` (nouveau) — repo root, remplace `TRAINING_DATA_REPO`
- `TRAINING_DATA_WRITER_ID` (nouveau) — hash 12-char writer, requis quand flag ON
- `TRAINING_DATA_WRITER_SCOPED` (nouveau) — feature flag
- `TRAINING_DATA_REPO` (déprécié) — fallback avec DeprecationWarning, conservé en transition

## Entry points ajoutés

- `provision-writer <alias>` (avec `--interactive`)
- `lint-authority-coherence` (CI step ajouté en WARN-only)

## Test plan

- [x] 21 tests unitaires `test_data_repo_writer_scoped.py` ✅
- [x] 15 tests intégration `test_provision_writer.py` (fixture pytest tmp_path + git init) ✅
- [x] 15 tests `test_lint_authority_coherence.py` ✅
- [x] Total local : 51/51 verts
- [ ] CI green (en attente)
- [ ] Backward compat vérifiée : env var `TRAINING_DATA_REPO` existante doit continuer à fonctionner sans changement (flag OFF par défaut)

## Coordination wave 1A+1C

Mon scope post-merge (PR A) :
- Exécuter `provision-writer mac --writer-id b08921dae3e7` (préservation hash existant)
- Exécuter `provision-writer nas-prod` + `provision-writer nas-preprod` (nouveaux hashes)
- Commit `.operators.yaml` initial dans le repo `training-logs` (séparé de magma-cycling)

Slot Legacy 4ème writer = doc dans ADR seulement, pas d'entrée créée maintenant.

ADR de référence : `/Users/Shared/ADR-training-logs-sync-v5.md` (hors repo public, conformément à la politique meta-doc).

Co-Authored-By: Junior <devjunior@magma>