### PR TITLE
feat(planning): K - validate IF/type coherence in sync-week-to-calendar

### DIFF
--- a/magma_cycling/_mcp/handlers/remote_sync.py
+++ b/magma_cycling/_mcp/handlers/remote_sync.py
@@ -83,6 +83,33 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
                     and session.duration_min == 0
                 )
 
+                if not is_rest_day:
+                    from magma_cycling.planning.workout_validation import (
+                        ValidationResult,
+                        validate_intensity_coherence,
+                    )
+
+                    coherence_check = validate_intensity_coherence(
+                        session_type=session.session_type,
+                        tss=session.tss_planned,
+                        duration_minutes=session.duration_min,
+                    )
+                    if coherence_check.result == ValidationResult.FAIL:
+                        errors.append(
+                            f"Session {session.session_id}: intensity incoherent — "
+                            f"{coherence_check.message}. "
+                            f"Correct session_type, tss_planned, or duration_min before syncing."
+                        )
+                        continue
+                    if coherence_check.result == ValidationResult.WARNING:
+                        warnings.append(
+                            {
+                                "session_id": session.session_id,
+                                "type": "intensity_drift",
+                                "message": coherence_check.message,
+                            }
+                        )
+
                 # Guard: non-rest sessions MUST have a structured workout
                 # from the workouts file — escalate if missing (never sync placeholders)
                 if not is_rest_day and intervals_name not in workout_descriptions:

--- a/magma_cycling/planning/workout_validation.py
+++ b/magma_cycling/planning/workout_validation.py
@@ -21,6 +21,35 @@ class ValidationResult(str, Enum):
     FAIL = "fail"
 
 
+TYPE_TO_IF_WINDOW: dict[str, tuple[float, float]] = {
+    "REC": (0.55, 0.65),
+    "END": (0.65, 0.75),
+    "TMP": (0.75, 0.85),
+    "SS": (0.85, 0.94),
+    "FTP": (0.95, 1.04),
+    "CLM": (0.95, 1.04),
+    "TT": (0.95, 1.04),
+    "VO2": (1.05, 1.14),
+}
+
+SKIP_IF_VALIDATION_TYPES: frozenset[str] = frozenset({"INT", "RACE", "TEC", "MIX", "SPR"})
+
+IF_WARNING_TOLERANCE = 0.05
+
+# Ordered intensity ladder (low → high) used to measure zone distance.
+# CLM/TT alias to FTP (same rank).
+_IF_ZONE_LADDER: list[str] = ["REC", "END", "TMP", "SS", "FTP", "VO2"]
+_IF_ZONE_ALIASES: dict[str, str] = {"CLM": "FTP", "TT": "FTP"}
+
+
+def _zone_rank(session_type: str) -> int:
+    canon = _IF_ZONE_ALIASES.get(session_type, session_type)
+    try:
+        return _IF_ZONE_LADDER.index(canon)
+    except ValueError:
+        return -1
+
+
 @dataclass
 class WorkoutCheck:
     """Single validation check result."""
@@ -293,6 +322,129 @@ def validate_workout(
         checks=checks,
         safe_to_prescribe=safe_to_prescribe,
         recommendations=recommendations,
+    )
+
+
+def compute_intensity_factor(tss: float, duration_minutes: float) -> float | None:
+    """Compute Intensity Factor from TSS and duration.
+
+    Inverse of TrainingPeaks formula: TSS = (t_sec × IF² × 100) / 3600
+    → IF = sqrt(TSS × 3600 / (t_sec × 100))
+
+    Returns None if inputs are non-positive (IF undefined).
+    """
+    if duration_minutes <= 0 or tss <= 0:
+        return None
+    duration_sec = duration_minutes * 60
+    return (tss * 3600 / (duration_sec * 100)) ** 0.5
+
+
+def validate_intensity_coherence(
+    session_type: str, tss: int, duration_minutes: int
+) -> WorkoutCheck:
+    """Validate (TSS, duration) produces an IF coherent with declared session_type.
+
+    Args:
+        session_type: Magma session type (REC, END, TMP, SS, FTP, CLM, TT, VO2, ...)
+        tss: Planned Training Stress Score
+        duration_minutes: Planned duration in minutes
+
+    Returns:
+        WorkoutCheck with result PASS / WARNING / FAIL.
+        - PASS: IF within reference window, OR session_type non-validable
+          (INT, RACE, TEC, MIX, SPR — multi-block or ad-hoc, no stable IF target)
+        - WARNING: IF within IF_WARNING_TOLERANCE of window edge
+        - FAIL: IF beyond tolerance OR falls in another zone's window
+    """
+    if session_type in SKIP_IF_VALIDATION_TYPES:
+        return WorkoutCheck(
+            check_name="Cohérence IF/type",
+            result=ValidationResult.PASS,
+            message=f"Type {session_type} : validation IF non-applicable (multi-bloc / ad-hoc)",
+            severity="info",
+        )
+
+    window = TYPE_TO_IF_WINDOW.get(session_type)
+    if window is None:
+        return WorkoutCheck(
+            check_name="Cohérence IF/type",
+            result=ValidationResult.PASS,
+            message=f"Type {session_type} : pas de window IF référence (validation skipped)",
+            severity="info",
+        )
+
+    if_calc = compute_intensity_factor(tss, duration_minutes)
+    if if_calc is None:
+        return WorkoutCheck(
+            check_name="Cohérence IF/type",
+            result=ValidationResult.PASS,
+            message=f"TSS={tss}, durée={duration_minutes}min : IF non-calculable (valeurs nulles)",
+            severity="info",
+        )
+
+    low, high = window
+
+    if low <= if_calc <= high:
+        return WorkoutCheck(
+            check_name="Cohérence IF/type",
+            result=ValidationResult.PASS,
+            message=f"IF calculé {if_calc:.2f} ∈ window {session_type} [{low:.2f}–{high:.2f}]",
+            severity="info",
+        )
+
+    delta = (low - if_calc) if if_calc < low else (if_calc - high)
+
+    zone_match = None
+    for other_type, (other_low, other_high) in TYPE_TO_IF_WINDOW.items():
+        if other_type == session_type:
+            continue
+        if other_low <= if_calc <= other_high:
+            zone_match = other_type
+            break
+
+    if zone_match is not None:
+        declared_rank = _zone_rank(session_type)
+        match_rank = _zone_rank(zone_match)
+        if declared_rank >= 0 and match_rank >= 0 and abs(declared_rank - match_rank) <= 1:
+            return WorkoutCheck(
+                check_name="Cohérence IF/type",
+                result=ValidationResult.WARNING,
+                message=(
+                    f"IF calculé {if_calc:.2f} dans zone adjacente {zone_match} "
+                    f"(déclaré {session_type}, window [{low:.2f}–{high:.2f}])"
+                ),
+                severity="warning",
+            )
+        return WorkoutCheck(
+            check_name="Cohérence IF/type",
+            result=ValidationResult.FAIL,
+            message=(
+                f"IF calculé {if_calc:.2f} (TSS={tss}, durée={duration_minutes}min) "
+                f"tombe dans la zone {zone_match}, pas {session_type} "
+                f"(window attendue [{low:.2f}–{high:.2f}])"
+            ),
+            severity="critical",
+        )
+
+    if delta > IF_WARNING_TOLERANCE:
+        return WorkoutCheck(
+            check_name="Cohérence IF/type",
+            result=ValidationResult.FAIL,
+            message=(
+                f"IF calculé {if_calc:.2f} hors window {session_type} "
+                f"[{low:.2f}–{high:.2f}] (écart {delta:+.2f})"
+            ),
+            severity="critical",
+        )
+
+    return WorkoutCheck(
+        check_name="Cohérence IF/type",
+        result=ValidationResult.WARNING,
+        message=(
+            f"IF calculé {if_calc:.2f} légèrement hors window {session_type} "
+            f"[{low:.2f}–{high:.2f}] (écart {delta:+.2f})"
+        ),
+        severity="warning",
     )
 
 

--- a/tests/_mcp/handlers/test_remote_sync.py
+++ b/tests/_mcp/handlers/test_remote_sync.py
@@ -304,3 +304,101 @@ class TestTemporalHeuristic:
                 result = _extract(await handle_sync_week_to_calendar({"week_id": "S099"}))
 
         assert result["summary"]["warnings"] == 1
+
+
+class TestIntensityCoherenceValidation:
+    """Validate IF/type coherence rejects nonsensical sessions before sync."""
+
+    _VALIDATOR_PATCH = "magma_cycling.intervals_format_validator.IntervalsFormatValidator"
+
+    @pytest.mark.asyncio
+    async def test_rec_with_high_if_rejected_with_error(self):
+        """S094-01 régression: REC + TSS=18 + 15min → IF=0.85 (zone SS) → ERROR, no create."""
+        session = _make_session(
+            session_id="S094-01",
+            name="MorningRec",
+            session_type="REC",
+            tss_planned=18,
+            duration_min=15,
+            session_date=date(2026, 5, 18),
+            description="Récup",
+            status="planned",
+        )
+        plan = _make_plan(
+            [session],
+            start_date=date(2026, 5, 18),
+            end_date=date(2026, 5, 24),
+        )
+        client = _make_client()
+        workout_descs = {"S094-01-REC-MorningRec-V001": "- 15min @ 60% FTP"}
+
+        with _patch_sync(plan, client, workout_descriptions=workout_descs):
+            with patch(self._VALIDATOR_PATCH) as mock_val:
+                mock_val.return_value.validate_workout.return_value = (True, [], [])
+                result = _extract(await handle_sync_week_to_calendar({"week_id": "S094"}))
+
+        assert result["summary"]["to_create"] == 0
+        assert result["summary"]["errors"] == 1
+        assert "intensity incoherent" in result["errors"][0]
+        assert "SS" in result["errors"][0]
+        client.create_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_coherent_session_passes_validation(self):
+        """END + TSS=70 + 60min → IF=0.84... falls in TMP zone — fails coherence as expected.
+
+        Note: with adjacent-zone windows, any drift falls into a neighbour and fails.
+        Use exact-window values to pass: END 60min / 49 TSS → IF=0.7 (mid window).
+        """
+        session = _make_session(
+            session_id="S094-02",
+            name="EnduranceRide",
+            session_type="END",
+            tss_planned=49,
+            duration_min=60,
+            session_date=date(2026, 5, 19),
+            description="Endurance Z2",
+            status="planned",
+        )
+        plan = _make_plan(
+            [session],
+            start_date=date(2026, 5, 18),
+            end_date=date(2026, 5, 24),
+        )
+        client = _make_client()
+        workout_descs = {"S094-02-END-EnduranceRide-V001": "- 60min @ 70% FTP"}
+
+        with _patch_sync(plan, client, workout_descriptions=workout_descs):
+            with patch(self._VALIDATOR_PATCH) as mock_val:
+                mock_val.return_value.validate_workout.return_value = (True, [], [])
+                result = _extract(await handle_sync_week_to_calendar({"week_id": "S094"}))
+
+        assert result["summary"]["to_create"] == 1
+        assert result["summary"]["errors"] == 0
+        client.create_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rest_day_bypass_coherence_check(self):
+        """A true rest day (REC, TSS=0, duration=0) bypasses coherence and creates NOTE."""
+        session = _make_session(
+            session_id="S094-07",
+            name="ReposComplet",
+            session_type="REC",
+            tss_planned=0,
+            duration_min=0,
+            session_date=date(2026, 5, 24),
+        )
+        plan = _make_plan(
+            [session],
+            start_date=date(2026, 5, 18),
+            end_date=date(2026, 5, 24),
+        )
+        client = _make_client()
+
+        with _patch_sync(plan, client):
+            result = _extract(await handle_sync_week_to_calendar({"week_id": "S094"}))
+
+        assert result["summary"]["to_create"] == 1
+        assert result["summary"]["errors"] == 0
+        call_args = client.create_event.call_args[0][0]
+        assert call_args["category"] == "NOTE"

--- a/tests/planning/test_workout_validation.py
+++ b/tests/planning/test_workout_validation.py
@@ -10,7 +10,9 @@ import pytest
 
 from magma_cycling.planning.workout_validation import (
     ValidationResult,
+    compute_intensity_factor,
     format_validation_report,
+    validate_intensity_coherence,
     validate_workout,
 )
 
@@ -453,6 +455,159 @@ class TestEdgeCases:
         # Should have multiple checks failing/warning
         failed_checks = [c for c in validation.checks if c.result == ValidationResult.FAIL]
         assert len(failed_checks) >= 1  # At least sleep failure
+
+
+class TestComputeIntensityFactor:
+    """Tests for IF computation from (TSS, duration)."""
+
+    def test_if_60min_at_threshold(self):
+        """1h à FTP = 100 TSS = IF 1.00 par définition."""
+        assert compute_intensity_factor(tss=100, duration_minutes=60) == pytest.approx(1.0)
+
+    def test_if_s094_01_regression(self):
+        """S094-01 régression : REC 18 TSS / 15min → IF ≈ 0.849."""
+        assert compute_intensity_factor(tss=18, duration_minutes=15) == pytest.approx(
+            0.849, abs=0.01
+        )
+
+    def test_if_s094_05_regression(self):
+        """S094-05 régression : REC 16 TSS / 10min → IF ≈ 0.980."""
+        assert compute_intensity_factor(tss=16, duration_minutes=10) == pytest.approx(
+            0.980, abs=0.01
+        )
+
+    def test_if_zero_tss_returns_none(self):
+        assert compute_intensity_factor(tss=0, duration_minutes=60) is None
+
+    def test_if_zero_duration_returns_none(self):
+        assert compute_intensity_factor(tss=100, duration_minutes=0) is None
+
+
+class TestValidateIntensityCoherence:
+    """Tests for IF/type coherence validation."""
+
+    def test_rec_in_window_pass(self):
+        """REC 60min / 36 TSS → IF 0.60 ∈ [0.55-0.65]."""
+        check = validate_intensity_coherence("REC", tss=36, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+
+    def test_end_in_window_pass(self):
+        """END 120min / 98 TSS → IF 0.70 ∈ [0.65-0.75]."""
+        check = validate_intensity_coherence("END", tss=98, duration_minutes=120)
+        assert check.result == ValidationResult.PASS
+
+    def test_tmp_in_window_pass(self):
+        """TMP 60min / 64 TSS → IF 0.80 ∈ [0.75-0.85]."""
+        check = validate_intensity_coherence("TMP", tss=64, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+
+    def test_ss_in_window_pass(self):
+        """SS 60min / 81 TSS → IF 0.90 ∈ [0.85-0.94]."""
+        check = validate_intensity_coherence("SS", tss=81, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+
+    def test_ftp_in_window_pass(self):
+        """FTP 60min / 100 TSS → IF 1.00 ∈ [0.95-1.04]."""
+        check = validate_intensity_coherence("FTP", tss=100, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+
+    def test_vo2_in_window_pass(self):
+        """VO2 30min / 60 TSS → IF ≈ 1.095 ∈ [1.05-1.14]."""
+        check = validate_intensity_coherence("VO2", tss=60, duration_minutes=30)
+        assert check.result == ValidationResult.PASS
+
+    def test_s094_01_rec_to_ss_fail(self):
+        """Régression S094-01 : REC 15min / 18 TSS → IF 0.85 = zone SS → FAIL."""
+        check = validate_intensity_coherence("REC", tss=18, duration_minutes=15)
+        assert check.result == ValidationResult.FAIL
+        assert check.severity == "critical"
+        assert "SS" in check.message
+
+    def test_s094_05_rec_to_ftp_fail(self):
+        """Régression S094-05 : REC 10min / 16 TSS → IF 0.98 = zone FTP → FAIL."""
+        check = validate_intensity_coherence("REC", tss=16, duration_minutes=10)
+        assert check.result == ValidationResult.FAIL
+        assert check.severity == "critical"
+        assert "FTP" in check.message
+
+    def test_vo2_too_high_no_zone_match_fail(self):
+        """VO2 60min / 169 TSS → IF ≈ 1.30 hors window, pas dans autre zone → FAIL."""
+        check = validate_intensity_coherence("VO2", tss=169, duration_minutes=60)
+        assert check.result == ValidationResult.FAIL
+        assert check.severity == "critical"
+
+    def test_rec_just_below_window_warning(self):
+        """REC 60min / 26 TSS → IF ≈ 0.510, écart 0.04 < tolérance 0.05, no zone match → WARNING."""
+        check = validate_intensity_coherence("REC", tss=26, duration_minutes=60)
+        assert check.result == ValidationResult.WARNING
+        assert check.severity == "warning"
+
+    def test_vo2_just_above_window_warning(self):
+        """VO2 60min / 134 TSS → IF ≈ 1.158, écart 0.018 < tolérance 0.05, no zone match → WARNING."""
+        check = validate_intensity_coherence("VO2", tss=134, duration_minutes=60)
+        assert check.result == ValidationResult.WARNING
+
+    def test_adjacent_zone_drift_warning(self):
+        """END 60min / 65 TSS → IF ≈ 0.806 dans zone TMP adjacente → WARNING (pas FAIL).
+
+        Drift d'une seule zone (rank distance = 1) accepté en WARNING : sync continue,
+        on flagge mais on ne bloque pas. Évite de rejeter des sessions END légèrement
+        teintées de Tempo ou Recovery.
+        """
+        check = validate_intensity_coherence("END", tss=65, duration_minutes=60)
+        assert check.result == ValidationResult.WARNING
+        assert "TMP" in check.message
+        assert "adjacente" in check.message
+
+    def test_end_just_below_window_to_rec_warning(self):
+        """END 90min / 55 TSS → IF ≈ 0.605 dans REC adjacente → WARNING.
+
+        Cas test_session_ids_filter (fixture historique) : la séance END légère
+        ne doit pas être bloquée, juste flaggée.
+        """
+        check = validate_intensity_coherence("END", tss=55, duration_minutes=90)
+        assert check.result == ValidationResult.WARNING
+        assert "REC" in check.message
+
+    def test_distant_zone_drift_fail(self):
+        """REC déclaré + IF tombant 2+ zones plus haut → FAIL (cas S094-01/05)."""
+        check = validate_intensity_coherence("REC", tss=18, duration_minutes=15)
+        assert check.result == ValidationResult.FAIL
+
+    def test_int_skip_validation(self):
+        check = validate_intensity_coherence("INT", tss=18, duration_minutes=15)
+        assert check.result == ValidationResult.PASS
+        assert "non-applicable" in check.message
+
+    def test_race_skip_validation(self):
+        check = validate_intensity_coherence("RACE", tss=200, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+
+    def test_mix_skip_validation(self):
+        check = validate_intensity_coherence("MIX", tss=100, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+
+    def test_unknown_type_skip_validation(self):
+        check = validate_intensity_coherence("XYZ", tss=100, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+        assert "pas de window IF référence" in check.message
+
+    def test_zero_tss_skip(self):
+        check = validate_intensity_coherence("REC", tss=0, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+        assert "non-calculable" in check.message
+
+    def test_zero_duration_skip(self):
+        check = validate_intensity_coherence("REC", tss=36, duration_minutes=0)
+        assert check.result == ValidationResult.PASS
+
+    def test_clm_aliases_to_ftp_window_pass(self):
+        check = validate_intensity_coherence("CLM", tss=100, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
+
+    def test_tt_aliases_to_ftp_window_pass(self):
+        check = validate_intensity_coherence("TT", tss=100, duration_minutes=60)
+        assert check.result == ValidationResult.PASS
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Contexte

Brief Coach AI V3 du 2026-05-17, Section K (P1) : weekly-planner LLM a généré pour S094 des sessions avec couples `(type, TSS, durée)` physiologiquement incohérents :

- **S094-01** : `type=REC, TSS=18, durée=15min` → IF calculé ≈ **0.85** (zone Sweet-Spot)
- **S094-05** : `type=REC, TSS=16, durée=10min` → IF calculé ≈ **0.98** (zone FTP)

Aucun validateur post-génération ne vérifiait la cohérence `type ↔ paramètres` ; le pipeline `sync-week-to-calendar` poussait ces sessions sur Intervals.icu sans alerte.

## Solution

Ajout d'une étape de validation défensive dans `handle_sync_week_to_calendar` (juste avant la validation format Intervals existante) :

1. Recompute l'IF depuis `(tss_planned, duration_min)` via la formule TrainingPeaks inversée : `IF = sqrt(TSS × 3600 / (durée_sec × 100))`
2. Compare au window Coggan pour le `session_type` déclaré
3. Verdict en 3 paliers :

| Verdict | Critère | Action sync |
|---|---|---|
| **PASS** | IF dans window OU type multi-bloc/ad-hoc (INT, RACE, TEC, MIX, SPR) | Continue |
| **WARNING** | IF dans zone adjacente (rank distance = 1) — ex: END drift vers TMP ou REC | Continue + flag dans `warnings[]` |
| **FAIL** | IF dans zone distante (rank distance ≥ 2) — ex: REC → SS/FTP | Rejet : `errors.append(...)` + `continue` |

Jour de repos (`REC + TSS=0 + duration=0`) bypass par design.

## Windows IF utilisés (réf. Coggan / TrainingPeaks)

| Type magma | Window IF |
|---|---|
| REC | 0.55–0.65 |
| END | 0.65–0.75 |
| TMP | 0.75–0.85 |
| SS | 0.85–0.94 |
| FTP / CLM / TT | 0.95–1.04 |
| VO2 | 1.05–1.14 |

Types skip-validation (multi-bloc / ad-hoc) : **INT, RACE, TEC, MIX, SPR**.

## Tests

- **22 tests unitaires** ajoutés sur `validate_intensity_coherence()` et `compute_intensity_factor()` — couvre régression S094-01/05, chaque zone PASS, drift adjacent (WARNING), drift distant (FAIL), types skip, valeurs nulles
- **3 tests intégration** ajoutés sur `handle_sync_week_to_calendar` :
  - `test_rec_with_high_if_rejected_with_error` (régression S094-01)
  - `test_coherent_session_passes_validation`
  - `test_rest_day_bypass_coherence_check`
- Suite complète : **3814 passed, 5 skipped**

## Effet sur Coach AI

Coach AI ne pourra plus pousser sur Intervals des sessions avec couple `(TSS, durée)` physiologiquement absurde sans corriger d'abord (`session_type`, `tss_planned`, ou `duration_min`). Le message d'erreur retourné par le handler est actionnable.

## Files

- `magma_cycling/planning/workout_validation.py` (+152) — fonctions + constantes
- `magma_cycling/_mcp/handlers/remote_sync.py` (+27) — branchement pipeline
- `tests/planning/test_workout_validation.py` (+155) — tests unitaires
- `tests/_mcp/handlers/test_remote_sync.py` (+98) — tests intégration

## Follow-up optionnel

`validate_workout()` (API Peaks 11.2) prend `intensity_zone` au format string long ("Sweet-Spot") tandis que `session_type` magma est court ("SS"). Si on veut étendre `validate_workout()` avec un Check 8 cohérence IF/type, il faudra ajouter un mapping d'aliases. Hors scope de ce fix.