### PR TITLE
chore: align local version markers with v3.42.0 git tag

### DIFF
--- a/magma_cycling/__init__.py
+++ b/magma_cycling/__init__.py
@@ -2,7 +2,7 @@
 
 import sys as _sys
 
-__version__ = "3.7.0"
+__version__ = "3.42.0"
 
 
 # Force UTF-8 on stdout/stderr so emoji characters used throughout the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.14.0"
+version = "3.15.0"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.15.0"
+version = "3.42.0"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"


### PR DESCRIPTION
## Contexte

Task P2 cosmétique — alignement des 2 marqueurs version locaux sur le dernier tag git semantic-release.

**Avant** : `pyproject.toml:tool.poetry.version = "3.15.0"`, `magma_cycling/__init__.py:__version__ = "3.7.0"`
**Après** : les deux à `3.42.0` (= dernier tag git créé par semantic-release suite au merge PR #351 wellness)

## Source de vérité

La config semantic-release dans `pyproject.toml` :
- `tag_format = "v{version}"` 
- `version_toml = ["pyproject.toml:tool.poetry.version"]`
- `commit: false` implicite par branch protection main (pas de commit de version sur main)

→ La source de vérité version est les **tags git**, pas le pyproject. Les valeurs dans `pyproject.toml` et `__init__.py` sont des marqueurs cosmétiques.

## Cause de la désync

`github-utils-cli` (depuis le repo `outillages`) bumpe localement `pyproject.toml:version` après chaque `merge-pr`, mais ne push pas le bump (branch protection rejette toute modification directe). Le bump local s'accumule sans effet propagé → désync croissante avec les tags git.

Pas un bug code, juste un artefact CLI à aligner manuellement périodiquement.

## Workflow futur

À chaque retag `:stable`, refaire ce chore d'alignement :
1. `git fetch --tags`
2. Lire le dernier tag git
3. `pyproject.toml:version` + `__init__.py:__version__` ← dernière version
4. Commit `chore: align local version markers with vX.Y.Z`
5. PR + merge (`chore:` ne déclenche pas de bump semantic-release, pas de cascade)

Alternative à long terme : retirer manuellement les markers et lire dynamiquement via `importlib.metadata.version("magma-cycling")` — refacto plus large, hors scope cette PR.

## Tests

Pas de tests applicatifs touchés. Pre-commit (black/ruff/isort/check-safe-io/check-toml) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)