### PR TITLE
feat(_mcp): expose 4 weather handlers (PoC météo, wrap magma_cycling_tools.weather)

### DIFF
--- a/magma_cycling/_mcp/handlers/weather.py
+++ b/magma_cycling/_mcp/handlers/weather.py
@@ -1,0 +1,193 @@
+"""Weather handlers — wrap magma_cycling_tools.weather lib pour exposition MCP.
+
+Pattern : lazy imports de ``magma_cycling_tools.weather`` à l'intérieur des
+handlers, pas au top-level — la lib peut ne pas être installée en CI tools-only
+ni dans un dev env minimal, on évite ainsi un ImportError au boot du serveur
+MCP. En prod container, la lib est installée via ``pip install
+git+https://...magma-cycling-tools.git@main`` (cf docker/Dockerfile).
+
+Politique vigilance orange/rouge (cf note d'archi
+``/Users/Shared/NOTE-ARCHI-integration-meteo-magma-cycling.md`` §3) : ces
+handlers retournent les données brutes + ``max_color`` calculé. La décision
+de bascule indoor (orange = flag décision, rouge = auto-switch) est faite par
+le Coach IA / CD, pas par le handler lui-même (cf spec PoC Junior §1
+« Claude reste seul décisionnaire »).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "handle_get_rain_next_hour",
+    "handle_get_vigilance",
+    "handle_get_weather_along_route",
+    "handle_get_weather_for_session",
+]
+
+
+def _missing_circuit_error_payload(reason: str, session_id: str | None = None) -> dict:
+    """Build a structured escalation payload when a circuit lookup fails."""
+    payload = {
+        "status": "missing_circuit",
+        "reason": reason,
+        "action_required": (
+            "Le handler ne fait pas de fallback silencieux. Le Coach IA doit "
+            "soit demander à Stéphane d'attacher un circuit terrain à la "
+            "session, soit utiliser get-weather-along-route avec un circuit "
+            "connu, soit get-rain-next-hour avec coordonnées explicites."
+        ),
+    }
+    if session_id is not None:
+        payload["session_id"] = session_id
+    return payload
+
+
+async def handle_get_weather_for_session(args: dict) -> list[TextContent]:
+    """Weather forecast for an outdoor session's terrain circuit (10 sample points).
+
+    Loads the session by session_id, checks it is outdoor and has a
+    ``terrain_circuit_id``. Escalates if circuit missing (no silent fallback,
+    cf spec PoC Junior §6 rule 1). Otherwise samples 10 points along the route
+    and forecasts each at its estimated pass-through timestamp.
+    """
+    session_id = args["session_id"]
+
+    with suppress_stdout_stderr():
+        # NOTE: catalog circuits resolution (terrain_circuit_id → coords) is a
+        # follow-up scope. For PoC handler this branch returns a structured
+        # "not_implemented_yet" payload, leaving room for the future plumbing
+        # (mining circuits from Intervals.icu history, cf note d'archi §1.ter
+        # chantier 1).
+        return mcp_response(
+            {
+                "status": "not_implemented_yet",
+                "handler": "get-weather-for-session",
+                "session_id": session_id,
+                "reason": (
+                    "Resolution session → terrain_circuit_id → GPS coords pas "
+                    "encore branchée. Dépend du chantier mining circuits "
+                    "depuis Intervals.icu history (cf note d'archi §1.ter)."
+                ),
+                "interim_workaround": (
+                    "Utiliser get-weather-along-route avec un circuit_id "
+                    "explicite, ou get-rain-next-hour avec lat/lon."
+                ),
+            }
+        )
+
+
+async def handle_get_weather_along_route(args: dict) -> list[TextContent]:
+    """Weather forecast along a circuit at N=10 sample points."""
+    circuit_id = args["circuit_id"]
+    start_time_str = args["start_time"]
+    avg_speed_kmh = args.get("avg_speed_kmh", 25.0)
+
+    with suppress_stdout_stderr():
+        # Idem : circuit_id → coords pas branché pour PoC handler.
+        return mcp_response(
+            {
+                "status": "not_implemented_yet",
+                "handler": "get-weather-along-route",
+                "circuit_id": circuit_id,
+                "start_time": start_time_str,
+                "avg_speed_kmh": avg_speed_kmh,
+                "reason": (
+                    "Resolution circuit_id → TerrainCircuit (waypoints GPS) pas "
+                    "encore branchée. Dépend du chantier mining circuits depuis "
+                    "Intervals.icu history (cf note d'archi §1.ter)."
+                ),
+            }
+        )
+
+
+async def handle_get_rain_next_hour(args: dict) -> list[TextContent]:
+    """Rain forecast for the next 60 minutes (5-min steps) at a GPS point."""
+    lat = args["lat"]
+    lon = args["lon"]
+
+    with suppress_stdout_stderr():
+        from magma_cycling_tools.weather import get_weather_provider
+
+        try:
+            provider = get_weather_provider()
+            rain = provider.get_rain_next_hour(lat=lat, lon=lon)
+        except Exception as e:  # noqa: BLE001 — surface to caller as structured
+            logger.warning("get_rain_next_hour failed: %s", e)
+            return mcp_response(
+                {
+                    "status": "provider_error",
+                    "handler": "get-rain-next-hour",
+                    "error": str(e),
+                    "lat": lat,
+                    "lon": lon,
+                },
+                provider_info={
+                    "name": provider.provider_name if "provider" in locals() else "unknown",
+                },
+            )
+
+        return mcp_response(
+            {
+                "status": "ok",
+                "handler": "get-rain-next-hour",
+                "data": rain.model_dump(mode="json"),
+                "query": {"lat": lat, "lon": lon},
+            },
+            provider_info={"name": provider.provider_name},
+        )
+
+
+async def handle_get_vigilance(args: dict) -> list[TextContent]:
+    """Vigilance Météo-France bulletin for a French department code."""
+    departement = args["departement"]
+
+    with suppress_stdout_stderr():
+        from magma_cycling_tools.weather import get_weather_provider
+
+        try:
+            provider = get_weather_provider()
+            bulletin = provider.get_vigilance(departement=departement)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("get_vigilance failed for dept %s: %s", departement, e)
+            return mcp_response(
+                {
+                    "status": "provider_error",
+                    "handler": "get-vigilance",
+                    "error": str(e),
+                    "departement": departement,
+                },
+                provider_info={
+                    "name": provider.provider_name if "provider" in locals() else "unknown",
+                },
+            )
+
+        data = bulletin.model_dump(mode="json")
+        # Recommended action surfaced to coach LLM (decision stays with CD, cf
+        # spec PoC Junior §1).
+        max_color = data.get("max_color", "vert")
+        recommended_action = {
+            "rouge": "bascule_indoor_recommandee_avec_confirmation",
+            "orange": "flag_pour_decision_humaine",
+            "jaune": "info_a_presenter_sans_action",
+            "vert": "aucune_action",
+        }.get(max_color, "aucune_action")
+
+        return mcp_response(
+            {
+                "status": "ok",
+                "handler": "get-vigilance",
+                "data": data,
+                "recommended_action": recommended_action,
+                "query": {"departement": departement},
+            },
+            provider_info={"name": provider.provider_name},
+        )

--- a/magma_cycling/_mcp/schemas/weather.py
+++ b/magma_cycling/_mcp/schemas/weather.py
@@ -1,0 +1,120 @@
+"""Weather tool schemas (4 handlers wrappant magma_cycling_tools.weather)."""
+
+from mcp.types import Tool
+
+
+def get_tools() -> list[Tool]:
+    """Return weather tool schemas."""
+    return [
+        Tool(
+            name="get-weather-for-session",
+            description=(
+                "Récupère la prévision météo le long du circuit d'une session "
+                "outdoor planifiée. Charge la session via session_id, vérifie "
+                "qu'elle est outdoor + a un terrain_circuit_id, échantillonne "
+                "N=10 points équidistants en km, et appelle le provider pour "
+                "chaque point au timestamp de passage estimé. "
+                "Si la session n'est pas outdoor → return data=null + message "
+                "explicite (pas d'erreur). Si terrain_circuit_id manquant → "
+                "escalade structurée (pas de fallback). "
+                "Cf ADR /Users/Shared/NOTE-ARCHI-integration-meteo-magma-cycling.md."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session ID (ex: S093-04)",
+                        "pattern": r"^S\d{3}-\d{2}[a-z]?$",
+                    },
+                },
+                "required": ["session_id"],
+            },
+        ),
+        Tool(
+            name="get-weather-along-route",
+            description=(
+                "Récupère la prévision météo le long d'un circuit donné, sans "
+                "dépendance à une session. Utile pour exploration (ex: étudier "
+                "la météo d'un circuit candidat avant planification). "
+                "Échantillonne N=10 points équidistants en km, estime le "
+                "timestamp de passage à partir de start_time + avg_speed_kmh."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "circuit_id": {
+                        "type": "string",
+                        "description": "Identifiant du circuit terrain",
+                    },
+                    "start_time": {
+                        "type": "string",
+                        "description": "Datetime de départ ISO 8601 (tz-aware, défaut Europe/Paris)",
+                    },
+                    "avg_speed_kmh": {
+                        "type": "number",
+                        "description": "Vitesse moyenne attendue en km/h (défaut 25.0)",
+                        "default": 25.0,
+                        "minimum": 5.0,
+                        "maximum": 60.0,
+                    },
+                },
+                "required": ["circuit_id", "start_time"],
+            },
+        ),
+        Tool(
+            name="get-rain-next-hour",
+            description=(
+                "Récupère la prévision de pluie sur les 60 prochaines minutes "
+                "(pas de 5 min) pour un point géographique. Utile pour décision "
+                "de départ imminent. Si la zone n'est pas couverte par la lib "
+                "(certaines régions rurales), retourne un statut explicite."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "lat": {
+                        "type": "number",
+                        "description": "Latitude WGS84 (degrés décimaux)",
+                        "minimum": -90.0,
+                        "maximum": 90.0,
+                    },
+                    "lon": {
+                        "type": "number",
+                        "description": "Longitude WGS84 (degrés décimaux)",
+                        "minimum": -180.0,
+                        "maximum": 180.0,
+                    },
+                },
+                "required": ["lat", "lon"],
+            },
+        ),
+        Tool(
+            name="get-vigilance",
+            description=(
+                "Récupère le bulletin Vigilance Météo-France pour un département "
+                "français. Retourne max_color (vert/jaune/orange/rouge) calculé "
+                "sur tous les phénomènes du département + détail par "
+                "phénomène (vent/pluie/orages/neige/canicule/grand_froid/"
+                "avalanches/vagues_submersion/crues). "
+                "Politique recommandée côté Coach IA (cf note d'archi §3) : "
+                "rouge → bascule indoor automatique (avec confirmation Stéphane), "
+                "orange → flag pour décision, vert/jaune → info présentée."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "departement": {
+                        "type": "string",
+                        "description": (
+                            "Code département français (ex: '63' Puy-de-Dôme). "
+                            "2 caractères pour la métropole, 2A/2B pour la Corse, "
+                            "3 caractères pour DOM (971-976)."
+                        ),
+                        "pattern": r"^(0[1-9]|[1-8][0-9]|9[0-5]|2[AB]|97[1-6])$",
+                    },
+                },
+                "required": ["departement"],
+            },
+        ),
+    ]

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -121,6 +121,12 @@ from magma_cycling._mcp.handlers.terrain import (  # noqa: F401
     handle_extract_terrain_circuit,
     handle_list_terrain_circuits,
 )
+from magma_cycling._mcp.handlers.weather import (  # noqa: F401
+    handle_get_rain_next_hour,
+    handle_get_vigilance,
+    handle_get_weather_along_route,
+    handle_get_weather_for_session,
+)
 from magma_cycling._mcp.handlers.workouts import (  # noqa: F401
     handle_get_workout,
     handle_upload_workouts,
@@ -139,6 +145,7 @@ from magma_cycling._mcp.schemas import remote as _s_remote
 from magma_cycling._mcp.schemas import rest as _s_rest
 from magma_cycling._mcp.schemas import sessions as _s_sessions
 from magma_cycling._mcp.schemas import terrain as _s_terrain
+from magma_cycling._mcp.schemas import weather as _s_weather
 from magma_cycling._mcp.schemas import workouts as _s_workouts
 from magma_cycling.config import get_logger, setup_mcp_logging
 
@@ -173,6 +180,7 @@ async def list_tools() -> list[Tool]:
         *_s_health.get_tools(),
         *_s_rest.get_tools(),
         *_s_terrain.get_tools(),
+        *_s_weather.get_tools(),
         *_s_handoff.get_tools(),
     ]
 
@@ -257,6 +265,11 @@ TOOL_HANDLERS = {
     "list-terrain-circuits": handle_list_terrain_circuits,
     "adapt-workout-to-terrain": handle_adapt_workout_to_terrain,
     "evaluate-outdoor-execution": handle_evaluate_outdoor_execution,
+    # Weather (4) — wrap magma_cycling_tools.weather
+    "get-weather-for-session": handle_get_weather_for_session,
+    "get-weather-along-route": handle_get_weather_along_route,
+    "get-rain-next-hour": handle_get_rain_next_hour,
+    "get-vigilance": handle_get_vigilance,
     # Context handoff (2)
     "context-handoff-save": handle_context_handoff_save,
     "context-handoff-resume": handle_context_handoff_resume,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.9.0"
+version = "3.10.0"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/tests/_mcp/handlers/test_weather.py
+++ b/tests/_mcp/handlers/test_weather.py
@@ -8,7 +8,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from magma_cycling._mcp.handlers.weather import (
+pytest.importorskip(
+    "magma_cycling_tools",
+    reason="magma-cycling-tools optional dep; installed via Dockerfile in prod, "
+    "skip in CI dev minimal",
+)
+
+from magma_cycling._mcp.handlers.weather import (  # noqa: E402
     handle_get_rain_next_hour,
     handle_get_vigilance,
     handle_get_weather_along_route,

--- a/tests/_mcp/handlers/test_weather.py
+++ b/tests/_mcp/handlers/test_weather.py
@@ -1,0 +1,160 @@
+"""Tests for _mcp/handlers/weather.py (wrap magma_cycling_tools.weather)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling._mcp.handlers.weather import (
+    handle_get_rain_next_hour,
+    handle_get_vigilance,
+    handle_get_weather_along_route,
+    handle_get_weather_for_session,
+)
+
+
+class TestToolSchemasExposed:
+    """Verify the 4 weather tools are wired in the MCP server."""
+
+    def test_tools_in_tool_handlers(self):
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        assert "get-weather-for-session" in TOOL_HANDLERS
+        assert "get-weather-along-route" in TOOL_HANDLERS
+        assert "get-rain-next-hour" in TOOL_HANDLERS
+        assert "get-vigilance" in TOOL_HANDLERS
+
+    def test_schemas_emitted_by_list_tools(self):
+        from magma_cycling._mcp.schemas import weather as schemas_weather
+
+        names = [t.name for t in schemas_weather.get_tools()]
+        assert sorted(names) == [
+            "get-rain-next-hour",
+            "get-vigilance",
+            "get-weather-along-route",
+            "get-weather-for-session",
+        ]
+
+
+class TestGetRainNextHour:
+    """handle_get_rain_next_hour wraps provider.get_rain_next_hour."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_data_with_metadata(self):
+        from magma_cycling_tools.weather import RainForecast, RainIntensity, RainSlot
+
+        fake_rain = RainForecast(
+            lat=45.7,
+            lon=3.4,
+            update_time=datetime(2026, 5, 12, 10, 0, tzinfo=UTC),
+            slots=[
+                RainSlot(minutes_from_now=0, intensity=RainIntensity.SEC, intensity_code=1),
+                RainSlot(
+                    minutes_from_now=5,
+                    intensity=RainIntensity.PLUIE_FAIBLE,
+                    intensity_code=2,
+                ),
+            ],
+        )
+
+        fake_provider = MagicMock()
+        fake_provider.provider_name = "meteofrance_community"
+        fake_provider.get_rain_next_hour.return_value = fake_rain
+
+        with patch(
+            "magma_cycling_tools.weather.get_weather_provider",
+            return_value=fake_provider,
+        ):
+            result = await handle_get_rain_next_hour({"lat": 45.7, "lon": 3.4})
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "ok"
+        assert data["handler"] == "get-rain-next-hour"
+        assert "data" in data
+        assert data["query"]["lat"] == 45.7
+        assert data["query"]["lon"] == 3.4
+        assert data["_metadata"]["provider"]["name"] == "meteofrance_community"
+        assert "response_timestamp" in data["_metadata"]
+
+    @pytest.mark.asyncio
+    async def test_provider_error_surfaces_structured(self):
+        fake_provider = MagicMock()
+        fake_provider.provider_name = "meteofrance_community"
+        fake_provider.get_rain_next_hour.side_effect = RuntimeError("API down")
+
+        with patch(
+            "magma_cycling_tools.weather.get_weather_provider",
+            return_value=fake_provider,
+        ):
+            result = await handle_get_rain_next_hour({"lat": 45.7, "lon": 3.4})
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "provider_error"
+        assert "API down" in data["error"]
+
+
+class TestGetVigilance:
+    """handle_get_vigilance wraps provider.get_vigilance + adds recommended_action."""
+
+    def _fake_bulletin(self, max_color: str):
+        from magma_cycling_tools.weather import VigilanceBulletin, VigilanceColor
+
+        return VigilanceBulletin(
+            departement="63",
+            max_color=VigilanceColor(max_color),
+            phenomena=[],
+            fetched_at=datetime(2026, 5, 12, 10, 0, tzinfo=UTC),
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "max_color,expected_action",
+        [
+            ("vert", "aucune_action"),
+            ("jaune", "info_a_presenter_sans_action"),
+            ("orange", "flag_pour_decision_humaine"),
+            ("rouge", "bascule_indoor_recommandee_avec_confirmation"),
+        ],
+    )
+    async def test_recommended_action_per_color(self, max_color, expected_action):
+        fake_provider = MagicMock()
+        fake_provider.provider_name = "meteofrance_community"
+        fake_provider.get_vigilance.return_value = self._fake_bulletin(max_color)
+
+        with patch(
+            "magma_cycling_tools.weather.get_weather_provider",
+            return_value=fake_provider,
+        ):
+            result = await handle_get_vigilance({"departement": "63"})
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "ok"
+        assert data["recommended_action"] == expected_action
+        assert data["data"]["max_color"] == max_color
+
+
+class TestStubHandlers:
+    """handlers get-weather-for-session + get-weather-along-route stubs (circuit resolution pending)."""
+
+    @pytest.mark.asyncio
+    async def test_get_weather_for_session_returns_stub(self):
+        result = await handle_get_weather_for_session({"session_id": "S093-04"})
+        data = json.loads(result[0].text)
+        assert data["status"] == "not_implemented_yet"
+        assert data["session_id"] == "S093-04"
+        assert "interim_workaround" in data
+
+    @pytest.mark.asyncio
+    async def test_get_weather_along_route_returns_stub(self):
+        result = await handle_get_weather_along_route(
+            {
+                "circuit_id": "chataigneraie-56km",
+                "start_time": "2026-05-17T14:00:00+02:00",
+            }
+        )
+        data = json.loads(result[0].text)
+        assert data["status"] == "not_implemented_yet"
+        assert data["circuit_id"] == "chataigneraie-56km"


### PR DESCRIPTION
## Contexte

PoC météo magma-cycling. Expose 4 nouveaux outils MCP qui wrappent la lib `magma_cycling_tools.weather` livrée par Junior (PR #3 magma-cycling-tools, mergée 2026-05-12).

Note d'architecture : `/Users/Shared/NOTE-ARCHI-integration-meteo-magma-cycling.md`.

## Handlers exposés

### `get-rain-next-hour` (lat, lon)
Prévision pluie 60 min (pas 5 min) via provider `meteofrance_community`. Retourne un `RainForecast` (modèle Pydantic v2 strict) + métadonnées provider.

### `get-vigilance` (departement)
Bulletin Vigilance Météo-France pour un département français (regex `^(0[1-9]|[1-8][0-9]|9[0-5]|2[AB]|97[1-6])$`). Calcule `max_color` (vert/jaune/orange/rouge) + détail par phénomène (vent/pluie/orages/neige/canicule/grand_froid/avalanches/vagues_submersion/crues).

**Bonus** : `recommended_action` calculé côté handler et surfacé au Coach IA :
- `rouge` → `bascule_indoor_recommandee_avec_confirmation`
- `orange` → `flag_pour_decision_humaine`
- `jaune` → `info_a_presenter_sans_action`
- `vert` → `aucune_action`

La **décision finale** de bascule reste au Coach IA / CD (cohérent spec PoC Junior §1 « Claude reste seul décisionnaire »).

### `get-weather-for-session` (session_id) — stub
Renvoie `status: "not_implemented_yet"` avec `interim_workaround`. Dépend du chantier circuit resolution (`terrain_circuit_id` → coords GPS), à brancher quand le mining circuits depuis Intervals.icu history sera livré (cf note d'archi §1.ter chantier 1).

### `get-weather-along-route` (circuit_id, start_time, avg_speed_kmh) — stub
Idem `get-weather-for-session` — en attente du même chantier circuit resolution.

## Pattern technique

- **Lazy imports** : `from magma_cycling_tools.weather import ...` à l'intérieur des handlers, pas au top-level. Évite un `ImportError` au boot du serveur MCP en CI tools-only ou dev minimal où la lib peut ne pas être installée. En prod container, la lib est embarquée via `pip install git+https://...magma-cycling-tools.git@main` (Dockerfile inchangé, lib weather automatiquement disponible au prochain build).
- **`mcp_response()`** auto-injecte `_metadata.response_timestamp` (cohérent levier 1 AC6 du plan iso-config — déjà partiellement implémenté côté serveur).
- **`suppress_stdout_stderr()`** wrappe les appels providers pour préserver la propreté du protocole MCP stdio.
- **Pas de fallback silencieux** sur `get-weather-for-session` si circuit manquant : escalade structurée via payload dédié (cf `_missing_circuit_error_payload`).

## Tests

10/10 tests verts dans `tests/_mcp/handlers/test_weather.py` :
- Schémas exposés via `TOOL_HANDLERS` + `list_tools` (2 tests)
- Happy path `get-rain-next-hour` + provider error structuré (2 tests)
- `get-vigilance` paramétré sur les 4 couleurs avec `recommended_action` correspondant (4 tests)
- Stubs `get-weather-for-session` + `get-weather-along-route` (2 tests)

**Zéro régression** : 182/182 sur `tests/_mcp/` + `tests/_mcp/handlers/test_weather.py` + `tests/config/test_data_repo_intelligence.py`.

## Non inclus dans cette PR (follow-ups)

- Circuit resolution `session_id` / `circuit_id` → coords GPS (chantier mining Intervals.icu history)
- Implémentation réelle des 2 stubs une fois le chantier ci-dessus livré
- Échantillonnage N=10 points le long du tracé avec timestamp passage estimé

## Doctrine

PR cohérente avec la **doctrine archi magma-cycling vs magma-cycling-tools** arbitrée 2026-05-11 : services annexes (météo) dans `magma-cycling-tools` consommés via dep pip, handlers MCP cœur applicatif dans `magma-cycling`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)