### PR TITLE
chore(release): align pyproject + __init__ to 3.43.1 (close désync v3.42.x — test live fix #77)

### DIFF
--- a/magma_cycling/__init__.py
+++ b/magma_cycling/__init__.py
@@ -2,7 +2,7 @@
 
 import sys as _sys
 
-__version__ = "3.42.1"
+__version__ = "3.43.1"
 
 
 # Force UTF-8 on stdout/stderr so emoji characters used throughout the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.42.2"
+version = "3.43.0"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "magma-cycling"
-version = "3.43.0"
+version = "3.43.1"
 description = "Système automatisé d'analyse entraînements cyclisme"
 authors = ["Stéphane"]
 readme = "README.md"


### PR DESCRIPTION
## Contexte

Dernier rebump manuel avant que le fix outillages #77 (mergé 11:XX par Admin) prenne le relais automatiquement au prochain merge naturel.

État pré-PR :
- `pyproject.toml` = `3.42.2` (du chore #353 align)
- `__init__.py` = `3.42.1` (mon align manuel précédent)
- Tags GHCR existants : v3.42.0/1/2 + v3.43.0 (post PR #354 PR8, désync `__init__` non corrigée)

État de cette PR :
- `pyproject.toml` = `3.43.1` (rebump combined)
- `__init__.py` = `3.43.1` (alignement strict pyproject = __init__)

## Test live du fix #77

Au merge, github-utils-cli (avec fix #77 actif côté Leader, réinstall fait `poetry run pip install -e ~/Projects/outillages --upgrade`) devrait :
1. Bumper `pyproject.toml` 3.43.1 → 3.43.2 (chore = patch)
2. **Propager** `__init__.py` 3.43.1 → 3.43.2 via `version_variables` (= comportement nouveau fix #77)
3. Commit + push direct main + tag v3.43.2

Si push direct main est rejeté par branch protection durcie (Stéphane a durci en parallèle après incident PAT leak ce matin), le fix #77 actif fera **raise** + cleanup local au lieu du warning silencieux antérieur. C'est cohérent doctrine.

## Conséquence sur retag :stable

- Si merge + bump OK → cible :stable = **v3.43.2** avec pyproject + __init__ alignés. Plus jamais de rebump manuel après.
- Si bump auto échoue (branch protection refus) → cible :stable = **v3.43.1** (tag créé par semantic-release CI sur la PR mergée, pyproject + __init__ alignés via les edits de cette PR).

Dans les 2 cas, image cible :stable est **cohérente** (label container = pyproject = __init__).

## Doctrine

- Memory Junior `feedback_release_promotion_pattern.md` deviendra obsolète au merge de cette PR
- Mémo TNR `/Users/Shared/TNR-pre-retag-stable-v3.42.2.md` §1.2 Réserve désync intra-fichier reste documenté comme audit trail historique (v3.42.x ère)
- Test anti-tautologie task #18 reste pertinent en complément pour alerter en CI si désync revient

🤖 Generated with [Claude Code](https://claude.com/claude-code)