### PR TITLE
feat(intelligence): migrate intelligence.json to training-logs repo (PR1 iso-config)

### DIFF
--- a/magma_cycling/_mcp/schemas/analysis.py
+++ b/magma_cycling/_mcp/schemas/analysis.py
@@ -44,8 +44,9 @@ def get_tools() -> list[Tool]:
                 "pid-daily-evaluation). Two modes : 'daily' (default) collects "
                 "cycle metrics + learnings + CTL/Peaks monitoring + test FTP "
                 "opportunity check ; 'cycle' recalibrates PID with a measured "
-                "FTP at end of training cycle. Updates ~/data/intelligence.json "
-                "and appends to ~/data/monitoring/pid_evaluation.jsonl."
+                "FTP at end of training cycle. Updates <TRAINING_DATA_ROOT>/data/intelligence/"
+                "intelligence.json (or INTELLIGENCE_DATA_DIR override) and appends to "
+                "~/data/monitoring/pid_evaluation.jsonl."
             ),
             inputSchema={
                 "type": "object",

--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -56,15 +56,33 @@ WRITER_ID_ENV = "TRAINING_DATA_WRITER_ID"
 #: sécurité #1 du protocole niveau diamant).
 WRITER_SCOPED_ENV = "TRAINING_DATA_WRITER_SCOPED"
 
+#: Var d'env override pour le dossier de l'intelligence (rétro-compat dev
+#: local). Si définie, prend priorité sur ``<root>/data/intelligence/``.
+#: Par défaut (env absent) : ``<TRAINING_DATA_ROOT>/data/intelligence/``
+#: pour que le fichier survive aux redeploys container (cf. plan iso-config
+#: PR1, incident 2026-05-12 où redeploy stack #33 a effacé
+#: ``/home/magma/data/intelligence.json`` du writable layer Docker).
+INTELLIGENCE_DATA_DIR_ENV = "INTELLIGENCE_DATA_DIR"
+
 #: Nom du fichier d'index `.operators.yaml` à la racine du repo.
 OPERATORS_FILE = ".operators.yaml"
 
+#: Sous-dossier (relatif à la racine training-logs) qui héberge
+#: ``intelligence.json`` et les artefacts apparentés (= shared entre writers).
+INTELLIGENCE_SUBDIR = "data/intelligence"
+
+#: Nom du fichier intelligence sous :data:`INTELLIGENCE_SUBDIR`.
+INTELLIGENCE_FILENAME = "intelligence.json"
+
 #: Whitelist par défaut des fichiers racine autorisés (utilisée si
 #: ``.operators.yaml`` absent ou ne définit pas ``shared_root_files``).
+#: ``data/intelligence/**`` est inclus pour que le mode writer-scoped futur
+#: (cf. ADR v5) autorise l'écriture intelligence shared cross-writers.
 DEFAULT_SHARED_ROOT_FILES = [
     ".gitignore",
     "README.md",
     OPERATORS_FILE,
+    "data/intelligence/**",
 ]
 
 
@@ -100,6 +118,28 @@ def _resolve_root_from_env() -> Path | None:
         )
         return Path(legacy).expanduser()
     return None
+
+
+def resolve_intelligence_file_path() -> Path:
+    """Résout le path de ``intelligence.json`` sans instancier ``DataRepoConfig``.
+
+    Priorité (cf. plan iso-config PR1, ADR v5 §3) :
+
+    1. :data:`INTELLIGENCE_DATA_DIR_ENV` (override explicite, rétro-compat dev local).
+    2. :data:`ROOT_ENV` (``TRAINING_DATA_ROOT``) → ``<root>/data/intelligence/intelligence.json``.
+    3. :data:`LEGACY_ROOT_ENV` (``TRAINING_DATA_REPO``) → idem (avec DeprecationWarning).
+    4. Fallback legacy ``~/data/intelligence.json`` (dev local sans env, comportement pré-PR1).
+
+    Le helper ne touche pas au file system — la création du dossier parent reste
+    à la charge du caller (``mkdir(parents=True, exist_ok=True)``).
+    """
+    override = os.getenv(INTELLIGENCE_DATA_DIR_ENV)
+    if override:
+        return Path(override).expanduser() / INTELLIGENCE_FILENAME
+    root = _resolve_root_from_env()
+    if root is not None:
+        return root / INTELLIGENCE_SUBDIR / INTELLIGENCE_FILENAME
+    return Path.home() / "data" / INTELLIGENCE_FILENAME
 
 
 def _load_operators_yaml(root: Path) -> dict | None:
@@ -312,6 +352,28 @@ class DataRepoConfig:
         return self.data_repo_path / ".workflow_state.json"
 
     @property
+    def intelligence_dir(self) -> Path:
+        """Path au dossier intelligence (shared cross-writers).
+
+        Résolution :
+        1. Si :data:`INTELLIGENCE_DATA_DIR_ENV` est défini → ``Path(env).expanduser()``
+           (rétro-compat dev local / override explicite).
+        2. Sinon → ``root_path / data/intelligence/`` (mount training-logs partagé).
+
+        Le path utilise :attr:`root_path` (et non :attr:`data_repo_path`) pour
+        rester shared cross-writers en mode writer-scoped futur.
+        """
+        env_override = os.getenv(INTELLIGENCE_DATA_DIR_ENV)
+        if env_override:
+            return Path(env_override).expanduser()
+        return self.root_path / INTELLIGENCE_SUBDIR
+
+    @property
+    def intelligence_file_path(self) -> Path:
+        """Path au fichier ``intelligence.json`` (sous :attr:`intelligence_dir`)."""
+        return self.intelligence_dir / INTELLIGENCE_FILENAME
+
+    @property
     def handoff_dir(self) -> Path:
         """Path to handoff/ directory in data repo (context-handoff snapshots)."""
         return self.data_repo_path / "handoff"
@@ -323,6 +385,7 @@ class DataRepoConfig:
         self.workout_templates_dir.mkdir(parents=True, exist_ok=True)
         self.terrain_circuits_dir.mkdir(parents=True, exist_ok=True)
         self.handoff_dir.mkdir(parents=True, exist_ok=True)
+        self.intelligence_dir.mkdir(parents=True, exist_ok=True)
 
     def validate(self) -> bool:
         """Validate data repository structure.

--- a/magma_cycling/intelligence/workout_diversity.py
+++ b/magma_cycling/intelligence/workout_diversity.py
@@ -19,6 +19,8 @@ from dataclasses import asdict, dataclass
 from datetime import date, timedelta
 from pathlib import Path
 
+from magma_cycling.config.data_repo import resolve_intelligence_file_path
+
 logger = logging.getLogger(__name__)
 
 
@@ -78,7 +80,7 @@ class WorkoutDiversityTracker:
             max_repetition_rate: Maximum allowed repetition rate (0.0-1.0)
         """
         if intelligence_file is None:
-            intelligence_file = Path.home() / "data" / "intelligence.json"
+            intelligence_file = resolve_intelligence_file_path()
 
         self.intelligence_file = intelligence_file
         self.rotation_window_days = rotation_window_days

--- a/magma_cycling/scripts/pid_daily_evaluation.py
+++ b/magma_cycling/scripts/pid_daily_evaluation.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from magma_cycling.api.intervals_client import IntervalsClient
 from magma_cycling.config import get_intervals_config
+from magma_cycling.config.data_repo import resolve_intelligence_file_path
 from magma_cycling.intelligence.training_intelligence import TrainingIntelligence
 from magma_cycling.utils.cli import cli_main
 from magma_cycling.workflows.pid_eval.adherence import AdherenceMixin
@@ -97,7 +98,7 @@ class PIDDailyEvaluator(
         self.evaluation_log = (
             evaluation_log or Path.home() / "data" / "monitoring" / "pid_evaluation.jsonl"
         )
-        self.intelligence_file = intelligence_file or Path.home() / "data" / "intelligence.json"
+        self.intelligence_file = intelligence_file or resolve_intelligence_file_path()
 
         self.dry_run = dry_run
 

--- a/magma_cycling/workflows/eow/evaluation.py
+++ b/magma_cycling/workflows/eow/evaluation.py
@@ -32,10 +32,14 @@ class EvaluationMixin:
             # Run evaluation for the completed week
             result = evaluator.run_daily_evaluation(days_back=7)
 
+            from magma_cycling.config.data_repo import (
+                resolve_intelligence_file_path,
+            )
+
             print()
             print("  ✅ Évaluation PID terminée")
             print("  📊 Données sauvegardées dans ~/data/monitoring/pid_evaluation.jsonl")
-            print("  🧠 Intelligence mise à jour dans ~/data/intelligence.json")
+            print(f"  🧠 Intelligence mise à jour dans {resolve_intelligence_file_path()}")
 
             # Display test recommendation if present
             test_rec = result.get("test_recommendation")

--- a/magma_cycling/workflows/planner/context_loading.py
+++ b/magma_cycling/workflows/planner/context_loading.py
@@ -3,8 +3,9 @@
 import json
 import re
 import sys
-from pathlib import Path
 from typing import Any
+
+from magma_cycling.config.data_repo import resolve_intelligence_file_path
 
 
 class ContextLoadingMixin:
@@ -212,7 +213,7 @@ class ContextLoadingMixin:
                 context["protocols"] = "\n\n---\n\n".join(protocols)
 
         # Charger intelligence.json (recommandations PID et adaptations)
-        intelligence_file = Path.home() / "data" / "intelligence.json"
+        intelligence_file = resolve_intelligence_file_path()
         try:
             if intelligence_file.exists():
                 intelligence_data = json.loads(intelligence_file.read_text(encoding="utf-8"))

--- a/tests/config/test_data_repo_intelligence.py
+++ b/tests/config/test_data_repo_intelligence.py
@@ -1,0 +1,193 @@
+"""Tests pour la migration intelligence.json (plan iso-config PR1).
+
+Couvre :
+
+- ``resolve_intelligence_file_path()`` standalone helper (priorité env + fallback)
+- ``DataRepoConfig.intelligence_dir`` / ``intelligence_file_path`` properties
+- ``ensure_directories`` crée le dossier intelligence
+- ``DEFAULT_SHARED_ROOT_FILES`` contient le pattern ``data/intelligence/**`` pour
+  l'autorisation writer-scoped future
+- ``is_safe_write_path`` autorise les écritures sous ``data/intelligence/`` en
+  mode writer-scoped via la whitelist
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from magma_cycling.config.data_repo import (
+    DEFAULT_SHARED_ROOT_FILES,
+    INTELLIGENCE_DATA_DIR_ENV,
+    INTELLIGENCE_FILENAME,
+    INTELLIGENCE_SUBDIR,
+    LEGACY_ROOT_ENV,
+    OPERATORS_FILE,
+    ROOT_ENV,
+    WRITER_ID_ENV,
+    WRITER_SCOPED_ENV,
+    DataRepoConfig,
+    resolve_intelligence_file_path,
+)
+
+
+@pytest.fixture
+def temp_training_repo(tmp_path):
+    """Repo training-logs minimal pour DataRepoConfig.
+
+    Returns:
+        Tuple ``(root_path, writer_a_hash)``.
+    """
+    repo = tmp_path / "training-logs"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "--initial-branch=main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@magma"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "workouts-history.md").touch()
+    writer_a = "a3f7c1b2c4d5"
+    (repo / writer_a).mkdir()
+    (repo / writer_a / "workouts-history.md").touch()
+    operators = {
+        "shared_root_files": [
+            ".gitignore",
+            "README.md",
+            OPERATORS_FILE,
+            "data/intelligence/**",
+        ],
+        "writers": {
+            writer_a: {
+                "alias": "mac",
+                "host": "tiresias",
+                "provisioned_at": "2026-04-20T08:00:00Z",
+                "decommissioned_at": None,
+            },
+        },
+    }
+    (repo / OPERATORS_FILE).write_text(yaml.safe_dump(operators), encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=repo, check=True)
+    return repo, writer_a
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Wipe environment vars between tests."""
+    for v in (
+        ROOT_ENV,
+        LEGACY_ROOT_ENV,
+        WRITER_ID_ENV,
+        WRITER_SCOPED_ENV,
+        INTELLIGENCE_DATA_DIR_ENV,
+    ):
+        monkeypatch.delenv(v, raising=False)
+
+
+class TestResolveIntelligenceFilePath:
+    """Standalone helper — no DataRepoConfig instantiation, no filesystem touch."""
+
+    def test_fallback_legacy_when_no_env(self):
+        path = resolve_intelligence_file_path()
+        assert path == Path.home() / "data" / INTELLIGENCE_FILENAME
+
+    def test_uses_training_data_root(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        path = resolve_intelligence_file_path()
+        assert path == tmp_path / INTELLIGENCE_SUBDIR / INTELLIGENCE_FILENAME
+
+    def test_uses_legacy_training_data_repo(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(LEGACY_ROOT_ENV, str(tmp_path))
+        path = resolve_intelligence_file_path()
+        assert path == tmp_path / INTELLIGENCE_SUBDIR / INTELLIGENCE_FILENAME
+
+    def test_override_env_takes_priority(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path / "ignored"))
+        monkeypatch.setenv(INTELLIGENCE_DATA_DIR_ENV, str(tmp_path / "custom"))
+        path = resolve_intelligence_file_path()
+        assert path == tmp_path / "custom" / INTELLIGENCE_FILENAME
+
+    def test_override_env_expanduser(self, monkeypatch):
+        monkeypatch.setenv(INTELLIGENCE_DATA_DIR_ENV, "~/my-intel")
+        path = resolve_intelligence_file_path()
+        assert path == Path.home() / "my-intel" / INTELLIGENCE_FILENAME
+
+    def test_resolver_does_not_touch_filesystem(self, tmp_path, monkeypatch):
+        nonexistent = tmp_path / "absent"
+        monkeypatch.setenv(ROOT_ENV, str(nonexistent))
+        # Doit retourner le path sans lever — ne crée pas le dossier
+        path = resolve_intelligence_file_path()
+        assert path == nonexistent / INTELLIGENCE_SUBDIR / INTELLIGENCE_FILENAME
+        assert not nonexistent.exists()
+
+
+class TestIntelligenceDirOnConfig:
+    """``DataRepoConfig.intelligence_dir`` resolves under root, not writer subdir."""
+
+    def test_default_under_root_when_flat(self, temp_training_repo, monkeypatch):
+        repo, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        cfg = DataRepoConfig()
+        assert cfg.intelligence_dir == (repo / INTELLIGENCE_SUBDIR).resolve()
+        assert cfg.intelligence_file_path == (
+            repo / INTELLIGENCE_SUBDIR / INTELLIGENCE_FILENAME
+        ).resolve()
+
+    def test_shared_under_root_even_when_writer_scoped(
+        self, temp_training_repo, monkeypatch
+    ):
+        """Critical: intelligence stays under ROOT in writer-scoped mode."""
+        repo, writer_a = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
+        monkeypatch.setenv(WRITER_ID_ENV, writer_a)
+        cfg = DataRepoConfig()
+        # data_repo_path is under writer subdir
+        assert cfg.data_repo_path == (repo / writer_a).resolve()
+        # but intelligence_dir stays at root (shared cross-writers)
+        assert cfg.intelligence_dir == (repo / INTELLIGENCE_SUBDIR).resolve()
+
+    def test_override_env_takes_priority_on_config(
+        self, tmp_path, temp_training_repo, monkeypatch
+    ):
+        repo, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(INTELLIGENCE_DATA_DIR_ENV, str(tmp_path / "custom"))
+        cfg = DataRepoConfig()
+        assert cfg.intelligence_dir == tmp_path / "custom"
+
+
+class TestEnsureDirectoriesCreatesIntelligence:
+    """``ensure_directories`` includes ``intelligence_dir``."""
+
+    def test_creates_intelligence_dir(self, temp_training_repo, monkeypatch):
+        repo, _ = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        cfg = DataRepoConfig()
+        intel_dir = repo / INTELLIGENCE_SUBDIR
+        assert not intel_dir.exists()
+        cfg.ensure_directories()
+        assert intel_dir.is_dir()
+
+
+class TestWhitelistContainsIntelligence:
+    """``DEFAULT_SHARED_ROOT_FILES`` must include ``data/intelligence/**``."""
+
+    def test_default_whitelist_contains_intelligence_pattern(self):
+        assert "data/intelligence/**" in DEFAULT_SHARED_ROOT_FILES
+
+    def test_is_safe_write_path_allows_intelligence_in_scoped_mode(
+        self, temp_training_repo, monkeypatch
+    ):
+        """Critical: when scoped flag ON, intelligence writes must still pass guard-rail."""
+        repo, writer_a = temp_training_repo
+        monkeypatch.setenv(ROOT_ENV, str(repo))
+        monkeypatch.setenv(WRITER_SCOPED_ENV, "1")
+        monkeypatch.setenv(WRITER_ID_ENV, writer_a)
+        cfg = DataRepoConfig()
+        intel_file = repo / "data" / "intelligence" / "intelligence.json"
+        # Path doesn't need to exist for the check (operates on resolved paths)
+        intel_file.parent.mkdir(parents=True, exist_ok=True)
+        intel_file.touch()
+        assert cfg.is_safe_write_path(intel_file) is True

--- a/tests/config/test_data_repo_intelligence.py
+++ b/tests/config/test_data_repo_intelligence.py
@@ -130,13 +130,12 @@ class TestIntelligenceDirOnConfig:
         monkeypatch.setenv(ROOT_ENV, str(repo))
         cfg = DataRepoConfig()
         assert cfg.intelligence_dir == (repo / INTELLIGENCE_SUBDIR).resolve()
-        assert cfg.intelligence_file_path == (
-            repo / INTELLIGENCE_SUBDIR / INTELLIGENCE_FILENAME
-        ).resolve()
+        assert (
+            cfg.intelligence_file_path
+            == (repo / INTELLIGENCE_SUBDIR / INTELLIGENCE_FILENAME).resolve()
+        )
 
-    def test_shared_under_root_even_when_writer_scoped(
-        self, temp_training_repo, monkeypatch
-    ):
+    def test_shared_under_root_even_when_writer_scoped(self, temp_training_repo, monkeypatch):
         """Critical: intelligence stays under ROOT in writer-scoped mode."""
         repo, writer_a = temp_training_repo
         monkeypatch.setenv(ROOT_ENV, str(repo))
@@ -148,9 +147,7 @@ class TestIntelligenceDirOnConfig:
         # but intelligence_dir stays at root (shared cross-writers)
         assert cfg.intelligence_dir == (repo / INTELLIGENCE_SUBDIR).resolve()
 
-    def test_override_env_takes_priority_on_config(
-        self, tmp_path, temp_training_repo, monkeypatch
-    ):
+    def test_override_env_takes_priority_on_config(self, tmp_path, temp_training_repo, monkeypatch):
         repo, _ = temp_training_repo
         monkeypatch.setenv(ROOT_ENV, str(repo))
         monkeypatch.setenv(INTELLIGENCE_DATA_DIR_ENV, str(tmp_path / "custom"))


### PR DESCRIPTION
## Contexte

PR1 du plan iso-config + multi-opérateur portable S093-S096 (cf. `/Users/Shared/PLAN-iso-config-multi-operateur-S093-S096.md`).

Migre `intelligence.json` depuis `~/data/` (legacy, hors repo) vers `data/intelligence/intelligence.json` **dans le repo training-logs** → repo athlète portable canonique, switch d'opérateur MCP sans perte de contexte.

Livraison Junior (patch handoff sha256 `4135574608f15a3ede687a4ecf67fd2dce58f015b4bac5eb7e5c3a6e1de030e0`) — apply Leader sur main propre.

## Changements

### Helper standalone
`resolve_intelligence_file_path()` — priorité résolution :
1. `INTELLIGENCE_DATA_DIR` (override explicite)
2. `TRAINING_DATA_ROOT/data/intelligence/`
3. Legacy `~/data/intelligence.json`
4. Fallback `~/data/`

Pas d'instanciation `DataRepoConfig` requise (utilisable en `default=` arg, pas de risque `FileNotFoundError` sur repo absent).

### DataRepoConfig
+ Properties `intelligence_dir` + `intelligence_file_path` qui résolvent **sous `root_path`** (pas `data_repo_path`) → reste shared cross-writers en mode writer-scoped futur (anti-régression critique : `test_shared_under_root_even_when_writer_scoped`).

+ `DEFAULT_SHARED_ROOT_FILES` += `data/intelligence/**` → autorise écritures intelligence en mode scoped via guard-rail `is_safe_write_path` (anti-régression PR C).

### Sites callers migrés
- `scripts/pid_daily_evaluation.py` (default)
- `intelligence/workout_diversity.py` (default)
- `workflows/planner/context_loading.py` (read)
- `workflows/eow/evaluation.py` (runtime print resolved path)
- `_mcp/schemas/analysis.py` (tool description)

### Hors scope (cosmétique uniquement)
- `dashboard.py` + `scripts/backfill_intelligence.py` docstrings help — non-bloquant, pas migrés.

## Tests

142/142 verts (12 nouveaux + non-régression `data_repo` + `intelligence` + `workout_diversity`).

## Backfill post-merge (Admin)

Après merge + redeploy `:stable` :

```
docker exec magma-cycling-cron-jobs-1 sh -c \
  'mkdir -p /data/training-logs/data/intelligence && \
   cp /home/magma/data/intelligence.json \
      /data/training-logs/data/intelligence/intelligence.json'
```

Prévoir backup `tar.gz` préalable (cf. brief sécurité cross-agent).

## Notes infra

- `check-tools-docs` fail localement Junior = hook fantôme magma-cycling (cf. audit Admin) → CI passera (executable absent local uniquement).
- Squash recommandé au merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)