### PR TITLE
fix(ci): sync version markers from git tag before docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Closes T-github-utils-version-variables (vault P2). Root cause :
+      # release.yml force ``commit: "false"`` pour python-semantic-release
+      # (branch protection main bloque le push direct du bot) → le tag
+      # ``vX.Y.Z`` pointe sur un commit où pyproject.toml::version et
+      # magma_cycling/__init__.py::__version__ sont restés stale. L'image
+      # Docker buildée depuis ce commit hérite donc d'un ``__version__``
+      # qui ne correspond pas au tag pushé → ``system_info`` retourne une
+      # version fausse en runtime (catch Stéphane msg 3424 2026-05-23).
+      #
+      # Fix : sed les 2 fichiers AVANT ``docker build`` en utilisant le tag
+      # name. Git source reste intentionnellement stale (artefact tag-driven
+      # ``commit: "false"`` doctrine release Stéphane), seule l'image
+      # embarque la version correcte.
+      #
+      # Skipped sur ``workflow_dispatch`` (pas de tag git → pas de version
+      # à propager, image reste sur ce que dit pyproject à HEAD).
+      - name: Sync version markers from git tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          echo "Propagating tag version $TAG_VERSION to pyproject.toml + magma_cycling/__init__.py"
+          sed -i "s/^version = \".*\"/version = \"$TAG_VERSION\"/" pyproject.toml
+          sed -i "s/^__version__ = \".*\"/__version__ = \"$TAG_VERSION\"/" magma_cycling/__init__.py
+          echo "--- pyproject.toml after sync ---"
+          grep "^version = " pyproject.toml
+          echo "--- magma_cycling/__init__.py after sync ---"
+          grep "^__version__ = " magma_cycling/__init__.py
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Root cause

`release.yml` force `commit: "false"` pour python-semantic-release (branch protection `main` bloque le push direct du bot — commit f04a2d1, 2026-04-03). Le tag `vX.Y.Z` pointe donc sur un commit où `pyproject.toml::version` et `magma_cycling/__init__.py::__version__` restent **stale**. L'image Docker build depuis ce commit hérite du `__version__` figé → `system_info` retourne une version fausse en runtime.

Catch terrain : Stéphane msg 3424 2026-05-23, `system_info.version = 3.43.1` alors que prod tourne sur image `:3.47.0` (confirmé par Admin via Portainer API msg 3422).

## Fix

Ajout step `Sync version markers from git tag` **AVANT** `docker/build-push-action@v6` : `sed pyproject.toml + __init__.py` depuis `${GITHUB_REF_NAME#v}` quand `event=push+tags`.

- Git source reste intentionnellement stale (artefact tag-driven `commit: "false"`, cohérent doctrine release pin explicite actée msg 3416 = "image Docker = vérité unique")
- Seule l'image embarque la version correcte
- Skipped sur `workflow_dispatch` (pas de tag git → pas de version à propager)

## Options arbitrées

- **Option A** (rejetée) — toggle `release.yml commit: "true"` + bypass branch protection pour `github-actions[bot]` : refuse branch protection compromise
- **Option B** (✅ retenue) — sed dans `docker-publish.yml` : 0 impact branch protection, audit clair via build log, source git assumée stale par doctrine
- **Option C** (insuffisante seule) — `importlib.metadata.version("magma-cycling")` runtime : mais `pyproject` build-time = même problème stale

Vote Junior + Leader +1 Option B.

## Test plan

- [x] CI verte sur la PR
- [ ] Après merge : prochain tag semantic-release → image Docker devrait afficher `__version__ == tag` en runtime (`system_info`)
- [ ] Vérif terrain : appeler `system_info` après prochain retag stable, confirmer cohérence image/`__version__`

## Refs

- T-github-utils-version-variables (vault P2, closes)
- Catch Stéphane msg 3424 (`system_info` stale 3.43.1 vs image 3.47.0)
- Confirmation Admin msg 3422 (Portainer API : 3 containers preprod+prod sur `:3.47.0`)
- Doctrine release msg 3416 ("image Docker = vérité unique")
- Memory Leader `feedback_system_info_version_stale_use_docker_image.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>