### PR TITLE
feat(prompt): L - inject training phase recommendation into athlete profile

### DIFF
--- a/magma_cycling/prompts/prompt_builder.py
+++ b/magma_cycling/prompts/prompt_builder.py
@@ -34,6 +34,8 @@ def load_current_metrics() -> dict:
         profile = AthleteProfile.from_env()
         metrics["ftp"] = profile.ftp
         metrics["weight"] = profile.weight
+        metrics["ftp_target"] = profile.ftp_target
+        metrics["athlete_age"] = profile.age
     except Exception:
         logger.debug("Could not load AthleteProfile, skipping FTP/weight")
 
@@ -294,6 +296,49 @@ def format_athlete_profile(context: dict, metrics: dict) -> str:
         consec = metrics.get("consecutive_training_days")
         if consec and consec >= 2:
             lines.append(f"  - Jours consecutifs: {consec}")
+
+    ctl_for_phase = metrics.get("ctl")
+    ftp_for_phase = metrics.get("ftp")
+    ftp_target_for_phase = metrics.get("ftp_target")
+    athlete_age_for_phase = metrics.get("athlete_age", 54)
+    if (
+        ctl_for_phase is not None
+        and ftp_for_phase
+        and ftp_target_for_phase
+        and ftp_target_for_phase > 0
+    ):
+        try:
+            from magma_cycling.planning.peaks_phases import (
+                TrainingPhase,
+                determine_training_phase,
+            )
+
+            phase_rec = determine_training_phase(
+                ctl_current=float(ctl_for_phase),
+                ftp_current=int(ftp_for_phase),
+                ftp_target=int(ftp_target_for_phase),
+                athlete_age=int(athlete_age_for_phase),
+            )
+            phase_labels = {
+                TrainingPhase.RECONSTRUCTION_BASE: "RECONSTRUCTION_BASE",
+                TrainingPhase.CONSOLIDATION: "CONSOLIDATION",
+                TrainingPhase.DEVELOPMENT_FTP: "DEVELOPMENT_FTP",
+            }
+            lines.append("")
+            lines.append("Phase entrainement (Peaks methodology):")
+            lines.append(f"  - Phase: {phase_labels.get(phase_rec.phase, phase_rec.phase.value)}")
+            lines.append(
+                f"  - CTL cible: {phase_rec.ctl_target:.0f} "
+                f"(deficit {phase_rec.ctl_deficit:.0f})"
+            )
+            if phase_rec.weeks_to_rebuild > 0:
+                lines.append(f"  - Semaines pour rebuild: {phase_rec.weeks_to_rebuild}")
+            lines.append(f"  - TSS hebdo cible (charge): {phase_rec.weekly_tss_load}")
+            lines.append(f"  - TSS hebdo (recup): {phase_rec.weekly_tss_recovery}")
+            lines.append(f"  - Frequence semaine recup: 1 sur {phase_rec.recovery_week_frequency}")
+            lines.append(f"  - Rationale: {phase_rec.rationale}")
+        except Exception:
+            logger.debug("Could not compute training phase recommendation")
 
     # Blood pressure (cardiovascular recovery marker)
     sys_bp = metrics.get("systolic")

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1185,3 +1185,109 @@ class TestRecoveryDirectivesInProfile:
         assert "REPOS OBLIGATOIRE" in result
         assert "Alterner" in result
         assert "reduire TSS" in result
+
+
+class TestTrainingPhaseInjection:
+    """Tests for Section L: training phase recommendation injection.
+
+    Coach AI receives the training phase (RECONSTRUCTION_BASE / CONSOLIDATION
+    / DEVELOPMENT_FTP) at the same time as the raw ACWR / CTL / ATL metrics,
+    so it can weight ACWR interpretation by the cycle position instead of
+    applying a static 0.8-1.3 sweet-spot regardless of phase.
+    """
+
+    def test_phase_block_appears_with_full_context(self):
+        """ctl + ftp + ftp_target + age present → phase block injected."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "ftp": 220,
+            "weight": 84.0,
+            "ctl": 42.0,
+            "ftp_target": 260,
+            "athlete_age": 54,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Phase entrainement" in result
+        assert "Phase: RECONSTRUCTION_BASE" in result
+        assert "CTL cible:" in result
+        assert "TSS hebdo cible" in result
+        assert "Rationale:" in result
+
+    def test_phase_skipped_when_ftp_target_absent(self):
+        """No ftp_target → phase block silently skipped."""
+        context = {"name": "Test", "age": 54}
+        metrics = {"ftp": 220, "weight": 84.0, "ctl": 42.0, "athlete_age": 54}
+        result = format_athlete_profile(context, metrics)
+        assert "Phase entrainement" not in result
+
+    def test_phase_skipped_when_ctl_absent(self):
+        """No ctl → phase block silently skipped."""
+        context = {"name": "Test", "age": 54}
+        metrics = {"ftp": 220, "weight": 84.0, "ftp_target": 260, "athlete_age": 54}
+        result = format_athlete_profile(context, metrics)
+        assert "Phase entrainement" not in result
+
+    def test_phase_skipped_when_ftp_absent(self):
+        """No ftp → phase block silently skipped."""
+        context = {"name": "Test", "age": 54}
+        metrics = {"ctl": 42.0, "ftp_target": 260, "athlete_age": 54}
+        result = format_athlete_profile(context, metrics)
+        assert "Phase entrainement" not in result
+
+    def test_consolidation_phase_label(self):
+        """CTL in [0.85*target, target) → CONSOLIDATION."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "ftp": 260,
+            "weight": 84.0,
+            "ctl": 75.0,
+            "ftp_target": 260,
+            "athlete_age": 54,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Phase: CONSOLIDATION" in result
+
+    def test_development_ftp_phase_label(self):
+        """CTL >= ctl_target → DEVELOPMENT_FTP.
+
+        Simulates an athlete who reached/exceeded an earlier ftp_target: current
+        ftp 260 > ftp_target 220, ctl 80 above calculated ctl_target ~77.85.
+        """
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "ftp": 260,
+            "weight": 84.0,
+            "ctl": 80.0,
+            "ftp_target": 220,
+            "athlete_age": 54,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Phase: DEVELOPMENT_FTP" in result
+
+    def test_phase_block_appears_outside_overtraining_risk_block(self):
+        """Phase block must appear even without overtraining_risk set (independent indicator)."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "ftp": 220,
+            "weight": 84.0,
+            "ctl": 42.0,
+            "ftp_target": 260,
+            "athlete_age": 54,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "Indicateurs de charge" not in result
+        assert "Phase entrainement" in result
+
+    def test_phase_rationale_mentions_ctl_values(self):
+        """Rationale string contains CTL current and target for context."""
+        context = {"name": "Test", "age": 54}
+        metrics = {
+            "ftp": 220,
+            "weight": 84.0,
+            "ctl": 42.0,
+            "ftp_target": 260,
+            "athlete_age": 54,
+        }
+        result = format_athlete_profile(context, metrics)
+        assert "42" in result
+        assert "reconstruction base" in result.lower()


### PR DESCRIPTION
## Contexte

Brief Coach AI 2026-05-18, Section L (P2) : l'ACWR devient mathématiquement biaisé en phase reconstruction quand la CTL chute (CTL < 85% du target). L'interprétation statique 0.8-1.3 sweet-spot par Coach AI génère des faux positifs systématiques : toute reprise prudente fait remonter l'ACWR au-dessus du seuil sans vraie surcharge.

**Cas observé S093** : ACWR 1.90 sur TSS hebdo 345 (cohérent pour un athlète CTL 50+ en routine, mais bloquant en reconstruction). Coach AI a recommandé S094 à 270 TSS (-22%) sur la base ACWR, alors que la philosophie reconstruction demande +5-10% (370-380 TSS).

## Diagnostic Leader

`magma_cycling/utils/training_load.py` calcule l'ACWR brut correctement (formule Gabbett). `prompt_builder.py:272-281` l'injecte brut (sans seuils sémantiques) dans le prompt LLM, par doctrine « Claude reste seul décisionnaire » établie après faux positifs récurrents.

**Le gap** : le module `magma_cycling/planning/peaks_phases.py` calcule déjà la phase d'entraînement (RECONSTRUCTION_BASE / CONSOLIDATION / DEVELOPMENT_FTP) via `determine_training_phase(ctl, ftp_current, ftp_target, athlete_age)`, et l'émet déjà dans le **daily report** (`workflows/sync/ctl_peaks.py` + `workflows/pid_eval/test_opportunity.py`). Mais cette phase **n'arrivait pas dans le prompt LLM weekly-planner**, laissant Coach AI interpréter l'ACWR aveugle au contexte cycle.

## Solution (option A, validée par Stéphane 21/05)

Injection conditionnelle d'un bloc "Phase entrainement" dans `format_athlete_profile()` :

```
Phase entrainement (Peaks methodology):
  - Phase: RECONSTRUCTION_BASE
  - CTL cible: 70 (deficit 28)
  - Semaines pour rebuild: 11
  - TSS hebdo cible (charge): 350
  - TSS hebdo (recup): 250
  - Frequence semaine recup: 1 sur 2
  - Rationale: CTL critique (42.0 < 85% de 70). Phase reconstruction base prioritaire...
```

Déclenché quand `ctl + ftp + ftp_target` tous présents. Skip silencieux sinon. `load_current_metrics()` charge maintenant aussi `ftp_target` et `athlete_age` depuis `AthleteProfile.from_env()`.

## Pourquoi pas une violation de la doctrine ?

Le commentaire historique (PR4bis) explicite que les **seuils sémantiques** pré-mâchés sur ACWR ("DANGER", "optimal", "ALERTE") généraient des faux positifs et ont été retirés. La doctrine = magma fournit valeurs brutes, Coach AI arbitre interprétation.

Ce PR injecte de l'**info contextuelle** (où en est l'athlète dans le cycle), pas une interprétation pré-mâchée de l'ACWR. Le Coach AI garde la responsabilité de croiser ACWR brut + phase + rationale pour décider. Pattern identique au daily report qui injecte déjà phase + rationale sans pré-mâcher les recommandations.

## Tests

- **8 tests unitaires** ajoutés sur `TestTrainingPhaseInjection` :
  - Injection full-context (toutes les fields PhaseRecommendation présentes)
  - Skip silencieux quand `ftp_target` / `ctl` / `ftp` absent
  - Les 3 labels phase (RECONSTRUCTION_BASE / CONSOLIDATION / DEVELOPMENT_FTP)
  - Visibilité du bloc hors du bloc `overtraining_risk` (indicateur indépendant)
  - Rationale content (CTL values + phase label)
- Suite complète : **3839 passed, 5 skipped**

## Files

- `magma_cycling/prompts/prompt_builder.py` (+45) — `load_current_metrics()` enrichi + bloc phase dans `format_athlete_profile()`
- `tests/test_prompt_builder.py` (+106) — `TestTrainingPhaseInjection` (8 tests)