### PR TITLE
feat(wellness): archive raw wellness + backfill 90j (PR2 + PR2bis iso-config AC1)

### DIFF
--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -84,6 +84,12 @@ INTELLIGENCE_SUBDIR = "data/intelligence"
 #: Nom du fichier intelligence sous :data:`INTELLIGENCE_SUBDIR`.
 INTELLIGENCE_FILENAME = "intelligence.json"
 
+#: Sous-dossier (relatif à la racine training-logs) qui héberge l'archive
+#: wellness brut (1 fichier JSON par jour, PR2 plan iso-config AC2). Shared
+#: cross-writers — wellness est un fait per-athlète, pas per-writer. Le
+#: backfill 90j via PR2bis remplit rétroactivement ce dossier (~270 KB).
+WELLNESS_SUBDIR = "data/wellness"
+
 #: Sous-dossier (relatif à la racine training-logs) qui héberge la config
 #: athlète portable (PR5 AC1). Shared cross-writers — un seul athlète par repo.
 ATHLETE_CONFIG_SUBDIR = "config"
@@ -95,13 +101,15 @@ ATHLETE_CONFIG_FILENAME = "athlete.yaml"
 
 #: Whitelist par défaut des fichiers racine autorisés (utilisée si
 #: ``.operators.yaml`` absent ou ne définit pas ``shared_root_files``).
-#: ``data/intelligence/**`` est inclus pour que le mode writer-scoped futur
-#: (cf. ADR v5) autorise l'écriture intelligence shared cross-writers.
+#: ``data/intelligence/**`` et ``data/wellness/**`` sont inclus pour que le
+#: mode writer-scoped futur (cf. ADR v5) autorise l'écriture des artefacts
+#: shared cross-writers.
 DEFAULT_SHARED_ROOT_FILES = [
     ".gitignore",
     "README.md",
     OPERATORS_FILE,
     "data/intelligence/**",
+    "data/wellness/**",
     "config/athlete.yaml",
 ]
 
@@ -419,6 +427,17 @@ class DataRepoConfig:
         return self.root_path / ATHLETE_CONFIG_SUBDIR / ATHLETE_CONFIG_FILENAME
 
     @property
+    def wellness_dir(self) -> Path:
+        """Path au dossier d'archive wellness (shared cross-writers, sous root_path).
+
+        PR2 plan iso-config (AC2 self-contained) : 1 fichier JSON par jour de
+        wellness brut Intervals.icu (sleep, HRV, weight, readiness, CTL/ATL/TSB).
+        Sous ``root_path`` (et non ``data_repo_path``) car wellness est un fait
+        per-athlète, pas per-writer — invariant ADR v5.
+        """
+        return self.root_path / WELLNESS_SUBDIR
+
+    @property
     def intelligence_dir(self) -> Path:
         """Path au dossier intelligence (shared cross-writers).
 
@@ -454,6 +473,7 @@ class DataRepoConfig:
         self.handoff_dir.mkdir(parents=True, exist_ok=True)
         self.intelligence_dir.mkdir(parents=True, exist_ok=True)
         self.athlete_config_path.parent.mkdir(parents=True, exist_ok=True)
+        self.wellness_dir.mkdir(parents=True, exist_ok=True)
 
     def validate(self) -> bool:
         """Validate data repository structure.

--- a/magma_cycling/daily_sync.py
+++ b/magma_cycling/daily_sync.py
@@ -170,6 +170,21 @@ class DailySync(
             "tsb_threshold": -10,  # TSB <-10
         }
 
+    def _archive_wellness_for_date(self, check_date: date) -> None:
+        """Archive raw wellness for ``check_date`` to training-logs (PR2)."""
+        from magma_cycling.wellness import archive_wellness_day, wellness_archive_exists
+
+        date_str = check_date.isoformat()
+        if wellness_archive_exists(date_str):
+            return
+        wellness_data = self.client.get_wellness(oldest=date_str, newest=date_str)
+        payload = next((d for d in wellness_data if d.get("id") == date_str), None)
+        if payload is None:
+            print(f"ℹ️  no wellness data for {date_str} — archive skipped")
+            return
+        target = archive_wellness_day(date_str, payload)
+        print(f"💾 wellness archived: {target}")
+
     def run(
         self,
         check_date: date,
@@ -189,6 +204,14 @@ class DailySync(
         print("=" * 80)
         print("DAILY SYNC - Vérification Quotidienne")
         print("=" * 80)
+
+        # 0. Archive raw wellness for the day under training-logs/data/wellness/
+        # (PR2 plan iso-config AC2 self-contained). Idempotent: skip if file
+        # already exists. Failures are non-fatal — daily-sync continues.
+        try:
+            self._archive_wellness_for_date(check_date)
+        except Exception as exc:  # noqa: BLE001 - non-fatal best-effort
+            print(f"⚠️  wellness archive skipped: {exc}")
 
         # 1. Check activities - returns (new_activities, completed_activities)
         new_activities, completed_activities = self.check_activities(check_date)

--- a/magma_cycling/scripts/backfill_wellness.py
+++ b/magma_cycling/scripts/backfill_wellness.py
@@ -1,0 +1,139 @@
+"""Backfill historic wellness data (plan iso-config PR2bis, AC2 self-contained).
+
+Iterates ``--since`` to ``--to`` (inclusive) day-by-day, fetches the
+Intervals.icu wellness payload via :class:`IntervalsClient`, and writes
+each day to ``<TRAINING_DATA_ROOT>/data/wellness/YYYY-MM-DD.json`` via
+:func:`magma_cycling.wellness.archive.archive_wellness_day`.
+
+Idempotent : days already archived are skipped (override with
+``--force``). Volume estimate for 90 days ≈ 270 KB.
+
+Usage::
+
+    poetry run backfill-wellness --since 2026-02-10 --to 2026-05-10
+    poetry run backfill-wellness --since 2026-02-10 --to 2026-05-10 --dry-run
+    poetry run backfill-wellness --since 2026-02-10 --to 2026-05-10 --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date, timedelta
+
+from magma_cycling.wellness import (
+    archive_wellness_day,
+    resolve_wellness_dir,
+    wellness_archive_exists,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_date(s: str) -> date:
+    try:
+        return date.fromisoformat(s)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid date {s!r} (expected YYYY-MM-DD)") from exc
+
+
+def _iter_days(start: date, end: date):
+    cur = start
+    while cur <= end:
+        yield cur
+        cur += timedelta(days=1)
+
+
+def backfill(
+    since: date,
+    to: date,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the backfill and return a counters summary.
+
+    Returns:
+        Dict with keys ``fetched``, ``written``, ``skipped``, ``failed``.
+    """
+    if since > to:
+        raise ValueError(f"--since {since} must be <= --to {to}")
+
+    from magma_cycling.config import create_intervals_client
+
+    client = create_intervals_client()
+    payload_by_date: dict[str, dict] = {}
+    counters = {"fetched": 0, "written": 0, "skipped": 0, "failed": 0}
+
+    # Single API call covering the whole range — Intervals.icu returns one entry per day.
+    raw = client.get_wellness(oldest=since.isoformat(), newest=to.isoformat())
+    counters["fetched"] = len(raw)
+    for entry in raw:
+        d = entry.get("id")
+        if isinstance(d, str):
+            payload_by_date[d] = entry
+
+    for day in _iter_days(since, to):
+        date_str = day.isoformat()
+        if not force and wellness_archive_exists(date_str):
+            counters["skipped"] += 1
+            continue
+        payload = payload_by_date.get(date_str)
+        if payload is None:
+            logger.warning("no wellness data for %s — skipping", date_str)
+            counters["failed"] += 1
+            continue
+        if dry_run:
+            counters["written"] += 1
+            continue
+        archive_wellness_day(date_str, payload)
+        counters["written"] += 1
+
+    return counters
+
+
+def main() -> int:
+    """CLI entry point: ``poetry run backfill-wellness``."""
+    parser = argparse.ArgumentParser(
+        prog="backfill-wellness",
+        description="Backfill historic wellness data into training-logs/data/wellness/.",
+    )
+    parser.add_argument("--since", type=_parse_date, required=True, help="YYYY-MM-DD")
+    parser.add_argument("--to", type=_parse_date, required=True, help="YYYY-MM-DD")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-write existing archives (default: skip).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch + count without writing files.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    target_dir = resolve_wellness_dir()
+    print(f"📁 archive dir: {target_dir}", file=sys.stderr)
+    print(f"📅 range: {args.since} → {args.to}", file=sys.stderr)
+    if args.dry_run:
+        print("ℹ️  dry-run: no files written", file=sys.stderr)
+
+    try:
+        counters = backfill(args.since, args.to, force=args.force, dry_run=args.dry_run)
+    except (ValueError, RuntimeError) as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"✅ done — fetched={counters['fetched']} written={counters['written']} "
+        f"skipped={counters['skipped']} failed={counters['failed']}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/magma_cycling/wellness/__init__.py
+++ b/magma_cycling/wellness/__init__.py
@@ -1,0 +1,24 @@
+"""Wellness archive helpers (plan iso-config PR2 + PR2bis, AC2 self-contained).
+
+Public API:
+    - resolve_wellness_dir() — standalone path resolver (no DataRepoConfig)
+    - wellness_archive_path(date) — single-day file path
+    - archive_wellness_day(date, payload) — atomic write
+    - wellness_archive_exists(date) — idempotent check (used by backfill)
+"""
+
+from __future__ import annotations
+
+from magma_cycling.wellness.archive import (
+    archive_wellness_day,
+    resolve_wellness_dir,
+    wellness_archive_exists,
+    wellness_archive_path,
+)
+
+__all__ = [
+    "archive_wellness_day",
+    "resolve_wellness_dir",
+    "wellness_archive_exists",
+    "wellness_archive_path",
+]

--- a/magma_cycling/wellness/archive.py
+++ b/magma_cycling/wellness/archive.py
@@ -1,0 +1,94 @@
+"""Wellness raw archive (1 file per day) under training-logs/data/wellness/.
+
+PR2 plan iso-config (AC2 self-contained): the daily-sync extension archives
+the raw Intervals.icu wellness payload (sleep, HRV, weight, readiness +
+CTL/ATL/TSB) on every run. PR2bis adds the standalone ``backfill-wellness``
+CLI that fills 90 days of history retroactively.
+
+Storage path: ``<TRAINING_DATA_ROOT>/data/wellness/YYYY-MM-DD.json``
+(shared cross-writers — wellness is per-athlete, not per-writer).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from magma_cycling.config.data_repo import (
+    WELLNESS_SUBDIR,
+    _resolve_root_from_env,
+)
+
+logger = logging.getLogger(__name__)
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def resolve_wellness_dir() -> Path:
+    """Resolve the wellness archive directory without instantiating DataRepoConfig.
+
+    Priority:
+      1. ``TRAINING_DATA_ROOT`` (or legacy ``TRAINING_DATA_REPO``) →
+         ``<root>/data/wellness/``
+      2. Fallback ``~/data/wellness/`` (dev local sans env, comportement
+         pré-PR2 pour ne pas crasher si le caller n'a pas configuré l'env).
+    """
+    root = _resolve_root_from_env()
+    if root is not None:
+        return root / WELLNESS_SUBDIR
+    return Path.home() / "data" / "wellness"
+
+
+def wellness_archive_path(date_str: str) -> Path:
+    """Path du fichier d'archive d'une journée donnée.
+
+    Args:
+        date_str: ISO 8601 date ``YYYY-MM-DD``.
+
+    Raises:
+        ValueError: si ``date_str`` n'est pas un ISO 8601 ``YYYY-MM-DD`` valide.
+    """
+    if not _DATE_RE.match(date_str):
+        raise ValueError(f"date_str must be YYYY-MM-DD, got {date_str!r}")
+    return resolve_wellness_dir() / f"{date_str}.json"
+
+
+def wellness_archive_exists(date_str: str) -> bool:
+    """``True`` si l'archive d'une journée existe déjà sur disque.
+
+    Utilisé par :mod:`magma_cycling.scripts.backfill_wellness` pour éviter
+    le re-write idempotent (skip-existing par défaut).
+    """
+    return wellness_archive_path(date_str).is_file()
+
+
+def archive_wellness_day(date_str: str, payload: dict[str, Any]) -> Path:
+    """Write the daily wellness payload atomically.
+
+    Args:
+        date_str: ISO 8601 ``YYYY-MM-DD`` — drives the filename.
+        payload: Raw Intervals.icu wellness dict (must include ``id`` field
+            equal to ``date_str`` for cross-check).
+
+    Returns:
+        The final path written.
+
+    Raises:
+        ValueError: if ``date_str`` malformed or ``payload['id']`` mismatches.
+    """
+    target = wellness_archive_path(date_str)
+    payload_id = payload.get("id")
+    if payload_id and payload_id != date_str:
+        raise ValueError(f"payload['id']={payload_id!r} mismatches date_str={date_str!r}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False, indent=2, sort_keys=True)
+    os.chmod(tmp, 0o644)
+    tmp.replace(target)
+    logger.info("wellness archived: %s (%d bytes)", target, target.stat().st_size)
+    return target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.13.0"
+version = "3.14.0"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ daily-sync = "magma_cycling.daily_sync:main"
 insert-analysis = "magma_cycling.insert_analysis:main"
 manage-state = "magma_cycling.manage_workflow_state:main"
 backfill-history = "magma_cycling.scripts.backfill_history:main"
+backfill-wellness = "magma_cycling.scripts.backfill_wellness:main"
 provision-writer = "magma_cycling.scripts.provision_writer:main"
 lint-authority-coherence = "magma_cycling.scripts.lint_authority_coherence:main"
 

--- a/tests/scripts/test_backfill_wellness.py
+++ b/tests/scripts/test_backfill_wellness.py
@@ -1,0 +1,109 @@
+"""Tests for the backfill-wellness CLI (PR2bis plan iso-config)."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.config.data_repo import LEGACY_ROOT_ENV, ROOT_ENV, WELLNESS_SUBDIR
+from magma_cycling.scripts.backfill_wellness import backfill
+from magma_cycling.wellness import wellness_archive_exists, wellness_archive_path
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for v in (ROOT_ENV, LEGACY_ROOT_ENV):
+        monkeypatch.delenv(v, raising=False)
+
+
+def _fake_client(payloads: list[dict]) -> MagicMock:
+    client = MagicMock()
+    client.get_wellness.return_value = payloads
+    return client
+
+
+class TestBackfill:
+    def test_writes_one_file_per_day(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        payloads = [
+            {"id": "2026-05-12", "ctl": 40},
+            {"id": "2026-05-13", "ctl": 41},
+            {"id": "2026-05-14", "ctl": 42},
+        ]
+        with patch(
+            "magma_cycling.config.create_intervals_client", return_value=_fake_client(payloads)
+        ):
+            counters = backfill(date(2026, 5, 12), date(2026, 5, 14))
+        assert counters["fetched"] == 3
+        assert counters["written"] == 3
+        assert counters["skipped"] == 0
+        assert counters["failed"] == 0
+        for d in ("2026-05-12", "2026-05-13", "2026-05-14"):
+            assert wellness_archive_exists(d)
+
+    def test_skips_existing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        # Pre-populate one day
+        wellness_dir = tmp_path / WELLNESS_SUBDIR
+        wellness_dir.mkdir(parents=True)
+        (wellness_dir / "2026-05-13.json").write_text("{}", encoding="utf-8")
+
+        payloads = [
+            {"id": "2026-05-12", "ctl": 40},
+            {"id": "2026-05-13", "ctl": 41},  # ignored — file exists
+            {"id": "2026-05-14", "ctl": 42},
+        ]
+        with patch(
+            "magma_cycling.config.create_intervals_client", return_value=_fake_client(payloads)
+        ):
+            counters = backfill(date(2026, 5, 12), date(2026, 5, 14))
+        assert counters["written"] == 2
+        assert counters["skipped"] == 1
+
+    def test_force_overwrites(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        target = wellness_archive_path("2026-05-13")
+        target.parent.mkdir(parents=True)
+        target.write_text("OLD", encoding="utf-8")
+
+        payloads = [{"id": "2026-05-13", "ctl": 99}]
+        with patch(
+            "magma_cycling.config.create_intervals_client", return_value=_fake_client(payloads)
+        ):
+            counters = backfill(date(2026, 5, 13), date(2026, 5, 13), force=True)
+        assert counters["written"] == 1
+        assert counters["skipped"] == 0
+        assert "OLD" not in target.read_text(encoding="utf-8")
+
+    def test_dry_run_does_not_write(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        payloads = [{"id": "2026-05-13", "ctl": 41}]
+        with patch(
+            "magma_cycling.config.create_intervals_client", return_value=_fake_client(payloads)
+        ):
+            counters = backfill(date(2026, 5, 13), date(2026, 5, 13), dry_run=True)
+        assert counters["written"] == 1  # accounted as would-write
+        assert not wellness_archive_exists("2026-05-13")
+
+    def test_missing_day_counted_as_failed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        # API returns only 2 of the 3 days
+        payloads = [
+            {"id": "2026-05-12", "ctl": 40},
+            {"id": "2026-05-14", "ctl": 42},
+        ]
+        with patch(
+            "magma_cycling.config.create_intervals_client", return_value=_fake_client(payloads)
+        ):
+            counters = backfill(date(2026, 5, 12), date(2026, 5, 14))
+        assert counters["written"] == 2
+        assert counters["failed"] == 1
+        assert not wellness_archive_exists("2026-05-13")
+
+    def test_invalid_date_range_rejected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        with pytest.raises(ValueError, match="must be"):
+            backfill(date(2026, 5, 14), date(2026, 5, 12))

--- a/tests/wellness/test_archive.py
+++ b/tests/wellness/test_archive.py
@@ -1,0 +1,106 @@
+"""Tests for the wellness archive helpers (PR2 + PR2bis plan iso-config)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from magma_cycling.config.data_repo import (
+    DEFAULT_SHARED_ROOT_FILES,
+    LEGACY_ROOT_ENV,
+    ROOT_ENV,
+    WELLNESS_SUBDIR,
+)
+from magma_cycling.wellness import (
+    archive_wellness_day,
+    resolve_wellness_dir,
+    wellness_archive_exists,
+    wellness_archive_path,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for v in (ROOT_ENV, LEGACY_ROOT_ENV):
+        monkeypatch.delenv(v, raising=False)
+
+
+class TestResolveWellnessDir:
+    def test_uses_training_data_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        assert resolve_wellness_dir() == tmp_path / WELLNESS_SUBDIR
+
+    def test_uses_legacy_training_data_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(LEGACY_ROOT_ENV, str(tmp_path))
+        assert resolve_wellness_dir() == tmp_path / WELLNESS_SUBDIR
+
+    def test_fallback_when_no_env(self):
+        assert resolve_wellness_dir() == Path.home() / "data" / "wellness"
+
+
+class TestPathBuilders:
+    def test_archive_path_format(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        assert wellness_archive_path("2026-05-14") == tmp_path / WELLNESS_SUBDIR / "2026-05-14.json"
+
+    def test_invalid_date_rejected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        with pytest.raises(ValueError, match="YYYY-MM-DD"):
+            wellness_archive_path("14/05/2026")
+        with pytest.raises(ValueError):
+            wellness_archive_path("2026-5-14")  # missing zero-pad
+
+    def test_exists_false_when_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        assert wellness_archive_exists("2026-05-14") is False
+
+
+class TestArchiveWellnessDay:
+    def test_writes_json_atomically(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        payload = {
+            "id": "2026-05-14",
+            "ctl": 41.0,
+            "atl": 38.2,
+            "sleepSecs": 25200,
+            "weight": 84.7,
+        }
+        target = archive_wellness_day("2026-05-14", payload)
+        assert target == tmp_path / WELLNESS_SUBDIR / "2026-05-14.json"
+        loaded = json.loads(target.read_text(encoding="utf-8"))
+        assert loaded == payload
+        assert wellness_archive_exists("2026-05-14") is True
+        # No .tmp leftover
+        assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+    def test_creates_parent_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        wellness_dir = tmp_path / WELLNESS_SUBDIR
+        assert not wellness_dir.exists()
+        archive_wellness_day("2026-05-14", {"id": "2026-05-14"})
+        assert wellness_dir.is_dir()
+
+    def test_payload_id_mismatch_rejected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        with pytest.raises(ValueError, match="mismatches"):
+            archive_wellness_day("2026-05-14", {"id": "2026-05-15"})
+
+    def test_payload_without_id_accepted(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        # Edge case: lib sometimes returns entries with no id (incomplete day)
+        target = archive_wellness_day("2026-05-14", {"ctl": 40.0})
+        assert target.is_file()
+
+    def test_overwrites_existing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(ROOT_ENV, str(tmp_path))
+        archive_wellness_day("2026-05-14", {"id": "2026-05-14", "ctl": 40})
+        archive_wellness_day("2026-05-14", {"id": "2026-05-14", "ctl": 50})
+        loaded = json.loads(wellness_archive_path("2026-05-14").read_text(encoding="utf-8"))
+        assert loaded["ctl"] == 50
+
+
+class TestWhitelistContainsWellness:
+    def test_default_whitelist_contains_wellness_pattern(self):
+        assert "data/wellness/**" in DEFAULT_SHARED_ROOT_FILES


### PR DESCRIPTION
## Contexte

**PR2 + PR2bis combinées** plan iso-config — archive wellness brut + backfill 90j historique. **Ferme AC1 portabilité athlète sur la dimension wellness** (cf plan iso-config gap §3 ligne 40 « ❌ pas archivé, Withings/Intervals API only »).

Livraison Junior (patch handoff sha256 `dd3704bf18ec909c28c56a3ec576a4dc7cb5604872fd52c3b8130eb24b0bfe00`, stacké sur PR5 mergée). 1 commit PR5 squashed déjà sur main → `git am --3way --empty=drop` a propre.

## Architecture PR2 (archive quotidien)

### `magma_cycling/wellness/archive.py` (nouveau module)
- `resolve_wellness_dir()` — résolution path portable training-logs
- `archive_wellness_day(payload, date)` — write atomic + perms 0o644 + cross-check `payload['id']` cohérent avec la date
- `wellness_archive_exists(date)` — idempotent skip

### `DataRepoConfig.wellness_dir` property
Sous `root_path` (pas `data_repo_path`) → shared cross-writers en mode writer-scoped futur. Whitelist `data/wellness/**` ajoutée à `DEFAULT_SHARED_ROOT_FILES` (anti-régression PR C).

### `daily_sync.py::_archive_wellness_for_date()`
Step 0 inconditionnel dans `daily-sync`, idempotent (skip si exists), **non-fatal** si Intervals API down. Le daily-sync continue son flux normal même si l'archive échoue.

## Architecture PR2bis (backfill 90j)

CLI `poetry run backfill-wellness --since YYYY-MM-DD --to YYYY-MM-DD [--force] [--dry-run]`.

- **1 single API call** sur le range entier (pas 90 appels journaliers) — économie rate-limit
- **1 fichier par jour** dans `data/wellness/YYYY-MM-DD.json`
- **Skip-existing par défaut** (idempotent retry), missing-day counté `failed` (no invent / no fallback silencieux)
- Volume ~270 KB pour 90 jours (data wellness brut compact)
- `--dry-run` pour preview, `--force` pour overwrite

## Tests

**332/332 verts** sur ma branche apply (PR5 + PR2 + PR2bis + non-régression intégrale config + handlers MCP + wellness + scripts) :
- 12 nouveaux tests PR2 (`tests/wellness/test_archive.py`)
- 6 nouveaux tests PR2bis (`tests/scripts/test_backfill_wellness.py`)
- 0 régression sur les 314 tests existants

Pre-commit Junior : black/ruff/isort/pydocstyle/pycodestyle/check-safe-io ✅.

## Followup post-merge (Admin)

Après retag :stable de la nouvelle version intégrant PR2+PR2bis :

```bash
docker exec magma-cycling-cron-jobs-1 \
  poetry run backfill-wellness --since 2026-02-10 --to 2026-05-14
```

→ Génère ~93 fichiers `/data/training-logs/data/wellness/YYYY-MM-DD.json`. `data-repo-sync` push automatique au prochain tick (cron 30 22 * * *).

## Doctrine

- Plan iso-config v3.1 — AC1 portabilité athlète (wellness historique conservé hors API live)
- AC4 multi-opérateur : `wellness/` sous `root_path` portable + whitelist writer-scoped guard-rail
- Pattern « pas de fallback silencieux » : missing-day = failed counté, jamais invented

## Délai prod

Mergeable immédiatement. Backfill 90j post-retag à coordonner avec Admin (procédure dans la meta JSON Junior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)