### PR TITLE
fix(docker): container timezone Europe/Paris + remove stray project-clean cron

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,7 @@ FROM python:3.12-slim
 # openssh-client (SSH deploy key pour git push vers training-logs, cf. bascule
 # HTTPS→SSH du 18/04 suite expiration PAT — ephemere auparavant, pérennisé ici)
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git curl openssh-client \
+    && apt-get install -y --no-install-recommends git curl openssh-client tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # Supercronic (cron leger pour Docker) — multi-arch via TARGETARCH

--- a/docker/crontab
+++ b/docker/crontab
@@ -19,6 +19,3 @@
 # data-repo-sync : apres daily-sync (22h30) et apres end-of-week (20h30 dimanche)
 30 22 * * * data-repo-sync
 30 20 * * 0 data-repo-sync
-
-# project-clean : quotidien 03h00
-0 3 * * * project-clean

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ${WITHINGS_CREDENTIALS_DIR:-./credentials}:/data/credentials
     environment:
       - WITHINGS_CREDENTIALS_PATH=/data/credentials/withings.json
+      - TZ=${TZ:-Europe/Paris}
     env_file: stack.env
     restart: unless-stopped
     healthcheck:
@@ -38,6 +39,7 @@ services:
       - ${WITHINGS_CREDENTIALS_DIR:-./credentials}:/data/credentials
     environment:
       - WITHINGS_CREDENTIALS_PATH=/data/credentials/withings.json
+      - TZ=${TZ:-Europe/Paris}
     env_file: stack.env
     restart: unless-stopped
     init: true

--- a/docker/env.example
+++ b/docker/env.example
@@ -112,3 +112,11 @@ WITHINGS_CLIENT_SECRET=
 # ============================================
 # Path to directory containing server.crt, server.key, ca.crt
 MTLS_CERTS_PATH=
+
+# ============================================
+# Timezone (containers + crons)
+# ============================================
+# IANA timezone name. Default: Europe/Paris (= CET/CEST).
+# Required for crontab schedules to align with human-local time
+# (e.g. "0 20 * * 0 end-of-week" really fires at 20:00 local).
+TZ=Europe/Paris


### PR DESCRIPTION
## Summary
2 cleanups runtime container identifiés pendant l'investigation S093 EOW de ce dimanche soir :

### 1. `fix(docker): set container timezone to Europe/Paris`
Container avait aucun TZ → défaut UTC. Crons crontab tournaient 2h en retard vs human-local time. E.g. `0 20 * * 0 end-of-week` était schedulé pour 20:00 UTC = 22:00 CEST, surprenant l'opérateur qui lit le crontab comme local.

Changes :
- `Dockerfile` : install `tzdata`
- `docker-compose.yml` : add `TZ=${TZ:-Europe/Paris}` env sur `mcp-server` + `cron-jobs`
- `env.example` : doc nouvelle var

### 2. `chore(docker): remove project-clean from container crontab`
`project-clean` est un outil dev-environnement défini comme entry point Poetry **uniquement dans le repo `outillages`**. Il nettoie caches/temp/fichiers mal placés dans un repo SOURCE magma-cycling (Mac-side, via LaunchAgent `cyclisme.mnt.10-project-clean-daily` pointant `~/Projects/outillages`). Dans le container il n'y a pas de repo source à nettoyer → cron entry était un résidu, no-op silencieux.

## Test plan
- [ ] CI green
- [ ] Post-merge : Admin retag `:stable` v3.37.0 (semantic-release minor bump auto) + redeploy stack #33
- [ ] Vérif post-redeploy : `docker exec ... date` doit retourner CEST (Europe/Paris), prochain cron `end-of-week` doit fire à 20:00 CEST dimanche prochain (= 22:00 UTC, plus le décalage 2h)

## Note PR follow-up backlog
- Implémenter sync auto preprod (cron sidecar `*/5` `git pull --ff-only`) — backlog ADR v5 §1