### PR TITLE
feat(mcp): add current-time handler (PR8ter iso-config AC6 lev.2)

### DIFF
--- a/magma_cycling/_mcp/handlers/current_time.py
+++ b/magma_cycling/_mcp/handlers/current_time.py
@@ -1,0 +1,66 @@
+"""Current time handler — AC6 levier 2/3 du plan iso-config S093-S096.
+
+Ultra-light handler retournant l'autorité temporelle serveur sous forme
+structurée. À appeler par le LLM coach dès qu'il doute de son contexte
+temporel (drift typique sur conversations longues qui traversent minuit,
+ou sessions reprises après plusieurs jours).
+
+Conventions de retour :
+- UTC + local + timezone explicite (3 vues redondantes pour annuler tout
+  doute sur le décalage)
+- jour de la semaine en français + numérique (0=lundi, semaine ISO)
+- aides dérivées : today_iso, iso_year_week, hour_of_day, is_weekend
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from magma_cycling._mcp._utils import mcp_response
+
+if TYPE_CHECKING:
+    from mcp.types import TextContent
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["handle_current_time"]
+
+
+_DAY_OF_WEEK_FR = {
+    0: "lundi",
+    1: "mardi",
+    2: "mercredi",
+    3: "jeudi",
+    4: "vendredi",
+    5: "samedi",
+    6: "dimanche",
+}
+
+
+async def handle_current_time(args: dict) -> list[TextContent]:
+    """Return canonical server time information as a structured payload.
+
+    Designed as time-of-truth callable for LLM clients (Coach IA, Claude
+    Desktop, etc.) that need to anchor their temporal context without
+    inferring it from conversation history. AC6 levier 2/3.
+    """
+    now_local = datetime.now().astimezone()
+    now_utc = now_local.astimezone(timezone.utc)
+
+    iso_year, iso_week, _ = now_local.isocalendar()
+
+    return mcp_response(
+        {
+            "server_time_utc": now_utc.isoformat(timespec="seconds"),
+            "server_time_local": now_local.isoformat(timespec="seconds"),
+            "tz": str(now_local.tzinfo),
+            "today_iso": now_local.date().isoformat(),
+            "day_of_week_fr": _DAY_OF_WEEK_FR[now_local.weekday()],
+            "day_of_week_num": now_local.weekday(),
+            "iso_year_week": f"{iso_year}-W{iso_week:02d}",
+            "hour_of_day": now_local.hour,
+            "is_weekend": now_local.weekday() >= 5,
+        }
+    )

--- a/magma_cycling/_mcp/schemas/current_time.py
+++ b/magma_cycling/_mcp/schemas/current_time.py
@@ -1,0 +1,20 @@
+"""Current time tool schema — AC6 levier 2/3 du plan iso-config S093-S096."""
+
+from mcp.types import Tool
+
+
+def get_tools() -> list[Tool]:
+    """Return current-time tool schema."""
+    return [
+        Tool(
+            name="current-time",
+            description=(
+                "Return canonical server time information (UTC + local + timezone + "
+                "ISO week + day-of-week FR). Authoritative time-of-truth callable — "
+                "use this whenever you doubt your temporal context instead of inferring "
+                "the date from conversation history. Ultra-light, no side effects, no "
+                "arguments. Recommended at session start and after any long pause."
+            ),
+            inputSchema={"type": "object", "properties": {}},
+        ),
+    ]

--- a/magma_cycling/mcp_server.py
+++ b/magma_cycling/mcp_server.py
@@ -55,6 +55,9 @@ from magma_cycling._mcp.handlers.athlete import (  # noqa: F401
 from magma_cycling._mcp.handlers.catalog import (  # noqa: F401
     handle_list_workout_catalog,
 )
+from magma_cycling._mcp.handlers.current_time import (  # noqa: F401
+    handle_current_time,
+)
 from magma_cycling._mcp.handlers.decisions import (  # noqa: F401
     handle_record_decision,
 )
@@ -141,6 +144,7 @@ from magma_cycling._mcp.schemas import admin as _s_admin
 from magma_cycling._mcp.schemas import analysis as _s_analysis
 from magma_cycling._mcp.schemas import athlete as _s_athlete
 from magma_cycling._mcp.schemas import catalog as _s_catalog
+from magma_cycling._mcp.schemas import current_time as _s_current_time
 from magma_cycling._mcp.schemas import decisions as _s_decisions
 from magma_cycling._mcp.schemas import handoff as _s_handoff
 from magma_cycling._mcp.schemas import health as _s_health
@@ -180,6 +184,7 @@ async def list_tools() -> list[Tool]:
         *_s_athlete.get_tools(),
         *_s_analysis.get_tools(),
         *_s_admin.get_tools(),
+        *_s_current_time.get_tools(),
         *_s_catalog.get_tools(),
         *_s_health.get_tools(),
         *_s_rest.get_tools(),
@@ -249,6 +254,8 @@ TOOL_HANDLERS = {
     # Admin (2)
     "reload-server": handle_reload_server,
     "system-info": handle_system_info,
+    # Time / AC6 levier 2 (1) — PR8ter plan iso-config
+    "current-time": handle_current_time,
     # Catalog (1)
     "list-workout-catalog": handle_list_workout_catalog,
     # Health (8)

--- a/tests/test_mcp_current_time_handler.py
+++ b/tests/test_mcp_current_time_handler.py
@@ -1,0 +1,156 @@
+"""Tests for MCP current-time handler (PR8ter iso-config AC6 levier 2/3)."""
+
+import json
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+from magma_cycling._mcp.handlers.current_time import handle_current_time
+
+
+@pytest.mark.asyncio
+class TestCurrentTimeHandler:
+    """Tests for handle_current_time."""
+
+    async def test_returns_all_expected_fields(self):
+        """Handler returns every field required by AC6 spec."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        required_fields = {
+            "server_time_utc",
+            "server_time_local",
+            "tz",
+            "today_iso",
+            "day_of_week_fr",
+            "day_of_week_num",
+            "iso_year_week",
+            "hour_of_day",
+            "is_weekend",
+        }
+        assert required_fields.issubset(data.keys())
+
+    async def test_server_time_utc_is_valid_iso8601(self):
+        """server_time_utc is ISO 8601 in UTC."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        parsed = datetime.fromisoformat(data["server_time_utc"])
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timezone.utc.utcoffset(parsed)
+
+    async def test_server_time_local_is_valid_iso8601_with_offset(self):
+        """server_time_local includes timezone offset."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        parsed = datetime.fromisoformat(data["server_time_local"])
+        assert parsed.tzinfo is not None
+
+    async def test_today_iso_format(self):
+        """today_iso matches YYYY-MM-DD pattern."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        assert re.match(r"^\d{4}-\d{2}-\d{2}$", data["today_iso"])
+
+    async def test_iso_year_week_format(self):
+        """iso_year_week matches YYYY-Www pattern."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        assert re.match(r"^\d{4}-W\d{2}$", data["iso_year_week"])
+
+    async def test_day_of_week_fr_is_french(self):
+        """day_of_week_fr is one of seven French day names."""
+        valid_days = {
+            "lundi",
+            "mardi",
+            "mercredi",
+            "jeudi",
+            "vendredi",
+            "samedi",
+            "dimanche",
+        }
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        assert data["day_of_week_fr"] in valid_days
+
+    async def test_day_of_week_num_range(self):
+        """day_of_week_num is 0..6 (0=lundi convention Python)."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        assert 0 <= data["day_of_week_num"] <= 6
+
+    async def test_is_weekend_matches_day_of_week_num(self):
+        """is_weekend = True iff day_of_week_num in {5, 6}."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        assert data["is_weekend"] == (data["day_of_week_num"] >= 5)
+
+    async def test_hour_of_day_range(self):
+        """hour_of_day is 0..23."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        assert 0 <= data["hour_of_day"] <= 23
+
+    async def test_utc_and_local_represent_same_instant(self):
+        """server_time_utc and server_time_local are the same wall-clock moment."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        utc_dt = datetime.fromisoformat(data["server_time_utc"])
+        local_dt = datetime.fromisoformat(data["server_time_local"])
+
+        delta = abs((utc_dt - local_dt).total_seconds())
+        assert delta < 1.5
+
+    async def test_today_iso_matches_local_date(self):
+        """today_iso is the date component of server_time_local."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        local_dt = datetime.fromisoformat(data["server_time_local"])
+        assert data["today_iso"] == local_dt.date().isoformat()
+
+    async def test_args_dict_is_ignored(self):
+        """Handler ignores any input arguments (no input schema beyond {})."""
+        result_empty = await handle_current_time({})
+        result_with_args = await handle_current_time({"unexpected": "field"})
+
+        data_empty = json.loads(result_empty[0].text)
+        data_with_args = json.loads(result_with_args[0].text)
+
+        assert data_empty.keys() == data_with_args.keys()
+
+    async def test_response_includes_mcp_metadata(self):
+        """mcp_response wrapper injects _metadata (sanity check)."""
+        result = await handle_current_time({})
+        data = json.loads(result[0].text)
+
+        assert "_metadata" in data
+
+
+@pytest.mark.asyncio
+class TestCurrentTimeRegistration:
+    """Tests for current-time tool registration in MCP server."""
+
+    async def test_tool_is_in_tool_handlers(self):
+        """current-time is registered in TOOL_HANDLERS dispatch."""
+        from magma_cycling.mcp_server import TOOL_HANDLERS
+
+        assert "current-time" in TOOL_HANDLERS
+        assert TOOL_HANDLERS["current-time"] is handle_current_time
+
+    async def test_tool_schema_is_listed(self):
+        """current-time tool schema is included in list_tools()."""
+        from magma_cycling._mcp.schemas import current_time as _s_ct
+
+        tools = _s_ct.get_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "current-time"


### PR DESCRIPTION
## Contexte

PR8ter du plan iso-config S093-S096 (`/Users/Shared/plans/PLAN-iso-config-multi-operateur-S093-S096.md`), levier 2/3 de l'AC6 — synchro temporelle CD/serveur.

Glissée S094 → livrée S095 (recadrage Stéphane 14/05 priorisait AC1 portabilité athlète).

## Ce que fait la PR

Ajoute le handler MCP `current-time` ultra-léger : **autorité temporelle serveur callable explicite** pour les LLM coachs (Coach IA Claude.ai, Claude Desktop, etc.) qui doivent ré-ancrer leur contexte temporel sans inférer la date depuis l'historique conversation.

### Payload retourné

```json
{
  "server_time_utc": "2026-05-25T07:53:00+00:00",
  "server_time_local": "2026-05-25T09:53:00+02:00",
  "tz": "Europe/Paris",
  "today_iso": "2026-05-25",
  "day_of_week_fr": "lundi",
  "day_of_week_num": 0,
  "iso_year_week": "2026-W22",
  "hour_of_day": 9,
  "is_weekend": false,
  "_metadata": {...}
}
```

### Critères design

- **Ultra-light** : aucune dépendance externe, juste `datetime` + `timezone`. Réponse sub-milliseconde.
- **Triple représentation temporelle** : UTC + local + tz explicite annulent tout doute sur le décalage.
- **Aides dérivées prêtes à l'emploi** : `today_iso`, `iso_year_week`, `day_of_week_fr`, `is_weekend` évitent au LLM de devoir parser/calculer.
- **No-args** : `inputSchema = {"type": "object", "properties": {}}` — pas d'argument à fournir, callable à la demande.
- **No side effects** : pure lecture du `datetime.now()` serveur.

## Fichiers

- `magma_cycling/_mcp/handlers/current_time.py` — `handle_current_time()` (60 lignes)
- `magma_cycling/_mcp/schemas/current_time.py` — `get_tools()` (16 lignes)
- `magma_cycling/mcp_server.py` — enregistrement handler + schema (3 inserts, nouvelle section commentée « Time / AC6 levier 2 (1) »)
- `tests/test_mcp_current_time_handler.py` — **15 tests** couvrant payload shape, ISO 8601 validity, jours français, cohérence UTC/local, args ignorés, MCP metadata wrapper, registration dispatch + tool listing

## Validation locale

- 15/15 tests verts (`pytest tests/test_mcp_current_time_handler.py -v`)
- Cross-cutting OK avec `test_admin` (qui valide `tool_count == len(TOOL_HANDLERS)`) et `test_mcp_logging` — 38/38 tests verts ensemble
- Pre-commit hooks tous passants (black, ruff, isort, pydocstyle, pycodestyle, check-tools-docs, safe I/O, etc.)
- Tool count attendu : 60 → 61

## Rollback

Handler retirable du `TOOL_HANDLERS` + `list_tools()` sans casse. Fallback CD = appel `system-info` existant (qui retourne déjà du `response_timestamp` partiel via `mcp_response` wrapper, juste moins riche).

## Suivi plan iso-config

Restera pour AC6 : PR8bis (`_metadata.server_time_utc` injecté automatiquement dans TOUTES les réponses MCP, levier 1/3) + PR15 étendu (convention LLM dérive temporelle dans onboarding, levier 3/3, S096).