### PR TITLE
test(monthly): lock AI-on default + clarify CD doc (PR4 iso-config)

### DIFF
--- a/docs/onboarding-zwift-foudre.md
+++ b/docs/onboarding-zwift-foudre.md
@@ -135,7 +135,7 @@ Sommeil, poids, HRV, et évaluation de ta forme du jour.
 | `get-coach-analysis` | Récupère une analyse passée |
 | `patch-coach-analysis` | Ajoute des notes à une analyse existante |
 | `analyze-training-patterns` | Analyse globale (planning + activités + métriques) |
-| `monthly-analysis` | Analyse mensuelle complète |
+| `monthly-analysis` | Analyse mensuelle complète (IA Mistral activée par défaut, désactivable via `--no-ai`) |
 | `get-recommendations` | Recommandations d'entraînement |
 
 📝 `patch-coach-analysis` ne remplace jamais ton analyse — elle ajoute des éléments traçables.

--- a/tests/test_monthly_analysis_fallback.py
+++ b/tests/test_monthly_analysis_fallback.py
@@ -256,3 +256,26 @@ class TestRunAIIntegration:
 
         mock_load.assert_called_once()
         assert result["ctl"] == 65
+
+
+class TestDefaultBehavior:
+    """PR4 iso-config — lock the AI-on-by-default behaviour for monthly-analysis."""
+
+    def test_defaults_enable_mistral_api_and_ai(self):
+        """Default constructor uses provider='mistral_api' and no_ai=False (AI enabled)."""
+        with (
+            patch("magma_cycling.monthly_analysis.get_data_config") as mock_dc,
+            patch("magma_cycling.monthly_analysis.get_ai_config") as mock_ai_config,
+            patch("magma_cycling.monthly_analysis.AIProviderFactory") as mock_factory,
+        ):
+            mock_dc.return_value.data_repo_path = MagicMock()
+            mock_ai_config.return_value.get_provider_config.return_value = {
+                "mistral_api_key": "test-key"
+            }
+            mock_factory.create.return_value = MagicMock()
+
+            analyzer = MonthlyAnalyzer(month="2026-02")
+
+        assert analyzer.provider == "mistral_api"
+        assert analyzer.no_ai is False
+        assert analyzer.ai_analyzer is not None


### PR DESCRIPTION
## Scope

PR4 du **plan iso-config S093-S096** = *« Confirmer comportement défaut monthly-analysis »* sans change runtime.

L'analyse du code confirme : `MonthlyAnalyzer.__init__()` utilise déjà `provider='mistral_api'` + `no_ai=False` par défaut depuis la PR initiale du handler (cf `magma_cycling/monthly_analysis.py:45`). PR4 = juste verrouiller cette doctrine + clarifier la doc CD.

## Changements

### `tests/test_monthly_analysis_fallback.py`
- Nouveau `TestDefaultBehavior.test_defaults_enable_mistral_api_and_ai` qui vérifie que `MonthlyAnalyzer(month=...)` instancie bien avec `provider='mistral_api'`, `no_ai=False`, `ai_analyzer is not None`.
- Protection contre régression future (changement involontaire des défauts).

### `docs/onboarding-zwift-foudre.md`
- Description de l'outil `monthly-analysis` clarifie : *« IA Mistral activée par défaut, désactivable via `--no-ai` »*.

## Test plan

- [x] `pytest tests/test_monthly_analysis_fallback.py::TestDefaultBehavior` ✅ passe
- [x] Pre-commit hooks (black/ruff/isort) ✅
- [ ] CI verte avant merge

## Notes

- Aucun change comportemental → pas besoin de version bump.
- Effort : 0.25j prévu par le plan.
- Rollback : trivial (git revert simple — pas d'impact runtime).