### PR TITLE
docs(prompts): BT-014 — weekly_planning TSS formula + post-gen verification

### DIFF
--- a/magma_cycling/prompts/weekly_planning.txt
+++ b/magma_cycling/prompts/weekly_planning.txt
@@ -16,3 +16,37 @@ Tu prescris les SEANCES CONCRETES de la semaine a venir. Ton role :
 
 Sois CONCRET : zones en %FTP, cadences en rpm, durees en minutes.
 Pas de generalites du type "faites du fractionne". Prescris.
+
+## FORMULE TSS OBLIGATOIRE
+
+Calcul de chaque TSS via la formule canonique (QUADRATIQUE, pas lineaire) :
+
+    TSS = duree_heures × IF² × 100
+
+ou IF (Intensity Factor) = puissance normalisee moyenne / FTP, generalement :
+- REC  : IF 0.55-0.65
+- END  : IF 0.65-0.75
+- TMP  : IF 0.75-0.85
+- SS   : IF 0.85-0.94
+- FTP  : IF 0.95-1.04
+- VO2  : IF 1.05-1.14
+
+**Exemple concret** : 4h30 (4.5h) a IF cible 0.70 (END) :
+- Correct : TSS = 4.5 × 0.70² × 100 = 4.5 × 0.49 × 100 = **220**
+- Faux (lineaire) : 4.5 × 0.70 × 100 = 315 ❌
+- Faux (sans carre) : 4.5 × 100 = 450 ❌
+
+## VERIFICATION OBLIGATOIRE post-generation
+
+Pour chaque seance que tu prescris, **calcule l'IF derive** depuis (TSS, duree) :
+
+    IF_derive = sqrt(TSS × 3600 / (duree_min × 60 × 100))
+             = sqrt(TSS / (duree_heures × 100))
+
+Confirme que `IF_derive` tombe dans la window du type declare (voir tableau ci-dessus).
+Si IF_derive est hors window (ex : tu prescris REC avec TSS 18 / 15 min → IF_derive 0.85 = zone SS, INCOHERENT) :
+- Ajuste le TSS pour rentrer dans la window IF du type, OU
+- Ajuste la duree, OU
+- Change le type declare
+
+**Note technique** : le serveur magma-cycling refuse les seances avec couple (TSS, duree, type) physiologiquement incoherent au moment du sync via `sync-week-to-calendar` (filet de securite K, PR #373). Mieux vaut prescrire juste du premier coup que de te faire rejeter au sync.


### PR DESCRIPTION
Closes BT-014 (TSS sous-estimé planification).

## Contexte

Beta-tester Max signale TSS sous-estimé ~50% en planification S006 (420 vs 850 corrigé). LLM Claude Sonnet 4.6 a appliqué formule linéaire au lieu de quadratique. Cf historique #BT-014, msgs 3208/3211 et drafts Discord validés Stéphane.

## Fix

Durcissement explicite du prompt `weekly_planning.txt` avec :
- **FORMULE TSS OBLIGATOIRE** : `TSS = duree_heures × IF² × 100` (quadratique), tableau IF windows par type
- **Exemple concret arithmétique** : 4h30 IF 0.70 → 220 (pas 110)
- **VERIFICATION OBLIGATOIRE post-génération** : `IF_dérivé = sqrt(TSS / (duree_h × 100))`, check window match, ajuste si pas
- **Mention filet K** (PR #373 sync-week-to-calendar rejette les incohérences au sync, donc mieux vaut prescrire juste du premier coup)

\"TrainingPeaks\" évité dans le texte pour respecter le test `no_vendor_references` (vendor mention guard base_system).

## Tests

- `tests/test_prompt_builder.py` : 73 passed (incl. vendor checks)
- Suite complète : 3863 passed, 5 skipped

## Note

Le fix s'applique au prompt système. Stéphane (Coach AI client) bénéficiera dès qu'il prend une nouvelle session qui charge le prompt updated. Côté Max et autres beta-testeurs sur PyInstaller build local, le fix sera dispo dans le prochain build Windows déclenché sur le tag semantic-release post-merge.