### PR TITLE
revert: athlete-context fondo objective (RGPD/PII leak in build bundle)

### DIFF
--- a/magma_cycling/config/athlete_context.yaml
+++ b/magma_cycling/config/athlete_context.yaml
@@ -3,17 +3,7 @@ athlete:
   age: 54
   training_since: "2023-06"
   platform: "Home trainer (virtuel)"
-  objectives: "Objectif prioritaire : preparation Les Copains 81km (granfondo, 2026-07-04). Progression forme generale en dehors des fenetres de prep."
-  objectifs:
-    prioritaire:
-      nom: "Les Copains 81km"
-      type: granfondo
-      date: 2026-07-04
-      priorite: A
-      distance_km: 81
-      notes: |
-        Build S098-S099, taper + race week S100.
-        Pas d'application autonome auto-servo sur cette fenetre.
+  objectives: "Progression forme generale, pas de competition"
   constraints:
     - "Dette de sommeil chronique (moyenne 5-6h/nuit)"
     - "Travail terrain (technicien telecom), fatigue physique variable selon chantiers"


### PR DESCRIPTION
## Contexte

PR #397 a ajouté la fondo (« Les Copains 81km, 2026-07-04 ») dans `magma_cycling/config/athlete_context.yaml`.

**Problème non anticipé au moment du commit** : ce YAML est embarqué dans le bundle PyInstaller (`packaging/magma-cycling.spec:20-21`), donc distribué aux beta-testeurs Windows/macOS à chaque release. L'ajout fondo expose :

- Événement futur identifiable (nom + date)
- Plan préparation (build S098-S099, taper + race week S100)

→ leak de données personnelles dans le build public, aggravation du leak pré-existant (nom, âge, métier, contraintes santé).

## Changement

Revert de la PR #397 — `athlete_context.yaml` revient à l'état pré-fondo. Stoppe l'aggravation immédiate.

## Suites à discuter (hors scope de cette PR)

Le leak pré-existant (profil de l'auteur dans le bundle public) reste sur la table. Options à arbitrer :
- Migration iso-config (plan S093-S096) : déplacer le profil réel dans le repo `training-logs` privé, garder dans le bundle un template générique anonyme.
- Édit local hors-git (la persistance fondo serait posée uniquement sur la machine dev, hors du repo public).
- Inline minimal anonymisé : remplacer la chaîne `objectives` par une mention générique (« préparation événement sportif été 2026 ») sans nom/date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)