### PR TITLE
feat(mcp): expose version + data_repo fields in system_info

### DIFF
--- a/magma_cycling/_mcp/handlers/admin.py
+++ b/magma_cycling/_mcp/handlers/admin.py
@@ -126,11 +126,35 @@ async def handle_system_info(args: dict) -> list[TextContent]:
         except Exception:
             tool_count = -1
 
+        # Version et data repo info — utiles pour TNR post-déploiement.
+        # ``__version__`` peut être stale (semantic-release ne bump pas
+        # ``magma_cycling/__init__.py``) — c'est cosmétique, pas un défaut.
+        try:
+            from magma_cycling import __version__ as version
+        except Exception:
+            version = "unknown"
+
+        data_repo_path: str | None = None
+        data_repo_health_ok = False
+        try:
+            from magma_cycling.config import get_data_config
+
+            cfg = get_data_config()
+            data_repo_path = str(cfg.data_repo_path)
+            data_repo_health_ok = (
+                cfg.data_repo_path.exists() and (cfg.data_repo_path / ".git").exists()
+            )
+        except Exception as e:
+            logger.warning("data_repo discovery failed: %s", e)
+
         result = {
+            "version": version,
             "health": health_info,
             "calendar": calendar_info,
             "ai_providers": ai_info,
             "tool_count": tool_count,
+            "data_repo_path": data_repo_path,
+            "data_repo_health_ok": data_repo_health_ok,
         }
 
     return mcp_response(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.8.2"
+version = "3.9.0"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/tests/_mcp/handlers/test_admin.py
+++ b/tests/_mcp/handlers/test_admin.py
@@ -119,3 +119,48 @@ class TestHandleSystemInfoAIProvidersDiscovery:
         warnings = [r for r in caplog.records if "ai_provider discovery failed" in r.message]
         assert len(warnings) == 1
         assert "simulated config failure" in warnings[0].message
+
+
+class TestHandleSystemInfoExtendedFields:
+    """Tests for the version + data_repo fields exposed for TNR post-deploy."""
+
+    @pytest.mark.asyncio
+    async def test_response_contains_version(self):
+        """The response exposes ``version`` from ``magma_cycling.__version__``."""
+        from magma_cycling import __version__
+        from magma_cycling._mcp.handlers.admin import handle_system_info
+
+        result = await handle_system_info({})
+        data = json.loads(result[0].text)
+        assert data["version"] == __version__
+
+    @pytest.mark.asyncio
+    async def test_response_contains_data_repo_fields(self):
+        """The response exposes ``data_repo_path`` and ``data_repo_health_ok``."""
+        from magma_cycling._mcp.handlers.admin import handle_system_info
+
+        result = await handle_system_info({})
+        data = json.loads(result[0].text)
+        assert "data_repo_path" in data
+        assert "data_repo_health_ok" in data
+        assert isinstance(data["data_repo_health_ok"], bool)
+
+    @pytest.mark.asyncio
+    async def test_data_repo_failure_is_logged_and_fields_safe(self, caplog):
+        """If get_data_config raises, fields fallback to None / False with log warning."""
+        import logging
+
+        from magma_cycling._mcp.handlers.admin import handle_system_info
+
+        with patch(
+            "magma_cycling.config.get_data_config",
+            side_effect=RuntimeError("simulated data_repo failure"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="magma_cycling._mcp.handlers.admin"):
+                result = await handle_system_info({})
+
+        data = json.loads(result[0].text)
+        assert data["data_repo_path"] is None
+        assert data["data_repo_health_ok"] is False
+        warnings = [r for r in caplog.records if "data_repo discovery failed" in r.message]
+        assert len(warnings) == 1


### PR DESCRIPTION
## Summary
Follow-up à PR #341 — adresse l'écart template TNR identifié post-merge (le prompt TNR référençait des champs `__version__` / `data_repo_path` / `data_repo_health_ok` que `handle_system_info` n'exposait pas).

## Changes

`magma_cycling/_mcp/handlers/admin.py` — 3 nouveaux champs dans le retour de `handle_system_info` :

- **`version`** : `magma_cycling.__version__` (peut être stale — twist semantic-release qui ne bumpe pas `__init__.py`, documenté dans commentaire code)
- **`data_repo_path`** : `str(cfg.data_repo_path)` via `get_data_config()`
- **`data_repo_health_ok`** : bool — vérifie path exists + `.git/` dir présent

Failure paths : `version="unknown"`, `data_repo_path=None`, `data_repo_health_ok=False`, logged warning. Aucune exception propagée.

## Test plan

- [x] 3 nouveaux tests `TestHandleSystemInfoExtendedFields` (happy path + failure fallback)
- [x] 11/11 verts en local (`tests/_mcp/handlers/test_admin.py`)
- [x] black + ruff + pydocstyle clean

## Pourquoi

Pendant le TNR PREPROD post-PR #341 (10/05), les checks 1 et 6 ont été marqués FAIL parce que mon prompt TNR référençait ces 3 champs absents du handler. C'était une erreur de template (les champs n'avaient jamais été exposés), pas une régression code. Plutôt que juste corriger le template, on étend le handler pour répondre aux champs attendus en TNR — bénéfice pour tous les TNR futurs.

Template TNR mis à jour en parallèle dans `/Users/Shared/TNR-prompt-template.md` (hors repo public, conformément à la politique meta-doc).