### PR TITLE
chore: close __version__ desync structurally (semantic-release version_variables)

### DIFF
--- a/magma_cycling/__init__.py
+++ b/magma_cycling/__init__.py
@@ -2,7 +2,7 @@
 
 import sys as _sys
 
-__version__ = "3.42.0"
+__version__ = "3.42.1"
 
 
 # Force UTF-8 on stdout/stderr so emoji characters used throughout the

--- a/magma_cycling/_mcp/handlers/admin.py
+++ b/magma_cycling/_mcp/handlers/admin.py
@@ -127,8 +127,6 @@ async def handle_system_info(args: dict) -> list[TextContent]:
             tool_count = -1
 
         # Version et data repo info — utiles pour TNR post-déploiement.
-        # ``__version__`` peut être stale (semantic-release ne bump pas
-        # ``magma_cycling/__init__.py``) — c'est cosmétique, pas un défaut.
         try:
             from magma_cycling import __version__ as version
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,11 @@ exclude = [
 commit_parser = "conventional"
 tag_format = "v{version}"
 version_toml = ["pyproject.toml:tool.poetry.version"]
+# Verrouille la cohérence cross-fichier : semantic-release bumpe aussi
+# ``magma_cycling/__init__.py:__version__`` à chaque release. Évite la
+# désync chronique observable runtime (CLI ``--version``, setup wizard,
+# handler MCP admin) qui était documentée en code (admin.py) sans fix.
+version_variables = ["magma_cycling/__init__.py:__version__"]
 
 [tool.semantic_release.branches.main]
 match = "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.42.0"
+version = "3.42.1"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"


### PR DESCRIPTION
## Contexte

**Task P2 #10 ré-ouverte → fermeture structurelle.**

La task P2 cosmétique #10 (alignement `pyproject.toml` + `__init__.py`) a été mergée tout à l'heure (PR #352) comme alignement ponctuel. Stéphane + Coach IA CD ont demandé un grep préalable avant retag :stable v3.42.1 pour valider que `__init__.py:__version__` n'était pas consommé runtime.

**Grep révèle 5 consommateurs**, dont 3 runtime visibles utilisateur final / Coach IA :
- `magma_cycling/cli.py:18,134,342` — CLI `magma-cycling --version` + help banner
- `magma_cycling/scripts/setup_wizard.py:21,43` — setup wizard affichage version
- **`magma_cycling/_mcp/handlers/admin.py:130-133`** — handler MCP `admin` exposé au Coach IA, AVEC un commentaire TODO inline : *« `__version__` peut être stale (semantic-release ne bump pas...) — c'est cosmétique, pas un défaut »* (dette documentée mais non résolue par un dev précédent)

Donc l'alignement P2 #10 ponctuel n'était **pas cosmétique** mais corrigeait un bug runtime visible. Et au prochain auto-bump pyproject, la désync reviendrait. **Fix structurel requis.**

## Changement

### 1. Config semantic-release `version_variables`

```toml
[tool.semantic_release]
version_toml = ["pyproject.toml:tool.poetry.version"]
version_variables = ["magma_cycling/__init__.py:__version__"]  # ← ajout
```

`version_variables` est la directive `python-semantic-release` pour les fichiers Python source (non-TOML). À chaque release, semantic-release **bumpera les deux fichiers en cohérence**. La désync chronique est fermée à la racine.

### 2. Bump immediat `__init__.py:__version__`

`3.42.0` → `3.42.1` (alignement immédiat avec pyproject.toml courant = 3.42.1 post-chore #352). Sans ça, on attendrait le prochain auto-bump qui n'arriverait peut-être pas dans la fenêtre TNR.

### 3. Suppression commentaire TODO devenu mensonger

`magma_cycling/_mcp/handlers/admin.py:129-131` — 2 lignes de commentaire qui disaient *« peut être stale... c'est cosmétique, pas un défaut »*. Cette PR ferme la dette → commentaire devient faux, suppression.

## Conséquences sur le retag :stable

Au merge de cette PR :
- semantic-release verra un commit `chore:` modifiant code Python (admin.py) + config + Python source (__init__.py) → comportement : **probablement émission `v3.42.2`** (patch bump auto-incrémental sur tout commit non-doc).
- Si pas de tag émis (chore: vraiment neutre dans la config courante), `v3.42.1` reste cible :stable mais avec **les deux fichiers alignés** désormais (puisque __init__ a été bumpé manuellement à 3.42.1 dans ce commit).
- Soit dans tous les cas, le retag :stable post-merge sera sur une image qui affiche `version = 3.42.1` ou `3.42.2` cohérent partout (pyproject + __init__ + CLI + handler admin + label container).

## Tests

22/22 verts sur `tests/_mcp/handlers/test_admin.py` + `tests/test_cli.py` (couvrent les chemins consommateurs `__version__`). Pre-commit ✅.

## Follow-up planifié (PR séparée post-retag)

**Test anti-tautologie de cohérence cross-fichier** (suggestion Stéphane / CD ce matin) — empêcher la rechute silencieuse en CI :

```python
def test_version_coherence_pyproject_vs_init():
    import importlib.metadata
    from magma_cycling import __version__
    pkg_version = importlib.metadata.version("magma-cycling")
    assert __version__ == pkg_version, (
        f"__init__ = {__version__} vs pyproject/dist = {pkg_version}"
    )
```

Task #18 dans le suivi, ~5 min, à programmer après retag :stable v3.42.x. Non-bloquant.

## Doctrine

- Plan iso-config v3.1 — sujet annexe P2 cosmétique réouvert + fermé structurellement
- Memory `project_refonte_stockage_secrets.md` — pattern « grep before validate cosmetic » à généraliser
- Pattern release promotion — préreq pour retag :stable propre

## Délai prod

Bloquant pour TNR L2 (Admin attend la nouvelle cible v3.42.x post-merge). Mergeable immédiatement, ~10 min cycle CI + auto-bump + retag stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)