### PR TITLE
chore(scripts): fix maintenance scripts referencing externalized paths

### DIFF
--- a/scripts/maintenance/README.md
+++ b/scripts/maintenance/README.md
@@ -104,8 +104,9 @@ Le bot maintient le projet impeccable en :
 
 2. **Détectant les fichiers mal placés**
    - Identifie fichiers à la racine qui ne devraient pas y être
-   - Suggère l'emplacement approprié (releases/, archives/, etc.)
+   - Suggère l'emplacement approprié (`scripts/maintenance/`, `scripts/debug/`, etc.)
    - Liste blanche des fichiers autorisés à la racine
+   - **Note** : les archives (`*.tar.gz`) et la méta projet (`*moa*`, `*livraison*`, `*sprint*`) sont désormais externalisées hors repo public — voir `~/Documents/Claude/magma-cycling/`
 
 3. **Créant des archives**
    - Archive complète du projet (hors .git, caches, etc.)
@@ -291,20 +292,16 @@ Le bot suggère automatiquement où déplacer les fichiers :
 
 | Type de Fichier | Destination Suggérée |
 |-----------------|---------------------|
-| `*.tar.gz`, `*.zip` | `releases/` |
-| `*moa*`, `*livraison*`, `*sprint*` | `project-docs/archives/` |
 | `fix_*.py` | `scripts/maintenance/` |
 | `test_*.py` | `scripts/debug/` |
-| Autres `*.txt`, `*.md` | `project-docs/archives/` |
+| `*.tar.gz`, `*.zip` | externalisé — `~/Documents/Claude/magma-cycling/releases/` |
+| `*moa*`, `*livraison*`, `*sprint*`, autres `*.md` | externalisé — `~/Documents/Claude/magma-cycling/project-docs/archives/` |
 
 **Exemple :**
 ```
-⚠️  Found 3 misplaced files at root:
-  → ANALYSE_MOA.md → project-docs/archives/
-  → sprint-r5.tar.gz → releases/
+⚠️  Found 2 misplaced files at root:
   → fix_something.py → scripts/maintenance/
-
-Run 'git mv <file> <destination>' to organize these files
+  → ANALYSE_MOA.md → externalisé (~/Documents/Claude/magma-cycling/project-docs/archives/)
 ```
 
 #### Archives Hors Projet

--- a/scripts/maintenance/README_SESSIONS.md
+++ b/scripts/maintenance/README_SESSIONS.md
@@ -2,6 +2,8 @@
 
 Scripts pour gérer et archiver les sessions Claude Code.
 
+> ⚠️ **Doc partiellement obsolète (2026-05-17)** : `archive_claude_sessions.py` n'existe plus dans ce repo ; le sous-dossier `project-docs/sessions/` a été externalisé vers `~/Documents/Claude/magma-cycling/project-docs/sessions/`. Les sections qui référencent ces paths/scripts sont conservées pour historique mais ne reflètent plus l'état du repo. Le bot d'archivage actuel (résumés de session) vit dans le repo `outillages` (`session-summarizer`).
+
 ## 📋 Scripts Disponibles
 
 ### 1. `session_summarizer.py` - Résumé de Sessions

--- a/scripts/maintenance/README_SYNC.md
+++ b/scripts/maintenance/README_SYNC.md
@@ -251,7 +251,7 @@ poetry run cleanup-archives --dry-run
 
 **✅ Nettoie:** `~/Documents/magma-cycling-archives/` (iCloud)
 
-**❌ Préserve:** `releases/` (local, jamais touché)
+**Note** : le dossier `releases/` du repo a été externalisé vers `~/Documents/Claude/magma-cycling/releases/` (hors repo public). Ce script ne le touche pas.
 
 ### Automatisation (optionnelle)
 
@@ -294,7 +294,7 @@ Summary:
 
 ### Sécurité
 
-- ✅ Archives locales (`releases/`) **jamais touchées**
+- ✅ Archives externalisées (`~/Documents/Claude/magma-cycling/releases/`) **jamais touchées**
 - ✅ Dry-run disponible pour prévisualiser
 - ✅ Ne supprime que les `.tar.gz` et `.sha256` dans iCloud
 - ✅ Garde toujours les N plus récentes

--- a/scripts/maintenance/generate_code_review_package.sh
+++ b/scripts/maintenance/generate_code_review_package.sh
@@ -294,7 +294,7 @@ cat > "$OUTPUT_DIR/metrics_summary.txt" << METRICS_EOF
 ### Project Organization
 - ✅ Root directory clean (files essentiels seulement)
 - ✅ Scripts organized (maintenance/, debug/)
-- ✅ Archives centralized (releases/)
+- ✅ Archives externalisées (~/Documents/Claude/magma-cycling/releases/)
 - ✅ Documentation structured (project-docs/)
 
 ---
@@ -342,7 +342,7 @@ cat > "$OUTPUT_DIR/metrics_summary.txt" << METRICS_EOF
 ### Organization
 - ✅ Root cleanup: 14 fichiers déplacés/supprimés
 - ✅ Scripts organizés: 8 scripts → scripts/maintenance/
-- ✅ Archives centralisées: releases/ créé
+- ✅ Archives externalisées: ~/Documents/Claude/magma-cycling/releases/
 - ✅ Bot maintenance: Créé et opérationnel
 
 ---
@@ -387,19 +387,12 @@ echo "📄 Copie de la documentation..."
 cp CODING_STANDARDS.md "$OUTPUT_DIR/" 2>/dev/null || echo "⚠️  CODING_STANDARDS.md non trouvé"
 cp README.md "$OUTPUT_DIR/" 2>/dev/null || echo "⚠️  README.md non trouvé"
 
-# Copier les documents MOA récents
-if [ -d "project-docs/sprints" ]; then
-    cp project-docs/sprints/LIVRAISON_MOA_20260104.md "$OUTPUT_DIR/" 2>/dev/null && echo "✅ LIVRAISON_MOA copiée" || echo "ℹ️  LIVRAISON_MOA non trouvée"
-fi
+# Copier l'explication des warnings (déplacé sous guides/ depuis le tri initial)
+cp project-docs/guides/REVIEW_WARNINGS_EXPLAINED.md "$OUTPUT_DIR/" 2>/dev/null && echo "✅ Documentation warnings copiée" || echo "ℹ️  REVIEW_WARNINGS_EXPLAINED.md non trouvé"
 
-# Copier l'explication des warnings
-cp project-docs/REVIEW_WARNINGS_EXPLAINED.md "$OUTPUT_DIR/" 2>/dev/null && echo "✅ Documentation warnings copiée" || echo "ℹ️  REVIEW_WARNINGS_EXPLAINED.md non trouvé"
-
-# Copier les sessions de développement récentes
-if [ -d "project-docs/sessions" ]; then
-    mkdir -p "$OUTPUT_DIR/sessions"
-    cp project-docs/sessions/SESSION_20260104_PEP8_LIVRABLE.md "$OUTPUT_DIR/sessions/" 2>/dev/null && echo "✅ Session documentation copiée"
-fi
+# Note : project-docs/{sprints,sessions}/ ont été externalisés hors repo public
+# (~/Documents/Claude/magma-cycling/project-docs/) le 2026-05-17.
+# Les anciens cp de LIVRAISON_MOA et SESSION_*_PEP8_LIVRABLE ont été retirés.
 
 echo "⚙️  Copie des configurations..."
 echo "   📝 Configuration moderne dans pyproject.toml (PEP 518/621)"
@@ -947,7 +940,7 @@ review_package_v2.2.0_[TIMESTAMP]/
 
 - **Root directory** clean (essentiels seulement)
 - **Scripts** organisés (maintenance/, debug/)
-- **Archives** centralisées (releases/)
+- **Archives** externalisées (~/Documents/Claude/magma-cycling/releases/)
 - **Documentation** structurée (project-docs/)
 
 ---


### PR DESCRIPTION
## Summary

Follow-up des PR #356/#357/#358 (externalisation méta hors repo public). Les scripts sous `scripts/maintenance/` référençaient encore les paths supprimés (`project-docs/{archives,sprints,sessions}/`, `releases/`).

## Changements

| Fichier | Action |
|---|---|
| `README.md` | Table de suggestions du bot maintenance : `*.tar.gz` et `*moa*/*sprint*` désormais flaggés "externalisé" → `~/Documents/Claude/magma-cycling/` |
| `README_SYNC.md` | Note sur `releases/` mise à jour (externalisé) |
| `README_SESSIONS.md` | Header d'obsolescence ajouté (script `archive_claude_sessions.py` n'existe plus dans ce repo, `session-summarizer` vit dans outillages) |
| `generate_code_review_package.sh` | Suppression des `cp` cassés vers `project-docs/{sprints,sessions}/`, fix path `REVIEW_WARNINGS_EXPLAINED.md` (déplacé sous `guides/`), update 3 echo descriptions mentionnant `releases/` |

## Sûreté

- Aucun impact fonctionnel : les blocs `cp` retirés échouaient déjà silencieusement (`|| echo`)
- Aucun fichier bundlé impacté
- CI : doc/script only → `paths-ignore: '**.md'` skip pour les 3 README, le `.sh` n'est pas exécuté par CI

## Test plan

- [x] `git status` propre hors scope
- [x] `grep` final : il reste 3 refs dans `README_SESSIONS.md` mais elles sont sous le disclaimer d'obsolescence
- [ ] CI verte (skip attendu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)