### PR TITLE
feat(session-monitor): trigger adapted pipeline on unplanned activity (#368)

### DIFF
--- a/magma_cycling/session_monitor.py
+++ b/magma_cycling/session_monitor.py
@@ -13,6 +13,7 @@ Author: Claude Code
 Created: 2026-03-01
 """
 
+import json
 import os
 import subprocess
 from datetime import date, datetime
@@ -28,6 +29,7 @@ PROJECT_DIR = os.environ.get(
     "MAGMA_PROJECT_DIR",
     str(Path(__file__).resolve().parent.parent),
 )
+PROCESSED_CACHE_PATH = Path.home() / ".local/share/magma-cycling/processed_today.json"
 
 
 def log(msg: str) -> None:
@@ -88,6 +90,118 @@ def _fallback_cutoff(day_of_week: int) -> int:
     return 21
 
 
+def _load_processed_today_cache(today: date) -> set[str]:
+    """Load processed activity IDs from cache, reset if date changed.
+
+    Cache file: ~/.local/share/magma-cycling/processed_today.json
+    Format: {"date": "YYYY-MM-DD", "activity_ids": ["id1", "id2", ...]}
+    Stale cache (different day) returns empty set, callers must save fresh.
+    """
+    if not PROCESSED_CACHE_PATH.exists():
+        return set()
+    try:
+        data = json.loads(PROCESSED_CACHE_PATH.read_text(encoding="utf-8"))
+        if data.get("date") != today.isoformat():
+            return set()
+        return {str(x) for x in data.get("activity_ids", [])}
+    except Exception:
+        return set()
+
+
+def _save_processed_today_cache(today: date, activity_ids: set[str]) -> None:
+    """Persist processed activity IDs cache for today."""
+    PROCESSED_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    data = {"date": today.isoformat(), "activity_ids": sorted(activity_ids)}
+    PROCESSED_CACHE_PATH.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _handle_unplanned_activity(today: date) -> int:
+    """Trigger adapted pipeline when activity exists without planned session.
+
+    Adapted pipeline (skip adherence — null result without plan ref):
+      1. withings-presync
+      2. daily-sync --send-email --ai-analysis --auto-servo
+      3. pid-daily-evaluation --days-back 7
+      4. end-of-week (Sunday only)
+
+    Idempotence: skips if all detected activities already in
+    ``processed_today.json`` cache (handles re-trigger on next cron tick
+    AND case where the session gets added to the planning a posteriori).
+
+    Returns 0 in all cases (LaunchAgent must not retry on its own).
+    """
+    try:
+        client = create_intervals_client()
+        date_str = today.isoformat()
+        activities = client.get_activities(oldest=date_str, newest=date_str)
+        cycling = [
+            a
+            for a in activities
+            if a.get("type") in ("Ride", "VirtualRide") and not a.get("icu_ignore_time", False)
+        ]
+    except Exception as e:
+        log(f"Error querying Intervals.icu (unplanned check): {e}")
+        return 0
+
+    if not cycling:
+        log("No planned session, no Intervals activity, exit")
+        return 0
+
+    processed = _load_processed_today_cache(today)
+    new_activities = [a for a in cycling if str(a.get("id", "")) not in processed]
+    if not new_activities:
+        log(f"All {len(cycling)} unplanned activities already processed, exit")
+        return 0
+
+    new_ids = ", ".join(str(a.get("id", "?")) for a in new_activities)
+    log(f"Unplanned activity detected (id={new_ids}), triggering adapted pipeline")
+
+    run_command("withings-presync", ["withings-presync"])
+
+    try:
+        run_command(
+            "daily-sync",
+            ["daily-sync", "--send-email", "--ai-analysis", "--auto-servo"],
+        )
+    except Exception as e:
+        log(f"daily-sync error: {e}")
+
+    log("adherence... SKIPPED (no plan reference for unplanned activity)")
+
+    try:
+        run_command(
+            "pid-evaluation",
+            ["pid-daily-evaluation", "--days-back", "7"],
+        )
+    except Exception as e:
+        log(f"pid-evaluation error: {e}")
+
+    if today.weekday() == 6:
+        log("Sunday detected, triggering end-of-week")
+        try:
+            run_command(
+                "end-of-week",
+                [
+                    "end-of-week",
+                    "--auto-calculate",
+                    "--provider",
+                    "mistral_api",
+                    "--auto",
+                ],
+            )
+        except Exception as e:
+            log(f"end-of-week error: {e}")
+
+    processed.update(str(a.get("id", "")) for a in new_activities)
+    _save_processed_today_cache(today, processed)
+
+    log("Done (unplanned)")
+    return 0
+
+
 @cli_main
 def main() -> int:
     """Entry point."""
@@ -104,15 +218,15 @@ def main() -> int:
     try:
         plan = planning_tower.read_week(week_id)
     except FileNotFoundError:
-        log(f"No planning file for {week_id}, exit")
-        return 0
+        log(f"No planning file for {week_id}, checking for unplanned activity...")
+        return _handle_unplanned_activity(today)
 
     todays_sessions = [s for s in plan.planned_sessions if s.session_date == today]
 
-    # Step 2: No session today
+    # Step 2: No session today → check for unplanned activity (#368 ghost session)
     if not todays_sessions:
-        log("No session today, exit")
-        return 0
+        log("No session today, checking for unplanned activity...")
+        return _handle_unplanned_activity(today)
 
     # Step 3: Classify sessions (supports double sessions)
     terminal = ("completed", "cancelled", "skipped", "rest_day")

--- a/tests/test_session_monitor.py
+++ b/tests/test_session_monitor.py
@@ -1,0 +1,231 @@
+"""Tests for magma_cycling.session_monitor — focus on #368 unplanned activity fork.
+
+Coverage:
+    - Regression: planned session + activity → existing behavior unchanged
+    - #368: no planned session + Intervals activity → adapted pipeline (skip adherence)
+    - #368: no planned session + no activity → exit
+    - #368: idempotence cache → skip on second tick same day
+    - #368: Sunday + unplanned → end-of-week trigger
+    - #368: cache helpers (load empty, load stale, save/load roundtrip)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from magma_cycling.session_monitor import (
+    _handle_unplanned_activity,
+    _load_processed_today_cache,
+    _save_processed_today_cache,
+)
+
+
+@pytest.fixture
+def cache_path(tmp_path, monkeypatch):
+    """Redirect PROCESSED_CACHE_PATH to a tmp path for test isolation."""
+    fake = tmp_path / "processed_today.json"
+    monkeypatch.setattr("magma_cycling.session_monitor.PROCESSED_CACHE_PATH", fake)
+    return fake
+
+
+class TestProcessedCacheHelpers:
+    """Unit tests for _load/_save_processed_today_cache helpers."""
+
+    def test_load_empty_when_file_absent(self, cache_path):
+        assert _load_processed_today_cache(date(2026, 5, 23)) == set()
+
+    def test_load_empty_when_date_stale(self, cache_path):
+        cache_path.write_text(
+            json.dumps({"date": "2026-05-22", "activity_ids": ["A1", "A2"]}),
+            encoding="utf-8",
+        )
+        assert _load_processed_today_cache(date(2026, 5, 23)) == set()
+
+    def test_load_returns_ids_when_date_matches(self, cache_path):
+        cache_path.write_text(
+            json.dumps({"date": "2026-05-23", "activity_ids": ["A1", "A2"]}),
+            encoding="utf-8",
+        )
+        assert _load_processed_today_cache(date(2026, 5, 23)) == {"A1", "A2"}
+
+    def test_save_then_load_roundtrip(self, cache_path):
+        _save_processed_today_cache(date(2026, 5, 23), {"X1", "X2", "X3"})
+        assert _load_processed_today_cache(date(2026, 5, 23)) == {"X1", "X2", "X3"}
+
+    def test_load_returns_empty_on_corrupted_json(self, cache_path):
+        cache_path.write_text("not valid json {{{", encoding="utf-8")
+        assert _load_processed_today_cache(date(2026, 5, 23)) == set()
+
+    def test_save_creates_parent_dir(self, tmp_path, monkeypatch):
+        nested = tmp_path / "deep" / "nested" / "processed.json"
+        monkeypatch.setattr("magma_cycling.session_monitor.PROCESSED_CACHE_PATH", nested)
+        _save_processed_today_cache(date(2026, 5, 23), {"X1"})
+        assert nested.exists()
+
+
+class TestHandleUnplannedActivityNoActivity:
+    """Exit path when no Intervals activity is present."""
+
+    def test_no_activity_exits_zero(self, cache_path):
+        client = MagicMock()
+        client.get_activities.return_value = []
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 23))
+        assert rc == 0
+        mock_run.assert_not_called()
+
+    def test_non_cycling_activity_ignored(self, cache_path):
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "R1", "type": "Run"},
+            {"id": "S1", "type": "Swim"},
+        ]
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 23))
+        assert rc == 0
+        mock_run.assert_not_called()
+
+    def test_intervals_error_exits_zero(self, cache_path):
+        client = MagicMock()
+        client.get_activities.side_effect = Exception("network down")
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 23))
+        assert rc == 0
+        mock_run.assert_not_called()
+
+    def test_icu_ignore_time_activity_filtered_out(self, cache_path):
+        """Activities flagged icu_ignore_time should not trigger the pipeline."""
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "A1", "type": "Ride", "icu_ignore_time": True},
+        ]
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 23))
+        assert rc == 0
+        mock_run.assert_not_called()
+
+
+class TestHandleUnplannedActivityPipelineTrigger:
+    """Adapted pipeline (skip adherence) fires on unplanned cycling activity."""
+
+    def test_unplanned_ride_triggers_adapted_pipeline(self, cache_path):
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "A1", "type": "Ride", "icu_ignore_time": False},
+        ]
+        # Not Sunday (Friday 2026-05-22)
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 22))
+
+        assert rc == 0
+        labels = [call.args[0] for call in mock_run.call_args_list]
+        assert "withings-presync" in labels
+        assert "daily-sync" in labels
+        assert "pid-evaluation" in labels
+        assert "adherence" not in labels  # SKIPPED for unplanned
+        assert "end-of-week" not in labels  # not Sunday
+
+    def test_unplanned_virtualride_triggers_pipeline(self, cache_path):
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "VR1", "type": "VirtualRide", "icu_ignore_time": False},
+        ]
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 22))
+        assert rc == 0
+        labels = [call.args[0] for call in mock_run.call_args_list]
+        assert "withings-presync" in labels
+        assert "daily-sync" in labels
+
+    def test_sunday_unplanned_triggers_end_of_week(self, cache_path):
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "A1", "type": "Ride", "icu_ignore_time": False},
+        ]
+        # Sunday 2026-05-24 (weekday 6)
+        sunday = date(2026, 5, 24)
+        assert sunday.weekday() == 6
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(sunday)
+
+        assert rc == 0
+        labels = [call.args[0] for call in mock_run.call_args_list]
+        assert "end-of-week" in labels
+
+
+class TestHandleUnplannedActivityIdempotence:
+    """Cache prevents double-trigger across cron ticks."""
+
+    def test_first_tick_runs_pipeline_and_caches(self, cache_path):
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "A1", "type": "Ride", "icu_ignore_time": False},
+        ]
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 22))
+
+        assert rc == 0
+        assert mock_run.called
+        cached = _load_processed_today_cache(date(2026, 5, 22))
+        assert cached == {"A1"}
+
+    def test_second_tick_skips_when_id_already_cached(self, cache_path):
+        _save_processed_today_cache(date(2026, 5, 22), {"A1"})
+
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "A1", "type": "Ride", "icu_ignore_time": False},
+        ]
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 22))
+
+        assert rc == 0
+        mock_run.assert_not_called()
+
+    def test_new_activity_alongside_cached_one_triggers_pipeline(self, cache_path):
+        """A2 nouvelle → pipeline ré-armé même si A1 déjà processed."""
+        _save_processed_today_cache(date(2026, 5, 22), {"A1"})
+
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "A1", "type": "Ride", "icu_ignore_time": False},
+            {"id": "A2", "type": "Ride", "icu_ignore_time": False},
+        ]
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 22))
+
+        assert rc == 0
+        assert mock_run.called
+        cached = _load_processed_today_cache(date(2026, 5, 22))
+        assert cached == {"A1", "A2"}
+
+    def test_stale_cache_from_yesterday_reset_and_pipeline_runs(self, cache_path):
+        """Cache file dated 2026-05-21 must not prevent run on 2026-05-22."""
+        _save_processed_today_cache(date(2026, 5, 21), {"A1"})
+
+        client = MagicMock()
+        client.get_activities.return_value = [
+            {"id": "A1", "type": "Ride", "icu_ignore_time": False},
+        ]
+        with patch("magma_cycling.session_monitor.create_intervals_client", return_value=client):
+            with patch("magma_cycling.session_monitor.run_command") as mock_run:
+                rc = _handle_unplanned_activity(date(2026, 5, 22))
+
+        assert rc == 0
+        assert mock_run.called
+        cached = _load_processed_today_cache(date(2026, 5, 22))
+        assert cached == {"A1"}


### PR DESCRIPTION
Closes #368 (first-cut).

## Contexte

Brief Coach AI consolidé S093, issue B cousin = scope cron `session_monitor.py`. Initialement P3 dans le vault TODO-triade, reclassé P1 par Stéphane (msg consolidé) car fil rouge \"robustesse coaching\". L'issue mère #360 (Ghost session pipeline complet) reste ouverte pour le scope FREE session creation + end-to-end Coach AI.

**Bug observé** : `session_monitor.py` cron `*/20 6-23 * * *` exit prématurément sur \"No session today\" même quand une activité non planifiée existe sur Intervals.icu (dimanche off transformé en sortie, mid-week impromptu, etc.). Conséquence : ghost session — daily-sync / PID / end-of-week skipped, Coach AI perd la visibilité sur la charge du jour.

## Design arbitré (vault TODO-triade)

1. **Comportement par défaut ON** (pas d'opt-in env var)
2. **Pipeline adapté** : `withings-presync` + `daily-sync --send-email --ai-analysis --auto-servo` + `pid-evaluation` + `end-of-week` (Sunday). **Skip `adherence`** (no plan ref = null result)
3. **Idempotence renforcée** : cache `processed_today.json` empêche re-trigger sur cron tick suivant ET cas où session ajoutée au planning a posteriori

## Implémentation

### Nouveau : `_handle_unplanned_activity(today)` 

Appelée depuis 2 chemins du `main()` :
- `planning_tower.read_week(week_id)` → `FileNotFoundError` (pas de planning pour cette semaine)
- `todays_sessions` empty (planning existe mais aucune session today)

Logique :
- Query Intervals.icu activités du jour (filtre `Ride|VirtualRide` + exclude `icu_ignore_time`)
- Pas d'activity → exit nominal, log explicite
- Activités présentes → load cache → filter ids déjà processed → si new activities → pipeline adapté + cache append
- Pas de récursion ni complexity. Returns 0 dans tous les cas (LaunchAgent must not retry).

### Cache idempotence

`~/.local/share/magma-cycling/processed_today.json` format `{date, activity_ids: [...]}` :
- Stale cache (date différente) → ignoré, fresh start
- Lecture defensive : empty set sur FileNotFoundError / JSON corrompu / mismatch date
- Reset auto à change de date

### Adherence skipped explicitement

Le pipeline emet un log explicite `adherence... SKIPPED (no plan reference for unplanned activity)` plutôt qu'un silence. Cohérent avec la convention \"chaque step trace son skip\" déjà appliquée dans `magma_cycling/session_monitor.py`.

### Pas de régression sur planned flow

`_get_event_cutoff` + main planned-session path inchangés. Le fork unplanned ne s'active **que** dans les 2 chemins exit-prématuré historiques.

## Tests

`tests/test_session_monitor.py` créé (n'existait pas avant) — **17 tests** :

- **6 cache helpers** : empty / stale-date / matching-date / save+load roundtrip / corrupted JSON / nested dir creation
- **4 no-activity exits** : empty list / non-cycling type / Intervals API error / `icu_ignore_time` filter
- **3 pipeline trigger** : Ride / VirtualRide / Sunday end-of-week
- **4 idempotence** : first tick caches / second tick skips / new alongside cached partial trigger / stale-yesterday cache reset

Full suite : **3863 passed, 5 skipped**.

## Acceptance #368

- [x] `session_monitor.py` ne skip plus sur \"No session today\" si activité non-terminale Intervals
- [x] Pipeline adapté déclenché (`adherence` skipped explicitement)
- [x] Cache `processed_activity_ids` empêche double-trigger
- [x] Tests unitaires + intégration

## Hors scope (issue mère #360)

- Création FREE session retroactive dans le data repo
- Pipeline end-to-end Coach AI sur la FREE session
- Tagging session_type / IF / TSS depuis activité réelle

Suivra dans une 2nd PR dédiée à #360 après validation #368 en prod.