### PR TITLE
fix(intervals): O - bubble up create_event errors to MCP response

### DIFF
--- a/magma_cycling/_mcp/handlers/remote_events.py
+++ b/magma_cycling/_mcp/handlers/remote_events.py
@@ -397,9 +397,22 @@ async def handle_create_remote_note(args: dict) -> list[TextContent]:
                     "message": f"✅ NOTE created successfully on Intervals.icu (ID: {created_event['id']}){local_update_msg}",
                 }
             else:
+                err = getattr(client, "last_error", None) or {}
+                detail = err.get("message") or "unknown error"
+                status_code = err.get("status_code")
+                body = err.get("body")
+                message_parts = ["❌ Failed to create NOTE on Intervals.icu — ", detail]
+                if status_code is not None:
+                    message_parts.append(f" (HTTP {status_code})")
+                if body:
+                    body_preview = str(body)[:200]
+                    message_parts.append(f" — body: {body_preview}")
                 result = {
                     "success": False,
-                    "message": "❌ Failed to create NOTE - no ID returned from Intervals.icu",
+                    "message": "".join(message_parts),
+                    "error_detail": err,
+                    "date": note_date,
+                    "name": name,
                 }
 
         return mcp_response(result, provider_info=_provider_info)

--- a/magma_cycling/_mcp/handlers/remote_sync.py
+++ b/magma_cycling/_mcp/handlers/remote_sync.py
@@ -252,10 +252,16 @@ async def handle_sync_week_to_calendar(args: dict) -> list[TextContent]:
                         created = client.create_event(item["event_data"])
 
                         if created is None:
-                            errors.append(
-                                f"Failed to create {item['session_id']}: API returned None "
-                                f"(check logs for HTTP errors)"
-                            )
+                            err = getattr(client, "last_error", None) or {}
+                            detail = err.get("message") or "API returned None"
+                            status_code = err.get("status_code")
+                            body = err.get("body")
+                            parts = [f"Failed to create {item['session_id']}: {detail}"]
+                            if status_code is not None:
+                                parts.append(f" (HTTP {status_code})")
+                            if body:
+                                parts.append(f" — body: {str(body)[:200]}")
+                            errors.append("".join(parts))
                         elif "id" not in created:
                             errors.append(
                                 f"Failed to create {item['session_id']}: Response missing 'id' field. "

--- a/magma_cycling/api/intervals_client.py
+++ b/magma_cycling/api/intervals_client.py
@@ -87,6 +87,7 @@ class IntervalsClient:
         self.session = requests.Session()
         self.session.auth = ("API_KEY", api_key)
         self.session.headers.update({"Content-Type": "application/json"})
+        self.last_error: dict[str, Any] | None = None
 
     def get_athlete(self) -> dict[str, Any]:
         """
@@ -459,6 +460,7 @@ class IntervalsClient:
             >>> if created:
             ...     print(f"Created event ID: {created.get('id')}")
         """
+        self.last_error = None
         try:
             url = f"{self.BASE_URL}/athlete/{self.athlete_id}/events"
             response = self.session.post(url, json=event_data)
@@ -469,17 +471,33 @@ class IntervalsClient:
             return created_event
 
         except requests.exceptions.HTTPError as e:
-            logger.error(f"HTTP error creating event: {e}")
+            status_code = e.response.status_code if e.response is not None else None
+            body: Any = None
             if e.response is not None:
                 try:
-                    error_detail = _safe_json(e.response)
-                    logger.error(f"Error detail: {error_detail}")
+                    body = _safe_json(e.response)
                 except Exception:
-                    logger.error(f"Response: {_safe_text(e.response)}")
+                    body = _safe_text(e.response)
+            self.last_error = {
+                "type": "http_error",
+                "status_code": status_code,
+                "body": body,
+                "message": str(e),
+                "event_data": event_data,
+            }
+            logger.error(f"HTTP error creating event: {e}")
+            if body is not None:
+                logger.error(f"Error detail: {body}")
             logger.error(f"Event data: {event_data}")
             return None
 
         except Exception as e:
+            self.last_error = {
+                "type": "exception",
+                "exception_class": type(e).__name__,
+                "message": str(e),
+                "event_data": event_data,
+            }
             logger.error(f"Error creating event: {e}")
             logger.error(f"Event data: {event_data}")
             return None

--- a/tests/_mcp/handlers/test_remote_events.py
+++ b/tests/_mcp/handlers/test_remote_events.py
@@ -393,6 +393,7 @@ class TestHandleCreateRemoteNote:
         client = MagicMock()
         client.get_provider_info.return_value = MOCK_PROVIDER_INFO
         client.create_event.return_value = {}  # no 'id' key
+        client.last_error = None
         mock_factory.return_value = client
 
         with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
@@ -557,3 +558,126 @@ class TestHandleCreateRemoteNote:
         plan = json.loads(plan_path.read_text(encoding="utf-8"))
         s01 = next(s for s in plan["planned_sessions"] if s["session_id"] == "S999-01")
         assert s01["status"] == "uploaded"
+
+
+class TestHandleCreateRemoteNoteErrorBubbleUp:
+    """Section O regression: surface Intervals.icu HTTP errors in MCP response.
+
+    Before fix: `create_event` returned None silently on HTTP error and the
+    handler responded with a generic 'Failed to create NOTE - no ID returned'
+    message — leaving Coach AI / Claude Desktop with 'Tool execution failed'
+    and no actionable detail. After fix: `client.last_error` carries
+    {status_code, body, message} and the handler propagates it.
+    """
+
+    _PAYLOADS = [
+        {
+            "date": "2026-05-20",
+            "name": "Test Coaching avec accents é à",
+            "description": "Boire 1L+, IF cible 0.70, plan B en cas pluie",
+        },
+        {
+            "date": "2026-05-20",
+            "name": "Test Coaching sans accents",
+            "description": "Boire eau, IF cible 0.70",
+        },
+        {
+            "date": "2026-05-20",
+            "name": "Test minimal",
+            "description": "Test",
+        },
+    ]
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_http_400_surfaces_status_and_body(self, mock_factory):
+        """HTTP 400 from Intervals.icu must produce an actionable MCP message."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = None
+        client.last_error = {
+            "type": "http_error",
+            "status_code": 400,
+            "body": {"error": "Invalid start_date_local format"},
+            "message": "400 Bad Request",
+            "event_data": self._PAYLOADS[0],
+        }
+        mock_factory.return_value = client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+            result = await handle_create_remote_note(self._PAYLOADS[0])
+
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert "HTTP 400" in data["message"]
+        assert "Invalid start_date_local format" in data["message"]
+        assert data["error_detail"]["status_code"] == 400
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_http_401_surfaces_auth_error(self, mock_factory):
+        """HTTP 401 (auth fail) propagated with status code."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = None
+        client.last_error = {
+            "type": "http_error",
+            "status_code": 401,
+            "body": "Unauthorized",
+            "message": "401 Unauthorized",
+            "event_data": self._PAYLOADS[1],
+        }
+        mock_factory.return_value = client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+            result = await handle_create_remote_note(self._PAYLOADS[1])
+
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert "HTTP 401" in data["message"]
+        assert data["error_detail"]["status_code"] == 401
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_http_404_minimal_payload(self, mock_factory):
+        """Minimal payload + HTTP 404 still surfaces error detail."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = None
+        client.last_error = {
+            "type": "http_error",
+            "status_code": 404,
+            "body": {"error": "Not found"},
+            "message": "404 Not Found",
+            "event_data": self._PAYLOADS[2],
+        }
+        mock_factory.return_value = client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+            result = await handle_create_remote_note(self._PAYLOADS[2])
+
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert "HTTP 404" in data["message"]
+        assert data["error_detail"]["status_code"] == 404
+
+    @pytest.mark.asyncio
+    @patch("magma_cycling.config.create_intervals_client")
+    async def test_no_last_error_falls_back_to_unknown(self, mock_factory):
+        """If client has no last_error (legacy path), fallback to 'unknown error'."""
+        client = MagicMock()
+        client.get_provider_info.return_value = MOCK_PROVIDER_INFO
+        client.create_event.return_value = None
+        client.last_error = None
+        mock_factory.return_value = client
+
+        with patch("magma_cycling.planning.control_tower.planning_tower") as mock_tower:
+            mock_tower.planning_dir.exists.return_value = False
+            result = await handle_create_remote_note(self._PAYLOADS[0])
+
+        data = json.loads(result[0].text)
+        assert data["success"] is False
+        assert "unknown error" in data["message"]

--- a/tests/api/test_intervals_client.py
+++ b/tests/api/test_intervals_client.py
@@ -273,6 +273,60 @@ class TestCreateEvent:
 
         assert result is None
 
+    def test_create_event_http_error_populates_last_error(self, client, mock_session):
+        """HTTP error must populate client.last_error with status_code + body + message."""
+        import requests
+
+        err_response = Mock()
+        err_response.status_code = 400
+        err_response.json.return_value = {"error": "Invalid date format"}
+        err_response.text = '{"error": "Invalid date format"}'
+
+        mock_response = Mock()
+        http_err = requests.exceptions.HTTPError("400 Bad Request")
+        http_err.response = err_response
+        mock_response.raise_for_status.side_effect = http_err
+        mock_session.post.return_value = mock_response
+
+        event_data = {"category": "NOTE", "name": "Test", "description": "Test"}
+
+        result = client.create_event(event_data)
+
+        assert result is None
+        assert client.last_error is not None
+        assert client.last_error["type"] == "http_error"
+        assert client.last_error["status_code"] == 400
+        assert client.last_error["body"] == {"error": "Invalid date format"}
+        assert "400 Bad Request" in client.last_error["message"]
+        assert client.last_error["event_data"] == event_data
+
+    def test_create_event_generic_error_populates_last_error(self, client, mock_session):
+        """Generic exception must populate client.last_error with exception_class + message."""
+        mock_session.post.side_effect = ValueError("Bad payload")
+
+        event_data = {"category": "NOTE", "name": "Test", "description": "Test"}
+
+        result = client.create_event(event_data)
+
+        assert result is None
+        assert client.last_error is not None
+        assert client.last_error["type"] == "exception"
+        assert client.last_error["exception_class"] == "ValueError"
+        assert client.last_error["message"] == "Bad payload"
+
+    def test_create_event_success_resets_last_error(self, client, mock_session):
+        """Successful create_event must reset last_error from any previous failure."""
+        client.last_error = {"type": "http_error", "status_code": 500}
+
+        mock_response = Mock()
+        mock_response.json.return_value = {"id": 42}
+        mock_session.post.return_value = mock_response
+
+        result = client.create_event({"category": "NOTE", "name": "OK", "description": "OK"})
+
+        assert result == {"id": 42}
+        assert client.last_error is None
+
 
 class TestErrorHandling:
     """Tests for error handling across all methods."""


### PR DESCRIPTION
## Contexte

Brief Coach AI 2026-05-19, Section O reformulée (P1) : le tool MCP \`create-remote-note\` a fail \"Tool execution failed\" 3x sans détails hier 18/05 ~21h, sur 3 payloads variés (accents, ASCII simple, minimal).

TNR Junior (analyse statique 30min) a isolé la cause racine probable :

1. **Intervals.icu retourne probablement 4xx** sur le payload (format date, auth, ou autre — à valider en repro empirique)
2. **\`suppress_stdout_stderr()\`** (`_utils.py:14-25`) wrappe le handler et **avale tous les \`logger.error(...)\`** — les détails techniques de l'HTTP error partent dans /dev/null
3. \`create_event\` retourne \`None\` silencieusement, sans canal d'information vers le caller
4. Handler renvoie \`{success: False, message: \"❌ Failed to create NOTE - no ID returned from Intervals.icu\"}\` (générique)
5. Coach AI résume en \"Tool execution failed\", aucune trace pour débugger

## Solution

Pattern \`last_error\` sur l'instance client, **backward-compatible** :

- \`IntervalsClient.create_event\` stocke un dict structuré sur \`self.last_error\` quand une exception survient (HTTP ou autre)
- Signature de retour inchangée : \`None\` en cas d'échec → tous les callers existants continuent de fonctionner
- Reset à \`None\` à chaque appel success

\`\`\`python
client.last_error = {
    \"type\": \"http_error\",
    \"status_code\": 400,
    \"body\": {\"error\": \"...\"},
    \"message\": \"400 Bad Request\",
    \"event_data\": {...},
}
\`\`\`

## Propagation

| Handler | Avant | Après |
|---|---|---|
| \`handle_create_remote_note\` | \`\"❌ Failed to create NOTE - no ID returned\"\` | \`\"❌ Failed to create NOTE on Intervals.icu — 400 Bad Request (HTTP 400) — body: {\\\"error\\\": \\\"Invalid start_date_local format\\\"}\"\` + \`error_detail\` dict complet |
| \`handle_sync_week_to_calendar\` | \`\"Failed to create S094-01: API returned None (check logs for HTTP errors)\"\` | \`\"Failed to create S094-01: 400 Bad Request (HTTP 400) — body: ...\"\` |

## Indépendant de la cause racine

Le fix est **défensif** : peu importe que la cause racine soit le format \`start_date_local\`, un bug auth, un timeout, ou un endpoint Intervals.icu changé — Coach AI / l'utilisateur verra désormais un message d'erreur exploitable. Les futures itérations de debug seront ~10x plus rapides.

## Tests

- **3 unit tests** sur \`IntervalsClient.create_event\` : HTTP error populates last_error, generic exception populates last_error, success resets last_error
- **4 integration tests** sur \`handle_create_remote_note\` couvrant HTTP **400/401/404** + fallback quand \`last_error\` est absent
- **3 payloads originels** de Coach AI (avec accents, sans accents, minimal) injectés dans \`TestHandleCreateRemoteNoteErrorBubbleUp._PAYLOADS\` comme régression structurelle
- Suite complète : **3831 passed, 5 skipped**

## Files

- \`magma_cycling/api/intervals_client.py\` (+26/-1) — \`last_error\` field, error capture
- \`magma_cycling/_mcp/handlers/remote_events.py\` (+15/-1) — propagation dans \`create_remote_note\`
- \`magma_cycling/_mcp/handlers/remote_sync.py\` (+10/-2) — propagation dans \`sync_week_to_calendar\`
- \`tests/api/test_intervals_client.py\` (+54)
- \`tests/_mcp/handlers/test_remote_events.py\` (+124)

## Suite

- Junior continue son ping Admin pour la **repro empirique** côté preprod (logs MCP server NAS). Une fois le 4xx exact connu, on pourra closer la cause racine. Mais l'observabilité est désormais en place quoi qu'il arrive.