### PR TITLE
fix(validator): M - scope interval format check to workout sections only

### DIFF
--- a/magma_cycling/intervals_format_validator.py
+++ b/magma_cycling/intervals_format_validator.py
@@ -172,12 +172,30 @@ class IntervalsFormatValidator:
 
         Format attendu: "- [durée] [intensité] [cadence]"
         Exemples: "- 10m 90% 85rpm", "- 5m ramp 50-65%"
+
+        Limite la validation aux sections workout structurées
+        (Warmup / Main set / Cooldown / Block). Les lignes commençant par "-"
+        dans des sections de prose (Notes execution, Plan B, Itinéraire,
+        Hydratation, etc.) sont ignorées — la mention d'une durée libre
+        type "30min" ou "90min" dans ces sections est légitime et ne doit
+        pas déclencher une erreur de format Intervals.icu.
         """
+        in_workout_section = True
+
         for i, line in enumerate(lines):
             stripped = line.strip()
 
-            # Ignorer lignes vides et sections
-            if not stripped or not stripped.startswith("-"):
+            if not stripped:
+                continue
+
+            if not stripped.startswith("-"):
+                if self.SECTION_TITLE_PATTERN.match(stripped):
+                    in_workout_section = True
+                else:
+                    in_workout_section = False
+                continue
+
+            if not in_workout_section:
                 continue
 
             # Vérifier suffixes de durée invalides (min, sec, hr, etc.)

--- a/tests/test_intervals_format_validator.py
+++ b/tests/test_intervals_format_validator.py
@@ -154,3 +154,104 @@ class TestWarmupCooldownMonoBloc:
         )
         fixed = v.fix_warmup_cooldown(workout)
         assert "- 15m 65% 85rpm" in fixed
+
+
+class TestNotesSectionFiltering:
+    """Section M regression: skip validation in non-workout sections.
+
+    Before fix: any line starting with "-" was validated for duration
+    suffix, even if it lived in a "Notes execution", "Plan B",
+    "Hydratation" etc. section — producing false-positive errors like
+    "Ligne 16: Durée invalide '90min'" when "1L+ pour 90min" was a
+    legitimate coaching note. After fix: only lines under
+    Warmup/Main set/Cooldown/Block are validated; lines under other
+    section titles are ignored.
+    """
+
+    def test_s094_02_intro_30min_in_notes_no_error(self):
+        """S094-02 regression: '30min' mentioned in notes section under non-workout title."""
+        validator = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 10m ramp 50-75% 85rpm\n"
+            "\nMain set\n- 30m 75%\n"
+            "\nCooldown\n- 10m ramp 75-50% 85rpm\n"
+            "\nNotes execution\n- Tempo progressif sur 30min puis relax\n"
+        )
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert is_valid, f"unexpected errors: {errors}"
+
+    def test_s094_04_plan_b_45min_in_notes_no_error(self):
+        """S094-04 regression: 'Plan B 45min' in notes must not fail validation."""
+        validator = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 10m ramp 50-75% 85rpm\n"
+            "\nMain set\n- 75m 70%\n"
+            "\nCooldown\n- 10m ramp 75-50% 85rpm\n"
+            "\nPlan B\n- Si pluie: indoor 45min Z2\n"
+        )
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert is_valid, f"unexpected errors: {errors}"
+
+    def test_s094_06_hydration_90min_in_notes_no_error(self):
+        """S094-06 regression: '90min' in hydration note must not fail."""
+        validator = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 10m ramp 50-75% 85rpm\n"
+            "\nMain set\n- 70m 70%\n"
+            "\nCooldown\n- 10m ramp 75-50% 85rpm\n"
+            "\nHydratation\n- 1L+ pour 90min effort\n"
+        )
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert is_valid, f"unexpected errors: {errors}"
+
+    def test_invalid_duration_in_workout_section_still_rejected(self):
+        """Anti-false-negative: '30min' in Main set MUST still be flagged."""
+        validator = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 10m ramp 50-75% 85rpm\n"
+            "\nMain set\n- 30min 75%\n"
+            "\nCooldown\n- 10m ramp 75-50% 85rpm\n"
+        )
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert not is_valid
+        assert any("30min" in e for e in errors)
+
+    def test_invalid_duration_in_block_section_still_rejected(self):
+        """Block section also counts as workout section — must validate."""
+        validator = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 10m ramp 50-75% 85rpm\n"
+            "\nBlock 3x\n- 5min 95%\n- 3m 60%\n"
+            "\nCooldown\n- 10m ramp 75-50% 85rpm\n"
+        )
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert not is_valid
+        assert any("5min" in e for e in errors)
+
+    def test_multiple_invalid_durations_in_notes_no_error(self):
+        """Multiple bogus 'Xmin' across several non-workout sections all skipped."""
+        validator = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 10m ramp 50-75% 85rpm\n"
+            "\nMain set\n- 60m 75%\n"
+            "\nCooldown\n- 10m ramp 75-50% 85rpm\n"
+            "\nNotes execution\n- Intro 30min easy\n"
+            "\nPlan B\n- Si météo défavorable, indoor 45min Z2\n"
+            "\nHydratation\n- 1L+ pour 90min effort\n"
+            "\nItinéraire\n- Boucle 75min via Z3\n"
+        )
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert is_valid, f"unexpected errors: {errors}"
+
+    def test_switch_back_to_workout_section_after_notes(self):
+        """Notes → return to Cooldown: validation must resume."""
+        validator = IntervalsFormatValidator()
+        workout = (
+            "Warmup\n- 10m ramp 50-75% 85rpm\n"
+            "\nMain set\n- 60m 75%\n"
+            "\nNotes\n- Garder cadence 90rpm sur 30min\n"
+            "\nCooldown\n- 10min ramp 75-50%\n"
+        )
+        is_valid, errors, _warnings = validator.validate_workout(workout)
+        assert not is_valid
+        assert any("10min" in e for e in errors), f"expected 10min flag, got: {errors}"


### PR DESCRIPTION
## Contexte

Brief Coach AI complément S094 (2026-05-18), Section M (P3) : le `IntervalsFormatValidator` flag des lignes commençant par \"-\" sous des sections de prose (Notes execution, Plan B, Hydratation, Itinéraire) comme des erreurs de format, parce que ces lignes contiennent des mentions de durée libre type \"30min\" / \"75min\" / \"90min\".

**Cas observés** :
- **S094-02** : \"Tempo Progressif (60min, 55 TSS)\" en intro → erreur \"Ligne 16: Durée invalide '30min'\"
- **S094-04** : \"Durée plafond strict 75min\" + \"Plan B 45min\" dans notes → 2 erreurs validation
- **S094-06** : \"1L+ pour 90min\" dans notes hydratation → erreur

**Workaround pratiqué** : reformuler les notes (\"30min\" → \"30 min\") ou supprimer les durées coaching. Perte d'information utile.

## Solution

`_check_interval_format` track maintenant la section courante via la `SECTION_TITLE_PATTERN` déjà existante (`Warmup|Main set|Cooldown|Block`). Une ligne \"-\" n'est validée pour son suffixe de durée que si elle vit sous un titre de section workout. Les lignes \"-\" sous tout autre titre (Notes, Plan B, Hydratation, etc.) sont skip.

**State machine** :
- `in_workout_section = True` au start (présomption d'innocence pour workouts sans titre explicite — reste cohérent avec `_check_minimal_structure` qui flag déjà l'absence d'intervalle valide)
- Titre matching `SECTION_TITLE_PATTERN` → `True`
- Tout autre non-dash, non-vide → `False`
- Switch back à `True` au prochain titre valide

## Tests

7 nouveaux tests `TestNotesSectionFiltering` :
- 3 régression S094-02/04/06
- Anti-faux-négatif : `30min` dans Main set toujours rejeté ✓
- `Block` section aussi validée ✓
- Multi-notes-sections : tout skip ✓
- Transition Notes → Cooldown : validation reprend ✓

Suite complète : **3846 passed, 5 skipped**

## Files

- `magma_cycling/intervals_format_validator.py` (+13/-2) — state machine `in_workout_section`
- `tests/test_intervals_format_validator.py` (+108) — TestNotesSectionFiltering

## Note hors scope

La PR ne touche pas le pattern `SECTION_TITLE_PATTERN` lui-même. Les sections valides restent les 4 historiques (Warmup, Main set, Cooldown, Block). Si on veut un jour reconnaître officiellement les sections \"Notes\" / \"Plan B\" via des patterns, faudra une 2e itération — hors scope ici.