### PR TITLE
fix(health): read canonical sleepSecs from Intervals.icu wellness (BT-010)

### DIFF
--- a/magma_cycling/_mcp/handlers/rest.py
+++ b/magma_cycling/_mcp/handlers/rest.py
@@ -97,9 +97,9 @@ async def handle_pre_session_check(args: dict) -> list[TextContent]:
         wellness_list = client.get_wellness(oldest=date_str, newest=date_str)
         wellness_raw = wellness_list[0] if wellness_list else {}
 
-        sleep_hours = wellness_raw.get("sleepTime")
+        sleep_hours = wellness_raw.get("sleepSecs") or wellness_raw.get("sleepTime")
         if sleep_hours and isinstance(sleep_hours, (int, float)) and sleep_hours > 24:
-            # sleepTime is in seconds from Intervals.icu
+            # sleepSecs is in seconds from Intervals.icu (sleepTime = legacy alias)
             sleep_hours = round(sleep_hours / 3600, 2)
 
         wellness = {

--- a/magma_cycling/health/factory.py
+++ b/magma_cycling/health/factory.py
@@ -44,7 +44,7 @@ def create_health_provider() -> HealthProvider:
         seven_days_ago = str(date.today() - timedelta(days=7))
         yesterday = str(date.today() - timedelta(days=1))
         wellness = client.get_wellness(oldest=seven_days_ago, newest=yesterday)
-        if wellness and any(w.get("sleepTime") for w in wellness):
+        if wellness and any(w.get("sleepSecs") or w.get("sleepTime") for w in wellness):
             from magma_cycling.health.intervals_provider import IntervalsHealthProvider
 
             logger.info("Using IntervalsHealthProvider (sleep data found in last 7 days)")

--- a/magma_cycling/health/intervals_provider.py
+++ b/magma_cycling/health/intervals_provider.py
@@ -40,7 +40,7 @@ class IntervalsHealthProvider(HealthProvider):
         w = self._get_wellness_day(target_date)
         if not w:
             return None
-        sleep_secs = w.get("sleepTime")
+        sleep_secs = w.get("sleepSecs") or w.get("sleepTime")
         if not sleep_secs:
             return None
         # Build a SleepData from available wellness fields

--- a/tests/health/test_factory.py
+++ b/tests/health/test_factory.py
@@ -23,14 +23,24 @@ class TestCreateHealthProvider:
     def test_returns_null_provider_when_not_configured(self):
         mock_config = Mock()
         mock_config.is_configured.return_value = False
-        with patch("magma_cycling.config.get_withings_config", return_value=mock_config):
+        intervals_client = Mock()
+        intervals_client.get_wellness.return_value = []
+        with (
+            patch("magma_cycling.config.get_withings_config", return_value=mock_config),
+            patch("magma_cycling.config.create_intervals_client", return_value=intervals_client),
+        ):
             provider = create_health_provider()
         assert isinstance(provider, NullProvider)
 
     def test_returns_null_provider_on_exception(self):
-        with patch(
-            "magma_cycling.config.get_withings_config",
-            side_effect=RuntimeError("config broken"),
+        intervals_client = Mock()
+        intervals_client.get_wellness.return_value = []
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                side_effect=RuntimeError("config broken"),
+            ),
+            patch("magma_cycling.config.create_intervals_client", return_value=intervals_client),
         ):
             provider = create_health_provider()
         assert isinstance(provider, NullProvider)
@@ -130,11 +140,28 @@ class TestIntervalsHealthProviderProbeWindow:
             provider = create_health_provider()
         assert isinstance(provider, IntervalsHealthProvider)
 
-    def test_falls_back_to_null_when_full_week_empty(self):
-        """If the entire 7-day window has no sleepTime, NullProvider is the
-        right answer (legitimately no Garmin/watch sync configured)."""
+    def test_returns_intervals_when_sleep_secs_canonical_field(self):
+        """BT-010 — Garmin push via Intervals.icu uses ``sleepSecs`` (canonical),
+        not the legacy ``sleepTime`` alias. The probe must accept both."""
         client = Mock()
-        client.get_wellness.return_value = [{"id": f"day-{i}", "sleepTime": None} for i in range(7)]
+        client.get_wellness.return_value = [
+            {"id": "2026-05-21", "sleepSecs": 27758, "sleepScore": 86},
+        ]
+        with (
+            patch(
+                "magma_cycling.config.get_withings_config",
+                return_value=self._withings_unconfigured(),
+            ),
+            patch("magma_cycling.config.create_intervals_client", return_value=client),
+        ):
+            provider = create_health_provider()
+        assert isinstance(provider, IntervalsHealthProvider)
+
+    def test_falls_back_to_null_when_full_week_empty(self):
+        """If the entire 7-day window has neither sleepSecs nor sleepTime,
+        NullProvider is the right answer (legitimately no Garmin/watch sync)."""
+        client = Mock()
+        client.get_wellness.return_value = [{"id": f"day-{i}", "sleepSecs": None} for i in range(7)]
         with (
             patch(
                 "magma_cycling.config.get_withings_config",

--- a/tests/health/test_intervals_provider.py
+++ b/tests/health/test_intervals_provider.py
@@ -46,6 +46,24 @@ class TestGetSleepSummary:
         provider = IntervalsHealthProvider(mock_client)
         assert provider.get_sleep_summary(date(2026, 4, 15)) is None
 
+    def test_reads_sleep_secs_canonical_garmin_push(self, mock_client):
+        # BT-010 — Garmin push via Intervals.icu wellness uses `sleepSecs`,
+        # not the legacy `sleepTime` alias. Confirmed empirically with Max's
+        # raw payload 2026-05-21.
+        mock_client.get_wellness.return_value = [
+            {
+                "id": "2026-05-21",
+                "sleepSecs": 27758,
+                "sleepScore": 86,
+                "sleepQuality": 2,
+            }
+        ]
+        provider = IntervalsHealthProvider(mock_client)
+        result = provider.get_sleep_summary(date(2026, 5, 21))
+        assert result is not None
+        assert result.total_sleep_hours == round(27758 / 3600, 2)
+        assert result.sleep_score == 86
+
 
 class TestGetReadiness:
     def test_good_sleep_all_systems_go(self, provider):


### PR DESCRIPTION
## Bug racine

`IntervalsHealthProvider` et le probe de la factory lisaient le champ legacy `sleepTime`, mais Intervals.icu pour les sources Garmin actuelles expose la valeur sous **`sleepSecs`** (confirmé empiriquement par le JSON wellness brut d'un beta-tester, 2026-05-21).

Conséquence : `factory.create_health_provider()` faisait son probe 7-day sur `sleepTime`, trouvait rien, et tombait sur `NullProvider` pour tout user Garmin. Même si le provider avait été détecté, `IntervalsHealthProvider.get_sleep_summary()` retournait `None` pour la même raison.

Le reste du codebase (`aggregator`, `prompt_builder`, `servo_evaluation`, `proactive_compensation`, write path `daily-sync`) utilisait déjà `sleepSecs` — ce patch finalise la conversion sur les 3 fichiers en retard.

## Fix

Lire `sleepSecs` en priorité, fallback `sleepTime` pour rétrocompat (comptes legacy qui exposeraient encore l'alias).

```python
sleep_secs = w.get("sleepSecs") or w.get("sleepTime")
```

## Fichiers modifiés

- `magma_cycling/health/factory.py` — probe accepte les 2 champs
- `magma_cycling/health/intervals_provider.py` — lecture cohérente
- `magma_cycling/_mcp/handlers/rest.py` — affichage pre-session-check
- `tests/health/test_factory.py` — ajout test Garmin-push canonical
- `tests/health/test_intervals_provider.py` — ajout test payload Garmin Max

## Impact

- ✅ Beta-testeurs Garmin (BT-010 + tous les autres dans la même config) : `IntervalsHealthProvider` détecté, `sleep_summary` populated, `get_readiness()` retourne des valeurs cohérentes
- ✅ Pre-session-check, servo evaluation, Coach AI accèdent enfin à la wellness Garmin
- ✅ Pas de régression pour les users existants : `sleepTime` reste lu en fallback
- ✅ Stéphane (Withings) : non impacté (chain Withings → Intervals → Null le by-pass)

## Test plan

- [x] `pytest tests/health/ tests/_mcp/handlers/test_rest.py` → 93 pass
- [x] Nouveau test `test_reads_sleep_secs_canonical_garmin_push` reproduit exactement le payload Max (sleepSecs=27758, sleepScore=86, sleepQuality=2) — vérifie `total_sleep_hours == 7.71` (27758/3600)
- [x] Nouveau test factory `test_returns_intervals_when_sleep_secs_canonical_field` vérifie probe accepte `sleepSecs`
- [ ] Post-merge : Max retest pre-session-check côté CD → devrait voir wellness Garmin enfin populée

## Refs

- Beta Support msg 3463 (Claude Desktop transmet JSON Max)
- Diag Leader msg ~16:25 (localisation 3 fichiers legacy `sleepTime`)
- Memory `project_garmin_via_intervals_icu_broker_doctrine.md` (doctrine archi 21/05)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>