### PR TITLE
feat(data-repo): add resolve_read_path helper (PR11a iso-config Phase 3 PR D)

### DIFF
--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -481,6 +481,131 @@ class DataRepoConfig:
         """Path to handoff/ directory in data repo (context-handoff snapshots)."""
         return self.data_repo_path / "handoff"
 
+    @property
+    def authority_rules(self) -> list[tuple[str, str]]:
+        """Liste ordonnée ``(pattern, writer_alias)`` issue de ``.operators.yaml::authority``.
+
+        L'ordre de déclaration YAML est préservé (premier match gagne dans
+        :meth:`resolve_read_path`). Retourne ``[]`` si la section ``authority``
+        est absente, le fichier ``.operators.yaml`` n'existe pas, ou les
+        valeurs ne sont pas des dicts simples ``pattern -> alias``.
+
+        Phase 3 PR D (plan iso-config PR11a) — strict read-only.
+        """
+        ops = self.operators_yaml
+        if not ops:
+            return []
+        auth = ops.get("authority")
+        if not isinstance(auth, dict):
+            return []
+        out: list[tuple[str, str]] = []
+        for pattern, alias in auth.items():
+            if isinstance(pattern, str) and isinstance(alias, str):
+                out.append((pattern, alias))
+        return out
+
+    def _resolve_writer_alias_to_hash(self, alias: str) -> str | None:
+        """Résoud un alias writer (``mac``, ``nas-prod``, ...) en son hash 12-char.
+
+        Consulte la section ``writers:`` de ``.operators.yaml``. Retourne
+        ``None`` si l'alias n'est pas trouvé ou si la section est absente.
+        Une entrée writer avec ``decommissioned_at`` non-null n'est PAS
+        exclue (read fallback historique reste possible — l'historique est
+        préservé même après décommission par convention ADR v5 §3).
+        """
+        ops = self.operators_yaml
+        if not ops:
+            return None
+        writers = ops.get("writers")
+        if not isinstance(writers, dict):
+            return None
+        for writer_hash, meta in writers.items():
+            if not isinstance(meta, dict):
+                continue
+            if meta.get("alias") == alias:
+                return writer_hash if isinstance(writer_hash, str) else None
+        return None
+
+    @staticmethod
+    def _match_authority_pattern(file_pattern: str, rule_pattern: str) -> bool:
+        """Match un ``file_pattern`` (path POSIX) contre un ``rule_pattern`` ``.operators.yaml::authority``.
+
+        Sémantique des patterns supportés :
+        - Suffixe ``/**`` ou ``/*`` → match préfixe directory récursif (ex.
+          ``workouts/**`` matche ``workouts/foo.zwo`` et ``workouts/sub/bar.zwo``)
+        - Sinon → match exact via :func:`fnmatch.fnmatchcase` (glob standard
+          POSIX, supporte ``*`` / ``?`` / ``[abc]``)
+
+        L'argument ``rule_pattern`` est tel que déclaré dans ``authority:``
+        (un seul wildcard récursif terminal est typiquement utilisé).
+        """
+        import fnmatch
+
+        if rule_pattern.endswith("/**") or rule_pattern.endswith("/*"):
+            prefix = rule_pattern.rsplit("/", 1)[0].rstrip("/") + "/"
+            return file_pattern.startswith(prefix)
+        return fnmatch.fnmatchcase(file_pattern, rule_pattern)
+
+    def resolve_read_path(self, file_pattern: str) -> Path:
+        """Résoud un path de lecture multi-writer selon ``.operators.yaml::authority``.
+
+        Phase 3 PR D (plan iso-config PR11a) — helper central consumer-side
+        pour faire converger les lectures vers la subdir du writer autoritaire,
+        plutôt que de lire flat depuis la racine du repo.
+
+        Comportement :
+
+        - **Mode legacy** (``writer_scoped=False``, défaut) : retourne
+          ``root_path / file_pattern`` — comportement runtime inchangé pour
+          tous les consumers, l'helper est un no-op jusqu'à l'activation
+          du flag.
+        - **Mode scoped** (``writer_scoped=True``) :
+            1. Itère :attr:`authority_rules` dans l'ordre de déclaration YAML
+            2. Premier ``rule_pattern`` qui matche ``file_pattern`` gagne
+            3. Si l'alias résolvable en hash via :meth:`_resolve_writer_alias_to_hash` →
+               retourne ``root_path / <hash> / file_pattern``
+            4. Si pas de match, ou alias non résolvable → fallback
+               ``root_path / file_pattern`` + warning log (le fichier pourrait
+               être co-owned racine, ou la config ``.operators.yaml`` incomplète)
+
+        Args:
+            file_pattern: Path relatif POSIX-style depuis la racine du repo
+                (ex. ``weekly-reports/S094/bilan_final_s094.md``).
+
+        Returns:
+            Path absolu résolu. **Le path n'est PAS vérifié pour existence**
+            — le caller décide (read-only helper, pas de side effect FS).
+
+        Examples:
+            >>> cfg.resolve_read_path("workouts/MyWorkout.zwo")
+            PosixPath('/Users/me/training-logs/b08921dae3e7/workouts/MyWorkout.zwo')
+
+            >>> cfg.resolve_read_path("weekly-reports/S094/bilan_final.md")
+            PosixPath('/Users/me/training-logs/5e6f282f9f03/weekly-reports/S094/bilan_final.md')
+        """
+        if not self.writer_scoped:
+            return self.root_path / file_pattern
+
+        for rule_pattern, writer_alias in self.authority_rules:
+            if self._match_authority_pattern(file_pattern, rule_pattern):
+                writer_hash = self._resolve_writer_alias_to_hash(writer_alias)
+                if writer_hash:
+                    return self.root_path / writer_hash / file_pattern
+                logger.warning(
+                    "authority rule '%s' → alias '%s' but no writer hash "
+                    "resolved in .operators.yaml::writers ; falling back to root_path",
+                    rule_pattern,
+                    writer_alias,
+                )
+                return self.root_path / file_pattern
+
+        logger.debug(
+            "no authority rule matched file_pattern '%s' ; falling back to root_path "
+            "(file may be co-owned shared_root_files)",
+            file_pattern,
+        )
+        return self.root_path / file_pattern
+
     def ensure_directories(self):
         """Create required directories if they don't exist."""
         self.bilans_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_data_repo_resolve_read_path.py
+++ b/tests/test_data_repo_resolve_read_path.py
@@ -1,0 +1,265 @@
+"""Tests for DataRepoConfig.resolve_read_path (PR11a iso-config Phase 3 PR D).
+
+Couvre :
+- Mode legacy (writer_scoped=False) : no-op, fallback root_path
+- Mode scoped (writer_scoped=True) : matching authority, résolution alias→hash
+- Matching patterns : exact, glob /**, glob /*, conflit ordre déclaration
+- Fallbacks : pas de match, alias non résolvable, .operators.yaml absent
+- Helper statique : _match_authority_pattern (POSIX-style)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from magma_cycling.config.data_repo import DataRepoConfig
+
+
+@pytest.fixture
+def tmp_repo(tmp_path: Path) -> Path:
+    """Crée un repo training-logs minimal pour exercer DataRepoConfig."""
+    (tmp_path / "workouts-history.md").touch()
+    return tmp_path
+
+
+@pytest.fixture
+def writers_section() -> str:
+    """3 writers conformes au .operators.yaml réel (ADR v5 §1.bis)."""
+    return """
+writers:
+  b08921dae3e7:
+    alias: mac
+    host: tiresias
+  5e6f282f9f03:
+    alias: nas-prod
+    host: synology-penelope
+  8816403fa31c:
+    alias: nas-preprod
+    host: synology-penelope
+"""
+
+
+def _seed_operators_yaml(repo_root: Path, content: str) -> None:
+    """Écrit ``.operators.yaml`` à la racine du repo."""
+    (repo_root / ".operators.yaml").write_text(content, encoding="utf-8")
+
+
+class TestResolveReadPathLegacyMode:
+    """Mode legacy (writer_scoped=False) : helper no-op."""
+
+    def test_no_writer_scoped_returns_root_path(self, tmp_repo: Path):
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        result = cfg.resolve_read_path("weekly-reports/S094/bilan_final.md")
+        assert result == tmp_repo / "weekly-reports/S094/bilan_final.md"
+
+    def test_no_writer_scoped_ignores_operators_yaml(self, tmp_repo: Path, writers_section: str):
+        _seed_operators_yaml(
+            tmp_repo,
+            writers_section
+            + """
+authority:
+  weekly-reports/**: nas-prod
+""",
+        )
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        result = cfg.resolve_read_path("weekly-reports/S094/bilan_final.md")
+        assert result == tmp_repo / "weekly-reports/S094/bilan_final.md"
+
+
+class TestResolveReadPathScopedMode:
+    """Mode scoped (writer_scoped=True) : résolution via authority+writers."""
+
+    def _make_scoped_cfg(self, tmp_repo: Path) -> DataRepoConfig:
+        (tmp_repo / "b08921dae3e7").mkdir(exist_ok=True)
+        return DataRepoConfig(data_repo_path=tmp_repo, writer_scoped=True, writer_id="b08921dae3e7")
+
+    def test_glob_recursive_authority_routes_to_writer_hash(
+        self, tmp_repo: Path, writers_section: str
+    ):
+        _seed_operators_yaml(
+            tmp_repo,
+            writers_section
+            + """
+authority:
+  weekly-reports/**: nas-prod
+  workouts/**: mac
+""",
+        )
+        cfg = self._make_scoped_cfg(tmp_repo)
+        assert (
+            cfg.resolve_read_path("weekly-reports/S094/bilan_final.md")
+            == tmp_repo / "5e6f282f9f03/weekly-reports/S094/bilan_final.md"
+        )
+        assert (
+            cfg.resolve_read_path("workouts/MyWorkout.zwo")
+            == tmp_repo / "b08921dae3e7/workouts/MyWorkout.zwo"
+        )
+
+    def test_exact_match_authority(self, tmp_repo: Path, writers_section: str):
+        _seed_operators_yaml(
+            tmp_repo,
+            writers_section
+            + """
+authority:
+  workouts-history.md: nas-prod
+""",
+        )
+        cfg = self._make_scoped_cfg(tmp_repo)
+        result = cfg.resolve_read_path("workouts-history.md")
+        assert result == tmp_repo / "5e6f282f9f03/workouts-history.md"
+
+    def test_first_match_wins_on_overlapping_rules(self, tmp_repo: Path, writers_section: str):
+        """L'ordre de déclaration YAML est respecté — premier match gagne."""
+        _seed_operators_yaml(
+            tmp_repo,
+            writers_section
+            + """
+authority:
+  data/backups/**: mac
+  data/**: nas-prod
+""",
+        )
+        cfg = self._make_scoped_cfg(tmp_repo)
+        result = cfg.resolve_read_path("data/backups/2026-05-25/snapshot.json")
+        assert result == tmp_repo / "b08921dae3e7/data/backups/2026-05-25/snapshot.json"
+
+    def test_no_match_falls_back_to_root_path(self, tmp_repo: Path, writers_section: str):
+        _seed_operators_yaml(
+            tmp_repo,
+            writers_section
+            + """
+authority:
+  weekly-reports/**: nas-prod
+""",
+        )
+        cfg = self._make_scoped_cfg(tmp_repo)
+        result = cfg.resolve_read_path(".gitignore")
+        assert result == tmp_repo / ".gitignore"
+
+    def test_alias_not_resolvable_falls_back_to_root_path(
+        self, tmp_repo: Path, writers_section: str, caplog
+    ):
+        _seed_operators_yaml(
+            tmp_repo,
+            writers_section
+            + """
+authority:
+  ghost-reports/**: ghost-writer
+""",
+        )
+        cfg = self._make_scoped_cfg(tmp_repo)
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="magma_cycling.config.data_repo"):
+            result = cfg.resolve_read_path("ghost-reports/foo.md")
+        assert result == tmp_repo / "ghost-reports/foo.md"
+        assert any("ghost-writer" in r.message for r in caplog.records)
+
+    def test_missing_operators_yaml_falls_back_to_root_path(self, tmp_repo: Path):
+        cfg = self._make_scoped_cfg(tmp_repo)
+        result = cfg.resolve_read_path("weekly-reports/S094/bilan_final.md")
+        assert result == tmp_repo / "weekly-reports/S094/bilan_final.md"
+
+    def test_authority_section_missing_falls_back_to_root_path(
+        self, tmp_repo: Path, writers_section: str
+    ):
+        _seed_operators_yaml(tmp_repo, writers_section)
+        cfg = self._make_scoped_cfg(tmp_repo)
+        result = cfg.resolve_read_path("weekly-reports/S094/bilan_final.md")
+        assert result == tmp_repo / "weekly-reports/S094/bilan_final.md"
+
+
+class TestAuthorityRulesProperty:
+    """Property authority_rules : extraction ordonnée du .operators.yaml."""
+
+    def test_empty_when_no_operators_yaml(self, tmp_repo: Path):
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        assert cfg.authority_rules == []
+
+    def test_empty_when_no_authority_section(self, tmp_repo: Path, writers_section: str):
+        _seed_operators_yaml(tmp_repo, writers_section)
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        assert cfg.authority_rules == []
+
+    def test_preserves_yaml_declaration_order(self, tmp_repo: Path, writers_section: str):
+        _seed_operators_yaml(
+            tmp_repo,
+            writers_section
+            + """
+authority:
+  data/backups/**: mac
+  data/**: nas-prod
+  weekly-reports/**: nas-prod
+""",
+        )
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        rules = cfg.authority_rules
+        assert rules == [
+            ("data/backups/**", "mac"),
+            ("data/**", "nas-prod"),
+            ("weekly-reports/**", "nas-prod"),
+        ]
+
+    def test_filters_non_string_entries(self, tmp_repo: Path, writers_section: str):
+        _seed_operators_yaml(
+            tmp_repo,
+            writers_section
+            + """
+authority:
+  weekly-reports/**: nas-prod
+  invalid_key: [list, value]
+  data/backups/**: mac
+""",
+        )
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        rules = cfg.authority_rules
+        assert ("weekly-reports/**", "nas-prod") in rules
+        assert ("data/backups/**", "mac") in rules
+        assert all(isinstance(v, str) for _, v in rules)
+
+
+class TestMatchAuthorityPattern:
+    """Helper statique _match_authority_pattern (POSIX-style)."""
+
+    def test_recursive_glob_double_star(self):
+        assert DataRepoConfig._match_authority_pattern("workouts/foo.zwo", "workouts/**")
+        assert DataRepoConfig._match_authority_pattern("workouts/sub/dir/bar.zwo", "workouts/**")
+
+    def test_recursive_glob_single_star(self):
+        assert DataRepoConfig._match_authority_pattern("workouts/foo.zwo", "workouts/*")
+        assert DataRepoConfig._match_authority_pattern("workouts/sub/bar.zwo", "workouts/*")
+
+    def test_glob_does_not_match_sibling_paths(self):
+        assert not DataRepoConfig._match_authority_pattern("other/foo.zwo", "workouts/**")
+
+    def test_exact_match(self):
+        assert DataRepoConfig._match_authority_pattern("workouts-history.md", "workouts-history.md")
+        assert not DataRepoConfig._match_authority_pattern(
+            "workouts-history.md.bak", "workouts-history.md"
+        )
+
+    def test_fnmatch_wildcard_no_slash(self):
+        assert DataRepoConfig._match_authority_pattern("S094_planning.json", "S*_planning.json")
+        assert not DataRepoConfig._match_authority_pattern("planning.json", "S*_planning.json")
+
+
+class TestResolveWriterAliasToHash:
+    """Helper _resolve_writer_alias_to_hash."""
+
+    def test_resolves_known_alias(self, tmp_repo: Path, writers_section: str):
+        _seed_operators_yaml(tmp_repo, writers_section)
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        assert cfg._resolve_writer_alias_to_hash("mac") == "b08921dae3e7"
+        assert cfg._resolve_writer_alias_to_hash("nas-prod") == "5e6f282f9f03"
+        assert cfg._resolve_writer_alias_to_hash("nas-preprod") == "8816403fa31c"
+
+    def test_unknown_alias_returns_none(self, tmp_repo: Path, writers_section: str):
+        _seed_operators_yaml(tmp_repo, writers_section)
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        assert cfg._resolve_writer_alias_to_hash("ghost") is None
+
+    def test_no_operators_yaml_returns_none(self, tmp_repo: Path):
+        cfg = DataRepoConfig(data_repo_path=tmp_repo)
+        assert cfg._resolve_writer_alias_to_hash("mac") is None


### PR DESCRIPTION
## Contexte

PR11a du plan iso-config S093-S096, Phase 3 PR D de l'ADR v5.

Premier des 5 sous-PRs PR11 (split validé par Stéphane) :
- **PR11a** (cette PR) — helper `resolve_read_path` + tests, no-op runtime
- PR11b — linter authority-coherence CI
- PR11c — refactor consumers (`weekly-reports/**`, `workouts-history.md`, etc.)
- PR11d — activation `TRAINING_DATA_WRITER_SCOPED=1` preprod + TNR canari par writer
- PR11e — flip prod après validation 24-48h

## Ce que fait la PR

Helper central côté `DataRepoConfig` pour faire converger les lectures consumer-side vers la subdir du writer autoritaire défini par `.operators.yaml::authority`, plutôt que de lire flat depuis la racine.

### Comportement

**Mode legacy (`writer_scoped=False`, défaut runtime)** : helper est un no-op, retourne `root_path / file_pattern` — comportement runtime inchangé pour tous les consumers tant que le flag `TRAINING_DATA_WRITER_SCOPED=1` n'est pas activé (PR11d/PR11e).

**Mode scoped (`writer_scoped=True`)** :
1. Itère `authority_rules` dans l'ordre de déclaration YAML
2. Premier `rule_pattern` qui matche `file_pattern` gagne (POSIX-style fnmatch + prefix-match pour `/**` et `/*`)
3. Résout l'alias en hash via section `writers` du `.operators.yaml` → retourne `root_path / <hash> / file_pattern`
4. Fallback graceful `root_path / file_pattern` + warning log si alias non résolvable ou pas de match (fichier potentiellement co-owned `shared_root_files`)

## API ajoutée à `DataRepoConfig`

- **`authority_rules`** property — extraction ordonnée de `.operators.yaml::authority` (premier match gagne, préserve l'ordre YAML)
- **`_resolve_writer_alias_to_hash(alias)`** — résolution `mac → b08921dae3e7`, etc., via section `writers`
- **`_match_authority_pattern(file_pattern, rule_pattern)`** staticmethod — match POSIX-style (prefix-match pour `/**` et `/*`, fnmatch.fnmatchcase sinon)
- **`resolve_read_path(file_pattern) -> Path`** — helper public consumer-side

Pas de change runtime visible (mode legacy actif par défaut). Le helper est purement additif.

## Pattern matching

Option A `fnmatch` validée par Stéphane (vs `pathlib.PurePath.match` limité < Python 3.13, vs mini-parser maison overkill). Sémantique :
- Suffixe `/**` ou `/*` → prefix-match récursif (ex. `workouts/**` matche `workouts/foo.zwo` ET `workouts/sub/bar.zwo`)
- Sinon → `fnmatch.fnmatchcase` exact (supporte `*`, `?`, `[abc]` non-récursifs)
- Premier match gagne dans l'ordre de déclaration YAML

## Tests

`tests/test_data_repo_resolve_read_path.py` — **21 tests** :

| Classe | Tests | Couverture |
|---|---|---|
| `TestResolveReadPathLegacyMode` | 2 | Mode legacy no-op (ignore `.operators.yaml`) |
| `TestResolveReadPathScopedMode` | 7 | Glob récursif, exact match, first-match-wins, no match fallback, alias non résolvable + warning, `.operators.yaml` absent, authority section absente |
| `TestAuthorityRulesProperty` | 4 | Empty si pas de yaml/section, préservation ordre, filtre entrées non-string |
| `TestMatchAuthorityPattern` | 5 | `/**` `/*` exact wildcard sibling exclusion |
| `TestResolveWriterAliasToHash` | 3 | Known/unknown alias/missing yaml |

Validation locale : 21/21 verts (`pytest tests/test_data_repo_resolve_read_path.py -v` en 1.31s).

## Rollback

Helper purement additif, aucun call site existant ne l'utilise. `git revert` triv si jamais. Mode legacy actif par défaut → zéro impact runtime même sans revert.

## Suite

- PR11b — linter authority-coherence (scan subdirs vs `.operators.yaml`, warn paths hors authority)
- PR11c — refactor consumers identifiés (`weekly-reports/**`, `workouts-history.md`, `monthly-reports/**` — audit list dans le plan §4 S095)
- PR11d — activation preprod + TNR canari par writer mac/nas-prod/nas-preprod
- PR11e — flip prod après validation 24-48h