### PR TITLE
refactor(prompts): drop semantic labels on ACWR/monotony/strain (PR4bis iso-config AC1)

### DIFF
--- a/magma_cycling/prompts/prompt_builder.py
+++ b/magma_cycling/prompts/prompt_builder.py
@@ -269,25 +269,28 @@ def format_athlete_profile(context: dict, metrics: dict) -> str:
             limit = metrics.get("intensity_limit_pct")
             if limit and limit < 100:
                 lines.append(f"  - Intensite max: {limit}% FTP")
+        # ACWR / monotonie / strain : valeurs brutes uniquement (plan iso-config
+        # PR4bis). Les anciens labels sémantiques pré-mâchés
+        # (optimal/attention/DANGER, OK/elevee, OK/ALERTE) produisaient des faux
+        # positifs récurrents (ex. CTL effondré post-blessure + ATL modeste →
+        # ACWR > 1.5 → "DANGER" injecté à tort). Le Coach IA reçoit la phase
+        # explicite dans le daily report et croise valeur brute + contexte.
+        # Cohérent doctrine « Claude reste seul décisionnaire ».
         acwr = metrics.get("acwr")
         if acwr is not None:
-            if acwr < 0.8:
-                acwr_label = "sous-entrainement"
-            elif acwr <= 1.3:
-                acwr_label = "optimal"
-            elif acwr <= 1.5:
-                acwr_label = "attention"
-            else:
-                acwr_label = "DANGER"
-            lines.append(f"  - ACWR: {acwr:.2f} ({acwr_label})")
+            lines.append(f"  - ACWR: {acwr:.2f}")
+            chronic_load = metrics.get("chronic_load")
+            if chronic_load is not None:
+                lines.append(f"  - Charge chronique (CTL 28j): {chronic_load:.1f}")
+            acute_load = metrics.get("acute_load")
+            if acute_load is not None:
+                lines.append(f"  - Charge aigue (ATL 7j): {acute_load:.1f}")
         monotony = metrics.get("monotony")
         if monotony is not None:
-            mono_label = "elevee (risque)" if monotony > 2.0 else "OK"
-            lines.append(f"  - Monotonie: {monotony:.2f} ({mono_label})")
+            lines.append(f"  - Monotonie: {monotony:.2f}")
         strain = metrics.get("strain")
         if strain is not None:
-            strain_label = "ALERTE" if strain > 3500 else "OK"
-            lines.append(f"  - Strain: {strain:.0f} ({strain_label})")
+            lines.append(f"  - Strain: {strain:.0f}")
         consec = metrics.get("consecutive_training_days")
         if consec and consec >= 2:
             lines.append(f"  - Jours consecutifs: {consec}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.10.0"
+version = "3.11.0"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -391,8 +391,13 @@ class TestFormatAthleteProfile:
         result = format_athlete_profile(context, metrics)
         assert "Indicateurs de charge" not in result
 
-    def test_acwr_monotony_strain_displayed(self):
-        """ACWR, Monotony, Strain appear in load indicators."""
+    def test_acwr_monotony_strain_raw_values_only(self):
+        """ACWR, Monotony, Strain shown as raw values without sematic labels.
+
+        Plan iso-config PR4bis: no more (optimal)/(attention)/(DANGER) on ACWR,
+        no (OK)/(elevee) on monotony, no (OK)/(ALERTE) on strain. Coach IA
+        cross-references raw value with phase context, decides itself.
+        """
         context = {"name": "Test", "age": 54}
         metrics = {
             "overtraining_risk": "low",
@@ -407,12 +412,24 @@ class TestFormatAthleteProfile:
             "strain": 2800,
         }
         result = format_athlete_profile(context, metrics)
-        assert "ACWR: 1.10 (optimal)" in result
-        assert "Monotonie: 1.50 (OK)" in result
-        assert "Strain: 2800 (OK)" in result
+        assert "ACWR: 1.10" in result
+        assert "Monotonie: 1.50" in result
+        assert "Strain: 2800" in result
+        # No more semantic labels in the prompt
+        assert "optimal" not in result
+        assert "attention" not in result
+        assert "DANGER" not in result
+        assert "(OK)" not in result
+        assert "elevee" not in result
+        assert "ALERTE" not in result
 
-    def test_acwr_danger_label(self):
-        """ACWR > 1.5 shows DANGER label."""
+    def test_acwr_high_value_no_danger_label(self):
+        """ACWR > 1.5 displays raw value without DANGER label.
+
+        Plan iso-config PR4bis: the 'DANGER' tag was a frequent false positive
+        on RECONSTRUCTION_BASE phase (collapsed CTL + modest ATL → mechanically
+        high ACWR). Coach IA reads the phase from the daily report and judges.
+        """
         context = {"name": "Test", "age": 54}
         metrics = {
             "overtraining_risk": "high",
@@ -423,7 +440,52 @@ class TestFormatAthleteProfile:
             "acwr": 1.8,
         }
         result = format_athlete_profile(context, metrics)
-        assert "ACWR: 1.80 (DANGER)" in result
+        assert "ACWR: 1.80" in result
+        assert "DANGER" not in result
+        assert "attention" not in result
+
+    def test_acwr_with_chronic_acute_load_context(self):
+        """ACWR is accompanied by chronic_load (CTL 28d) and acute_load (ATL 7d).
+
+        Plan iso-config PR4bis: provides the Coach IA with the raw building
+        blocks of ACWR so it can sanity-check the ratio (ex. ACWR > 1.5 caused
+        by collapsed chronic_load is a recovery context, not danger).
+        """
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "low",
+            "overtraining_veto": False,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 0.95,
+            "tsb": 3.0,
+            "acwr": 1.1,
+            "chronic_load": 65.4,
+            "acute_load": 71.9,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "ACWR: 1.10" in result
+        assert "Charge chronique (CTL 28j): 65.4" in result
+        assert "Charge aigue (ATL 7j): 71.9" in result
+
+    def test_acwr_without_chronic_acute_load_compat(self):
+        """ACWR alone is still displayed when chronic/acute are missing.
+
+        Backward-compat: callers that build `metrics` manually (older fixtures)
+        and only pass `acwr` should still produce a valid prompt.
+        """
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "overtraining_risk": "low",
+            "overtraining_veto": False,
+            "overtraining_factors": [],
+            "atl_ctl_ratio": 0.95,
+            "tsb": 3.0,
+            "acwr": 1.1,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "ACWR: 1.10" in result
+        assert "Charge chronique" not in result
+        assert "Charge aigue" not in result
 
     def test_intensity_100_not_displayed(self):
         """Intensity limit of 100% is not displayed (normal training)."""


### PR DESCRIPTION
## Contexte

PR4bis du plan iso-config + multi-opérateur S093-S096 (v3.1), rattachée à **AC1** (« portabilité totale + même qualité d'analyse coach »).

Retire les labels sémantiques pré-mâchés (`optimal` / `attention` / `DANGER` / `elevee (risque)` / `OK`) que `prompts/prompt_builder.py` injectait à côté des valeurs ACWR / monotony / strain. Le Coach IA reçoit désormais les valeurs brutes uniquement + le contexte CTL/ATL absolu, et croise lui-même avec la **phase déclarée dans le daily report** (ex : `Phase: RECONSTRUCTION_BASE`, cf. `training-logs/daily-reports/daily_report_2026-04-20.md:191,225,234`).

Cohérent avec la doctrine « Claude reste seul décisionnaire » (spec PoC Junior §1).

Livraison Junior (patch handoff sha256 `978509d35015c72ef0efcc1e4d6dc3379017f6138aaae21c395c3e05af4d35a5`) → apply Leader sur main propre.

## Faux positif fermé

CTL effondré (reprise post-blessure, post-break) + ATL modeste → ACWR mécaniquement >1.5 → label `DANGER` injecté au LLM à tort, alors que la phase est explicitement RECONSTRUCTION et la charge absolue minime. Le bricolage de seuils ad-hoc côté code a été rejeté en grooming — la solution propre est de **fournir au LLM les signaux contextualisés**, pas des verdicts pré-mâchés.

## Changements

### `prompts/prompt_builder.py:272-290`

3 blocs label virés (ACWR, monotony, strain). Valeurs brutes uniquement. **Ajout** de `chronic_load` (CTL 28j moyenne arithmétique) et `acute_load` (ATL 7j moyenne arithmétique) en lignes séparées quand présents — donne au Coach IA la possibilité de sanity-check le ratio.

Bloc commentaire ajouté explicitant la rationale (faux positif CTL effondré + ATL modeste → ACWR mécaniquement haut).

### `tests/test_prompt_builder.py`

- **2 tests rewrités** : assertions sur valeurs brutes + assertions négatives sur l'absence des labels (`DANGER`, `attention`, `optimal`, `elevee (risque)`)
- **2 nouveaux tests** : injection `chronic_load`/`acute_load` quand présents + backward-compat quand absents

## Hors scope (intentional)

Pas touché — restent labélisés en sortie car ces verdicts sont **physiologiquement contextualisés** (pas mécaniques) :
- TSB
- ATL/CTL ratio (verdict `overtraining_risk`)
- VETO ACTIF
- `recovery_recommendation`
- `intensity_limit_pct`
- Tension (blood pressure)
- Consecutive training days

## Tests

65/65 verts dans `tests/test_prompt_builder.py`. Pre-commit black / ruff / isort / pydocstyle / pycodestyle / check-safe-io tous OK.

(`check-tools-docs` fail localement chez Junior — hook fantôme upstream connu, option (a) skip portage tranchée. Passera CI.)

## Doctrine

Cohérent avec :
- Plan iso-config v3.1 — `/Users/Shared/PLAN-iso-config-multi-operateur-S093-S096.md` (PR4bis sprint S093)
- AC1 portabilité totale + qualité d'analyse coach
- Spec PoC Junior §1 « Claude reste seul décisionnaire »

## Délai prod

Cible **fin sprint S093 (15-16/05)** — mini-PR opportuniste comme planifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)