### PR TITLE
feat(_mcp/weather): standardize NIY + freshness_minutes + vigilance doc alignment

### DIFF
--- a/magma_cycling/_mcp/handlers/weather.py
+++ b/magma_cycling/_mcp/handlers/weather.py
@@ -17,6 +17,7 @@ le Coach IA / CD, pas par le handler lui-même (cf spec PoC Junior §1
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
@@ -32,6 +33,20 @@ __all__ = [
     "handle_get_weather_along_route",
     "handle_get_weather_for_session",
 ]
+
+
+def _freshness_minutes(reference_dt: datetime | None) -> float | None:
+    """Compute minutes elapsed between reference_dt and now (UTC).
+
+    Used to surface data age to the coach LLM so it can weight stale
+    forecasts vs server time without recomputing client-side.
+    """
+    if reference_dt is None:
+        return None
+    if reference_dt.tzinfo is None:
+        reference_dt = reference_dt.replace(tzinfo=UTC)
+    delta = datetime.now(UTC) - reference_dt
+    return round(delta.total_seconds() / 60.0, 1)
 
 
 def _missing_circuit_error_payload(reason: str, session_id: str | None = None) -> dict:
@@ -105,6 +120,12 @@ async def handle_get_weather_along_route(args: dict) -> list[TextContent]:
                     "encore branchée. Dépend du chantier mining circuits depuis "
                     "Intervals.icu history (cf note d'archi §1.ter)."
                 ),
+                "interim_workaround": (
+                    "Utiliser get-rain-next-hour avec lat/lon des waypoints "
+                    "connus du circuit, ou get-vigilance avec le département "
+                    "traversé. La composition timestamp passage + segments "
+                    "viendra avec la milestone circuit resolution."
+                ),
             }
         )
 
@@ -140,6 +161,7 @@ async def handle_get_rain_next_hour(args: dict) -> list[TextContent]:
                 "status": "ok",
                 "handler": "get-rain-next-hour",
                 "data": rain.model_dump(mode="json"),
+                "freshness_minutes": _freshness_minutes(rain.update_time),
                 "query": {"lat": lat, "lon": lon},
             },
             provider_info={"name": provider.provider_name},
@@ -187,6 +209,7 @@ async def handle_get_vigilance(args: dict) -> list[TextContent]:
                 "handler": "get-vigilance",
                 "data": data,
                 "recommended_action": recommended_action,
+                "freshness_minutes": _freshness_minutes(bulletin.fetched_at),
                 "query": {"departement": departement},
             },
             provider_info={"name": provider.provider_name},

--- a/magma_cycling/_mcp/schemas/weather.py
+++ b/magma_cycling/_mcp/schemas/weather.py
@@ -97,9 +97,12 @@ def get_tools() -> list[Tool]:
                 "sur tous les phénomènes du département + détail par "
                 "phénomène (vent/pluie/orages/neige/canicule/grand_froid/"
                 "avalanches/vagues_submersion/crues). "
-                "Politique recommandée côté Coach IA (cf note d'archi §3) : "
+                "Politique recommandée côté Coach IA (cf note d'archi §3), "
+                "alignée sur le champ recommended_action calculé côté handler : "
                 "rouge → bascule indoor automatique (avec confirmation Stéphane), "
-                "orange → flag pour décision, vert/jaune → info présentée."
+                "orange → flag pour décision humaine, "
+                "jaune → info présentée sans action, "
+                "vert → aucune action (pas de vigilance, rien à signaler)."
             ),
             inputSchema={
                 "type": "object",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.11.0"
+version = "3.11.1"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/tests/_mcp/handlers/test_weather.py
+++ b/tests/_mcp/handlers/test_weather.py
@@ -84,6 +84,8 @@ class TestGetRainNextHour:
         assert data["query"]["lon"] == 3.4
         assert data["_metadata"]["provider"]["name"] == "meteofrance_community"
         assert "response_timestamp" in data["_metadata"]
+        assert "freshness_minutes" in data
+        assert isinstance(data["freshness_minutes"], int | float)
 
     @pytest.mark.asyncio
     async def test_provider_error_surfaces_structured(self):
@@ -140,6 +142,8 @@ class TestGetVigilance:
         assert data["status"] == "ok"
         assert data["recommended_action"] == expected_action
         assert data["data"]["max_color"] == max_color
+        assert "freshness_minutes" in data
+        assert isinstance(data["freshness_minutes"], int | float)
 
 
 class TestStubHandlers:
@@ -164,3 +168,5 @@ class TestStubHandlers:
         data = json.loads(result[0].text)
         assert data["status"] == "not_implemented_yet"
         assert data["circuit_id"] == "chataigneraie-56km"
+        assert "interim_workaround" in data
+        assert "get-rain-next-hour" in data["interim_workaround"]


### PR DESCRIPTION
## Contexte

Hardening mini-PR opportuniste suite au **brief Dev Lead post-test CD live** sur les 4 outils météo PR #346 (Stéphane, 13/05/2026). 3 items priorisés P3-P4 fermés en un seul commit.

Brief original : tests get-rain-next-hour (lat=45.7831, lon=3.0828 Orcines) + get-vigilance (dept="63") + 2 stubs NIY. Retour sur 5 issues, 3 actionnables immédiates (les 2 autres P1/P2 = chantiers de plus grosse ampleur, loggués backlog).

## Changements

### 1. NIY contract standardisé (P3)

`handle_get_weather_along_route` ne retournait **pas** le champ `interim_workaround`, contrairement à `handle_get_weather_for_session` qui le faisait. Incohérence détectée au test CD.

Ajout du champ avec fallback explicite vers les 2 outils opérationnels :

```python
"interim_workaround": (
    "Utiliser get-rain-next-hour avec lat/lon des waypoints "
    "connus du circuit, ou get-vigilance avec le département "
    "traversé. La composition timestamp passage + segments "
    "viendra avec la milestone circuit resolution."
)
```

Coach IA reçoit désormais le même contrat de fallback pour les 2 stubs.

### 2. `freshness_minutes` (P4)

Calcul de l'âge de la donnée provider directement côté handler, surfacé dans le payload :
- `get-rain-next-hour` : delta `datetime.now(UTC)` vs `rain.update_time`
- `get-vigilance` : delta `datetime.now(UTC)` vs `bulletin.fetched_at`

Permet au Coach IA de pondérer la fraîcheur d'une prévision sans recalculer client-side. Cohérent avec la philosophie « valeurs brutes + contexte » de PR4bis ACWR.

Helper privé `_freshness_minutes(reference_dt)` ajouté en haut du module — gère datetimes naive/aware (auto-tag UTC si naive), arrondi 1 décimale, retourne `None` si input `None`.

### 3. Vigilance doc alignement (P4)

Friction sémantique détectée au test CD : le schema docstring disait *« rouge → bascule, orange → flag, vert/jaune → info présentée »* mais le handler retournait :
- `vert` → `aucune_action`
- `jaune` → `info_a_presenter_sans_action`

Doc mise à jour avec les **4 niveaux explicites alignés sur le mapping handler** :
- rouge → bascule indoor automatique (avec confirmation)
- orange → flag pour décision humaine
- jaune → info présentée sans action
- vert → aucune action (pas de vigilance, rien à signaler)

Le code n'a pas bougé (sémantique du handler est juste : pas de vigilance = pas d'info à signaler), seule la doc est corrigée.

## Tests

10/10 verts dans `tests/_mcp/handlers/test_weather.py`. Tests étendus :
- Assertion `freshness_minutes` + type sur `test_happy_path_returns_data_with_metadata` (rain)
- Assertion `freshness_minutes` + type sur `test_recommended_action_per_color` (vigilance, paramétré 4 couleurs)
- Assertion `interim_workaround` sur `test_get_weather_along_route_returns_stub`

Pre-commit : black / ruff / isort / pydocstyle / pycodestyle / check-safe-io tous ✅.

## Hors scope (loggués backlog)

- **P1** : mining circuits Intervals.icu pour débloquer les 2 stubs NIY → à arbitrer S094 avec ticket `find-suitable-circuits` (catalogue-first vs mining-first)
- **P2** : `get-forecast(lat, lon, horizon_hours)` J+1 à J+7 via provider Open-Meteo → planifier S094, effort 1.5j Junior
- **P4** : `confidence` métadonnée provider-dependent → secondaire, si pertinent

## Doctrine

- Cohérent avec philosophie « surfacer données contextualisées, pas de pré-jugement code-side » établie en PR4bis (AC1 plan iso-config)
- `_metadata.response_timestamp` déjà injecté par `mcp_response()` (cohérent AC6 levier 1)
- `freshness_minutes` = complément côté payload, calculable client-side mais épargné au Coach IA

🤖 Generated with [Claude Code](https://claude.com/claude-code)