### PR TITLE
feat(athlete-context): persist Les Copains 81km granfondo objective

### DIFF
--- a/magma_cycling/config/athlete_context.yaml
+++ b/magma_cycling/config/athlete_context.yaml
@@ -3,7 +3,17 @@ athlete:
   age: 54
   training_since: "2023-06"
   platform: "Home trainer (virtuel)"
-  objectives: "Progression forme generale, pas de competition"
+  objectives: "Objectif prioritaire : preparation Les Copains 81km (granfondo, 2026-07-04). Progression forme generale en dehors des fenetres de prep."
+  objectifs:
+    prioritaire:
+      nom: "Les Copains 81km"
+      type: granfondo
+      date: 2026-07-04
+      priorite: A
+      distance_km: 81
+      notes: |
+        Build S098-S099, taper + race week S100.
+        Pas d'application autonome auto-servo sur cette fenetre.
   constraints:
     - "Dette de sommeil chronique (moyenne 5-6h/nuit)"
     - "Travail terrain (technicien telecom), fatigue physique variable selon chantiers"


### PR DESCRIPTION
## Contexte

Le coach prépare une fondo (Les Copains 81km, 2026-07-04) — analyse de risque MCP autonome / prep coach a identifié 3 chantiers (auto-servo, persistance, force=true). Cette PR couvre le point 2 : **persister la date-objectif** côté `athlete_context.yaml` pour rendre les prochaines générations / contextes coach fondo-aware.

## Changement

`magma_cycling/config/athlete_context.yaml` :

- **Étend la string `objectives`** — visible directement dans le prompt coach via `prompt_builder.py:235` (`"Objectifs: ..."`). Le coach AI voit la fondo dès le prochain appel sans modif code.
- **Ajoute une section structurée `objectifs.prioritaire`** (nom, type, date, priorité, distance_km, notes) pour exploitation code future si on décide d'étendre `WeeklyPlanner.load_periodization_context()` à les consommer.

## Hors scope

- Injection structurée dans le prompt — `prompt_builder` lit uniquement la string `objectives`. La string suffit pour rendre la fondo visible coach AI immédiatement. Section `objectifs` reste dormant en attente d'usage.
- WeeklyPlanner restera **fondo-aveugle structurellement** : coach gère la périodisation manuellement (mode `prompt_only` + `modify-session-details`), c'est la posture validée.
- Auto-servo fondo-aware — point 1 de l'analyse, traité par revue manuelle coach (pas de chantier code).

## Test plan

- [x] YAML valide (check yaml pre-commit OK)
- [ ] Vérifier que la string `objectives` étendue apparaît bien dans le prompt coach lors du prochain `weekly-planner` ou `prepare-analysis`
- [ ] Vérifier que les contraintes existantes (`constraints`, `bike_setup`, `system_context`) restent inchangées

🤖 Generated with [Claude Code](https://claude.com/claude-code)