### PR TITLE
fix(health): fallback to last known weight (BT-015 follow-up)

### DIFF
--- a/magma_cycling/daily_sync.py
+++ b/magma_cycling/daily_sync.py
@@ -45,6 +45,7 @@ from magma_cycling.config import (
     get_data_config,
     get_week_config,
 )
+from magma_cycling.health.weight_fallback import apply_weight_fallback
 from magma_cycling.insert_analysis import WorkoutHistoryManager
 from magma_cycling.prepare_analysis import PromptGenerator
 from magma_cycling.utils.cli import cli_main
@@ -253,6 +254,9 @@ class DailySync(
                     oldest=activity_date_str, newest=activity_date_str
                 )
                 wellness_pre = wellness_data[0] if wellness_data else None
+                wellness_pre = apply_weight_fallback(
+                    self.client, date.fromisoformat(activity_date_str), wellness_pre
+                )
             except Exception:
                 wellness_pre = None
 

--- a/magma_cycling/health/intervals_provider.py
+++ b/magma_cycling/health/intervals_provider.py
@@ -155,9 +155,11 @@ class IntervalsHealthProvider(HealthProvider):
 
         BT-015: weight and restingHR are also extracted from the same
         wellness payload and populated on the returned TrainingReadiness.
-        Pre-fix, the IntervalsHealthProvider only read sleep and left
-        ``weight_kg`` / ``resting_hr`` null even when the payload had them.
+        BT-015 follow-up: if the day J payload has no weight (e.g. FitnessSyncer
+        J+1 lag), fall back to the most recent ``weight > 0`` in the last 14 days.
         """
+        from magma_cycling.health.weight_fallback import get_last_known_weight
+
         target = target_date or date.today()
         sleep = self.get_sleep_summary(target)
         if not sleep:
@@ -178,6 +180,20 @@ class IntervalsHealthProvider(HealthProvider):
         weight_raw = w.get("weight")
         resting_raw = w.get("restingHR")
         weight_kg = float(weight_raw) if weight_raw else None
+        if weight_kg is None or weight_kg <= 0:
+            fallback_weight, fallback_date = get_last_known_weight(
+                self._client, target, max_days_back=14
+            )
+            if fallback_weight is not None:
+                weight_kg = fallback_weight
+                if fallback_date is not None:
+                    age = (target - fallback_date).days
+                    logger.info(
+                        "BT-015 weight fallback (readiness): %.1fkg from %s (%d days ago)",
+                        fallback_weight,
+                        fallback_date.isoformat(),
+                        age,
+                    )
         resting_hr = int(resting_raw) if resting_raw else None
         return TrainingReadiness(
             date=target,

--- a/magma_cycling/health/weight_fallback.py
+++ b/magma_cycling/health/weight_fallback.py
@@ -1,0 +1,84 @@
+"""Fallback to last known weight in a recent wellness window (BT-015 follow-up).
+
+When Intervals.icu wellness for day J has no weight (e.g. no real weighing and
+FitnessSyncer J+1 lag), look back up to ``max_days_back`` days and return the
+most recent ``weight > 0`` found in the wellness range.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def get_last_known_weight(
+    client: Any, target_date: date, max_days_back: int = 14
+) -> tuple[float | None, date | None]:
+    """Return (weight_kg, measurement_date) — last weight > 0 in [target-N, target]."""
+    start = target_date - timedelta(days=max_days_back)
+    try:
+        entries = client.get_wellness(oldest=start.isoformat(), newest=target_date.isoformat())
+    except Exception as exc:
+        logger.warning("weight fallback: wellness range fetch failed: %s", exc)
+        return None, None
+    if not entries:
+        return None, None
+    for entry in sorted(entries, key=lambda e: e.get("id", ""), reverse=True):
+        raw = entry.get("weight")
+        if not raw:
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if value <= 0:
+            continue
+        day_str = entry.get("id")
+        try:
+            day = date.fromisoformat(day_str) if day_str else None
+        except (TypeError, ValueError):
+            day = None
+        return value, day
+    return None, None
+
+
+def apply_weight_fallback(
+    client: Any,
+    target_date: date,
+    wellness: dict | None,
+    max_days_back: int = 14,
+) -> dict | None:
+    """Return a copy of ``wellness`` with ``weight`` filled from fallback if missing.
+
+    If ``wellness`` is None or already has ``weight > 0``, return it unchanged.
+    Otherwise look back up to ``max_days_back`` days for the last known weight.
+    Logs an info-level message when fallback fires, with the age of the picked value.
+    """
+    if wellness is None:
+        return None
+    raw = wellness.get("weight")
+    if raw:
+        try:
+            if float(raw) > 0:
+                return wellness
+        except (TypeError, ValueError):
+            pass
+    fallback_weight, fallback_date = get_last_known_weight(client, target_date, max_days_back)
+    if fallback_weight is None:
+        return wellness
+    patched = dict(wellness)
+    patched["weight"] = fallback_weight
+    if fallback_date is not None:
+        age = (target_date - fallback_date).days
+        logger.info(
+            "BT-015 weight fallback: using %.1fkg from %s (%d days ago)",
+            fallback_weight,
+            fallback_date.isoformat(),
+            age,
+        )
+    else:
+        logger.info("BT-015 weight fallback: using %.1fkg (unknown date)", fallback_weight)
+    return patched

--- a/magma_cycling/prepare_analysis.py
+++ b/magma_cycling/prepare_analysis.py
@@ -56,11 +56,13 @@ Metadata:
 import argparse
 import subprocess
 import sys
+from datetime import date as _date
 from datetime import datetime, timedelta
 from pathlib import Path
 
 from magma_cycling.api.intervals_client import IntervalsClient
 from magma_cycling.config import create_intervals_client, get_ai_config
+from magma_cycling.health.weight_fallback import apply_weight_fallback
 from magma_cycling.paths import get_project_root
 from magma_cycling.utils.cli import cli_main
 from magma_cycling.workflow_state import WorkflowState
@@ -166,6 +168,7 @@ def analyze_batch(api, unanalyzed_activities, generator, state, project_root):
             # Wellness
             wellness_data = api.get_wellness(oldest=date_str, newest=date_str)
             wellness = wellness_data[0] if wellness_data else None
+            wellness = apply_weight_fallback(api, _date.fromisoformat(date_str), wellness)
 
             # Workout planifié
             print("🔍 Recherche du workout planifié...")
@@ -543,6 +546,7 @@ def main():
     # Récupérer wellness
     wellness_data = api.get_wellness(oldest=date, newest=date)
     wellness = wellness_data[0] if wellness_data else None
+    wellness = apply_weight_fallback(api, _date.fromisoformat(date), wellness)
 
     # Récupérer le workout planifié si disponible
     print(f"   ✅ Activité : {activity.get('name', 'Séance')}")

--- a/magma_cycling/workflows/sync/ai_analysis.py
+++ b/magma_cycling/workflows/sync/ai_analysis.py
@@ -2,6 +2,7 @@
 
 from datetime import date, timedelta
 
+from magma_cycling.health.weight_fallback import apply_weight_fallback
 from magma_cycling.planning.control_tower import planning_tower
 from magma_cycling.prompts.prompt_builder import build_prompt, load_current_metrics
 
@@ -117,6 +118,9 @@ class AIAnalysisMixin:
                     oldest=activity_date_str, newest=activity_date_str
                 )
                 wellness_pre = wellness_data[0] if wellness_data else None
+                wellness_pre = apply_weight_fallback(
+                    self.client, date.fromisoformat(activity_date_str), wellness_pre
+                )
             except Exception:
                 wellness_pre = None
 

--- a/tests/health/test_intervals_provider.py
+++ b/tests/health/test_intervals_provider.py
@@ -126,6 +126,24 @@ class TestGetReadiness:
         assert readiness.weight_kg is None
         assert readiness.resting_hr is None
 
+    def test_weight_falls_back_to_last_known_bt015_followup(self, mock_client):
+        # BT-015 follow-up — when day J has no weight (FitnessSyncer J+1 lag),
+        # IntervalsHealthProvider.get_readiness must look back up to 14 days
+        # and return the most recent weight > 0 found in the window.
+        def get_wellness(oldest, newest):
+            if oldest == newest == "2026-05-28":
+                return [{"id": "2026-05-28", "sleepSecs": 27000, "sleepScore": 80}]
+            return [
+                {"id": "2026-05-25", "weight": 72.5},
+                {"id": "2026-05-28", "sleepSecs": 27000, "sleepScore": 80},
+            ]
+
+        mock_client.get_wellness.side_effect = get_wellness
+        provider = IntervalsHealthProvider(mock_client)
+        readiness = provider.get_readiness(date(2026, 5, 28))
+        assert readiness is not None
+        assert readiness.weight_kg == 72.5
+
 
 class TestBodyComposition:
     def test_returns_none(self, provider):

--- a/tests/health/test_weight_fallback.py
+++ b/tests/health/test_weight_fallback.py
@@ -1,0 +1,107 @@
+"""Tests for weight_fallback utility (BT-015 follow-up)."""
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from magma_cycling.health.weight_fallback import (
+    apply_weight_fallback,
+    get_last_known_weight,
+)
+
+
+class TestGetLastKnownWeight:
+    def test_returns_weight_from_target_day(self):
+        client = MagicMock()
+        client.get_wellness.return_value = [
+            {"id": "2026-05-28", "weight": 72.3},
+        ]
+        weight, day = get_last_known_weight(client, date(2026, 5, 28), max_days_back=14)
+        assert weight == 72.3
+        assert day == date(2026, 5, 28)
+
+    def test_falls_back_to_earlier_day(self):
+        client = MagicMock()
+        client.get_wellness.return_value = [
+            {"id": "2026-05-25", "weight": 72.5},
+            {"id": "2026-05-26"},  # no weight
+            {"id": "2026-05-27", "weight": 0},
+            {"id": "2026-05-28"},  # no weight (target day)
+        ]
+        weight, day = get_last_known_weight(client, date(2026, 5, 28), max_days_back=14)
+        assert weight == 72.5
+        assert day == date(2026, 5, 25)
+
+    def test_returns_none_when_no_entries(self):
+        client = MagicMock()
+        client.get_wellness.return_value = []
+        weight, day = get_last_known_weight(client, date(2026, 5, 28))
+        assert weight is None
+        assert day is None
+
+    def test_returns_none_when_no_weight_in_window(self):
+        client = MagicMock()
+        client.get_wellness.return_value = [
+            {"id": "2026-05-26", "weight": 0},
+            {"id": "2026-05-27"},
+            {"id": "2026-05-28", "weight": None},
+        ]
+        weight, day = get_last_known_weight(client, date(2026, 5, 28))
+        assert weight is None
+        assert day is None
+
+    def test_queries_correct_range(self):
+        client = MagicMock()
+        client.get_wellness.return_value = []
+        get_last_known_weight(client, date(2026, 5, 28), max_days_back=14)
+        client.get_wellness.assert_called_once_with(oldest="2026-05-14", newest="2026-05-28")
+
+    def test_returns_none_when_client_raises(self):
+        client = MagicMock()
+        client.get_wellness.side_effect = RuntimeError("boom")
+        weight, day = get_last_known_weight(client, date(2026, 5, 28))
+        assert weight is None
+        assert day is None
+
+
+class TestApplyWeightFallback:
+    def test_none_wellness_passes_through(self):
+        client = MagicMock()
+        result = apply_weight_fallback(client, date(2026, 5, 28), None)
+        assert result is None
+        client.get_wellness.assert_not_called()
+
+    def test_existing_weight_unchanged(self):
+        client = MagicMock()
+        wellness = {"id": "2026-05-28", "weight": 72.0, "sleepSecs": 27000}
+        result = apply_weight_fallback(client, date(2026, 5, 28), wellness)
+        assert result is wellness
+        client.get_wellness.assert_not_called()
+
+    def test_fills_missing_weight_from_earlier_day(self):
+        client = MagicMock()
+        client.get_wellness.return_value = [
+            {"id": "2026-05-25", "weight": 72.5},
+            {"id": "2026-05-28"},
+        ]
+        wellness = {"id": "2026-05-28", "sleepSecs": 27000}
+        result = apply_weight_fallback(client, date(2026, 5, 28), wellness)
+        assert result["weight"] == 72.5
+        assert result["sleepSecs"] == 27000
+        assert wellness.get("weight") is None  # original not mutated
+
+    def test_zero_weight_triggers_fallback(self):
+        client = MagicMock()
+        client.get_wellness.return_value = [
+            {"id": "2026-05-25", "weight": 72.5},
+            {"id": "2026-05-28", "weight": 0},
+        ]
+        wellness = {"id": "2026-05-28", "weight": 0}
+        result = apply_weight_fallback(client, date(2026, 5, 28), wellness)
+        assert result["weight"] == 72.5
+
+    def test_no_fallback_available_leaves_wellness_unchanged(self):
+        client = MagicMock()
+        client.get_wellness.return_value = []
+        wellness = {"id": "2026-05-28", "sleepSecs": 27000}
+        result = apply_weight_fallback(client, date(2026, 5, 28), wellness)
+        assert result == wellness


### PR DESCRIPTION
## Contexte

Le fix BT-015 initial (commit 7b2a2d8) lisait `weight` du wellness day J via Intervals.icu, mais l'API renvoie `weight=null` pour J quand pas de pesée réelle — même quand la UI browser affiche la valeur héritée avec `tempWeight=true`.

Conséquence : Max (synchro Withings → FitnessSyncer → Intervals.icu nocturne, jamais de pesée jour J) avait toujours `weight_kg=null` malgré le fix sur v3.51.1.

## Changement

Utility `magma_cycling/health/weight_fallback.py` :
- `get_last_known_weight(client, target_date, max_days_back=14)` → query range, retourne `(weight_kg, measurement_date)` ou `(None, None)`.
- `apply_weight_fallback(client, target_date, wellness, max_days_back=14)` → retourne une copie du dict wellness avec `weight` rempli si manquant/zéro.

Logging info-level quand le fallback déclenche, avec l'âge de la mesure.

## Surfaces patchées

- `IntervalsHealthProvider.get_readiness()` — surface MCP `get-readiness`
- `prepare_analysis.py` ×2 — CLI `prepare-analysis`
- `daily_sync.py` — auto-servo metrics extraction
- `workflows/sync/ai_analysis.py` — sync auto AI analysis (Coach AI prompt)

## Hors scope

- `sync_intervals.py:197` (workouts-history batch) — utilise un pré-fetch range séparé, à patcher dans une PR ultérieure si besoin.

## Tests

- 11 nouveaux tests `tests/health/test_weight_fallback.py`
- 1 test `test_weight_falls_back_to_last_known_bt015_followup` dans `test_intervals_provider.py`
- Suite complète (804 tests workflows sync/health/MCP handlers) : verte locale

## Test plan

- [ ] Vérifier en prod sur compte Max (FitnessSyncer J+1) que `weight_kg` est désormais peuplé
- [ ] Vérifier qu'un compte avec pesée réelle quotidienne (e.g. Withings direct) garde le même comportement (pas de fallback déclenché)
- [ ] Confirmer que le log INFO apparaît dans les MCP logs quand fallback fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)