### PR TITLE
fix(health): populate weight + restingHR from Intervals.icu wellness (BT-015)

### DIFF
--- a/magma_cycling/health/intervals_provider.py
+++ b/magma_cycling/health/intervals_provider.py
@@ -151,8 +151,15 @@ class IntervalsHealthProvider(HealthProvider):
     # -- readiness -----------------------------------------------------------
 
     def get_readiness(self, target_date: date | None = None) -> TrainingReadiness | None:
-        """Evaluate readiness from Intervals.icu sleep data."""
-        sleep = self.get_sleep_summary(target_date or date.today())
+        """Evaluate readiness from Intervals.icu sleep + wellness data.
+
+        BT-015: weight and restingHR are also extracted from the same
+        wellness payload and populated on the returned TrainingReadiness.
+        Pre-fix, the IntervalsHealthProvider only read sleep and left
+        ``weight_kg`` / ``resting_hr`` null even when the payload had them.
+        """
+        target = target_date or date.today()
+        sleep = self.get_sleep_summary(target)
         if not sleep:
             return None
         ready = sleep.total_sleep_hours >= 6.5
@@ -167,13 +174,20 @@ class IntervalsHealthProvider(HealthProvider):
         veto = []
         if sleep.total_sleep_hours < 5.5:
             veto.append(f"Insufficient sleep: {sleep.total_sleep_hours}h")
+        w = self._get_wellness_day(target) or {}
+        weight_raw = w.get("weight")
+        resting_raw = w.get("restingHR")
+        weight_kg = float(weight_raw) if weight_raw else None
+        resting_hr = int(resting_raw) if resting_raw else None
         return TrainingReadiness(
-            date=target_date or date.today(),
+            date=target,
             sleep_hours=sleep.total_sleep_hours,
             sleep_score=sleep.sleep_score,
             ready_for_intense=ready,
             recommended_intensity=intensity,
             veto_reasons=veto,
+            weight_kg=weight_kg,
+            resting_hr=resting_hr,
         )
 
     # -- auth ----------------------------------------------------------------

--- a/tests/health/test_intervals_provider.py
+++ b/tests/health/test_intervals_provider.py
@@ -82,6 +82,50 @@ class TestGetReadiness:
         assert readiness.recommended_intensity == "endurance_max"
         assert len(readiness.veto_reasons) == 1
 
+    def test_populates_weight_and_resting_hr_bt015(self, mock_client):
+        # BT-015 — IntervalsHealthProvider must read `weight` + `restingHR`
+        # from the same wellness payload and populate them on the
+        # returned TrainingReadiness. Pre-fix the fields were always null.
+        mock_client.get_wellness.return_value = [
+            {
+                "id": "2026-05-21",
+                "sleepSecs": 27758,
+                "sleepScore": 86,
+                "weight": 69.4,
+                "restingHR": 46,
+            }
+        ]
+        provider = IntervalsHealthProvider(mock_client)
+        readiness = provider.get_readiness(date(2026, 5, 21))
+        assert readiness is not None
+        assert readiness.weight_kg == 69.4
+        assert readiness.resting_hr == 46
+
+    def test_weight_and_resting_hr_none_when_absent(self, provider):
+        # Default fixture has no weight / restingHR — must remain None.
+        readiness = provider.get_readiness(date(2026, 4, 15))
+        assert readiness is not None
+        assert readiness.weight_kg is None
+        assert readiness.resting_hr is None
+
+    def test_weight_and_resting_hr_none_when_zero_sentinel(self, mock_client):
+        # Intervals.icu uses 0 as "no measurement" sentinel for these
+        # fields ; reject them rather than letting Pydantic raise.
+        mock_client.get_wellness.return_value = [
+            {
+                "id": "2026-05-21",
+                "sleepSecs": 27000,
+                "sleepScore": 80,
+                "weight": 0,
+                "restingHR": 0,
+            }
+        ]
+        provider = IntervalsHealthProvider(mock_client)
+        readiness = provider.get_readiness(date(2026, 5, 21))
+        assert readiness is not None
+        assert readiness.weight_kg is None
+        assert readiness.resting_hr is None
+
 
 class TestBodyComposition:
     def test_returns_none(self, provider):


### PR DESCRIPTION
## Scope

Fix **BT-015** signalé par beta-tester via Beta Support 2026-05-26 (cf draft Claude Desktop msg 4146).

`IntervalsHealthProvider.get_readiness()` ne lisait pas les champs `weight` et `restingHR` du payload wellness Intervals.icu, alors qu'ils étaient bien présents. Conséquence : depuis le basculement du provider sleep vers Intervals (PR #381 fix BT-010), les beta-testeurs voyaient `weight_kg=null` + `resting_hr=null` dans `get-readiness` même quand leur payload contenait les valeurs.

## Changements

### `magma_cycling/health/intervals_provider.py`

- `get_readiness(target_date)` lit désormais `weight` + `restingHR` du même payload wellness que celui utilisé pour le sleep.
- Sentinel `0` traité comme "no measurement" → on retourne `None` proprement (évite `ValidationError` Pydantic `Field(gt=0)`).
- Aucun changement pour `WithingsHealthProvider` (toujours OK historiquement).

### `tests/health/test_intervals_provider.py`

+3 tests dans `TestGetReadiness` :
- `test_populates_weight_and_resting_hr_bt015` : payload avec weight + restingHR → champs populates.
- `test_weight_and_resting_hr_none_when_absent` : payload sans ces champs → `None`.
- `test_weight_and_resting_hr_none_when_zero_sentinel` : payload avec `0` sentinel → `None` (pas de crash Pydantic).

## Test plan

- [x] `pytest tests/health/test_intervals_provider.py` ✅ 19/19 (16 anciens + 3 nouveaux)
- [x] Pre-commit hooks (black/ruff/isort/pydocstyle/pycodestyle) ✅
- [ ] CI verte avant merge
- [ ] Smoke test live côté Beta Support : Max devrait revoir `weight_kg` et `resting_hr` populates dans `get-readiness` après merge + redeploy.

## Suite

Le ticket Beta Support reste ouvert tant que le smoke test live n'est pas confirmé. Je pingerai dès que la version est déployée.