### PR TITLE
feat(athlete-profile): persist priority_objective via MCP (user YAML, bundle untouched)

### DIFF
--- a/magma_cycling/_mcp/handlers/athlete.py
+++ b/magma_cycling/_mcp/handlers/athlete.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from magma_cycling._mcp._utils import mcp_response, suppress_stdout_stderr
 from magma_cycling.config.geo import GeoPoint, load_home_location, save_home_location
+from magma_cycling.config.objectives import (
+    PriorityObjective,
+    clear_priority_objective,
+    load_priority_objective,
+    save_priority_objective,
+)
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "handle_get_athlete_profile",
@@ -17,7 +26,7 @@ __all__ = [
 
 # Local-only fields routed to the athlete YAML (not Intervals.icu).
 # Extend this set as more portable fields land (PR5 iso-config and beyond).
-_LOCAL_FIELDS = frozenset({"home_location"})
+_LOCAL_FIELDS = frozenset({"home_location", "priority_objective"})
 
 
 async def handle_get_athlete_profile(args: dict) -> list[TextContent]:
@@ -73,6 +82,11 @@ async def handle_get_athlete_profile(args: dict) -> list[TextContent]:
         home = load_home_location()
         result["home_location"] = home.model_dump(exclude_none=True) if home else None
 
+        priority = load_priority_objective()
+        result["priority_objective"] = (
+            priority.model_dump(mode="json", exclude_none=True) if priority else None
+        )
+
         return mcp_response(result)
 
     except Exception as e:
@@ -98,6 +112,22 @@ async def handle_update_athlete_profile(args: dict) -> list[TextContent]:
                 save_home_location(location)
                 updated_fields.append("home_location")
                 current_values["home_location"] = location.model_dump(exclude_none=True)
+
+            if "priority_objective" in local_updates:
+                raw = local_updates["priority_objective"]
+                if raw is None:
+                    cleared = clear_priority_objective()
+                    updated_fields.append("priority_objective")
+                    current_values["priority_objective"] = None
+                    if cleared is None:
+                        logger.debug("priority_objective clear request with no existing value")
+                else:
+                    objective = PriorityObjective.model_validate(raw)
+                    save_priority_objective(objective)
+                    updated_fields.append("priority_objective")
+                    current_values["priority_objective"] = objective.model_dump(
+                        mode="json", exclude_none=True
+                    )
 
             # 2. Remote fields (Intervals.icu)
             if remote_updates:

--- a/magma_cycling/_mcp/schemas/athlete.py
+++ b/magma_cycling/_mcp/schemas/athlete.py
@@ -58,6 +58,41 @@ def get_tools() -> list[Tool]:
                                 "required": ["lat", "lon"],
                                 "additionalProperties": False,
                             },
+                            "priority_objective": {
+                                "description": (
+                                    "Priority training objective (event-style "
+                                    "goal with target date). Stored in the user "
+                                    "athlete YAML — never in the bundle. Pass "
+                                    "null to clear an existing objective."
+                                ),
+                                "oneOf": [
+                                    {"type": "null"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {"type": "string", "minLength": 1},
+                                            "type": {"type": "string", "minLength": 1},
+                                            "target_date": {
+                                                "type": "string",
+                                                "format": "date",
+                                                "description": "YYYY-MM-DD",
+                                            },
+                                            "priority": {
+                                                "type": "string",
+                                                "enum": ["A", "B", "C"],
+                                                "default": "A",
+                                            },
+                                            "distance_km": {
+                                                "type": "number",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "notes": {"type": "string"},
+                                        },
+                                        "required": ["name", "type", "target_date"],
+                                        "additionalProperties": False,
+                                    },
+                                ],
+                            },
                         },
                     },
                 },

--- a/magma_cycling/config/_yaml_io.py
+++ b/magma_cycling/config/_yaml_io.py
@@ -1,0 +1,71 @@
+"""Shared YAML I/O primitives for user-scoped configuration files.
+
+Used by ``geo`` (home_location) and ``objectives`` (priority_objective) — and
+any future portable field stored in the user athlete YAML.
+
+Security posture:
+- Writes go through ``atomic_write_yaml`` which uses ``os.open`` with explicit
+  ``0o600`` mode at creation time (no TOCTOU window between ``open`` and
+  ``chmod``), ``fsync`` before atomic ``replace``, and a PID-tagged temp name
+  so concurrent writes from the same user do not collide.
+- Parent directory is created with ``0o700`` when absent (existing dirs are
+  left alone — responsibility delegated upstream).
+- Reads silently fall back to ``{}`` on missing / malformed YAML and log a
+  short ``warning`` (no traceback) so the file contents are not echoed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def read_yaml(path: Path) -> dict:
+    """Read a YAML file, returning {} for missing / malformed / non-dict roots.
+
+    Logs a short warning (no traceback) on parse errors — the malformed
+    payload is not echoed.
+    """
+    if not path.exists():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except yaml.YAMLError:
+        logger.warning("YAML at %s is malformed; ignoring", path)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def atomic_write_yaml(path: Path, data: dict) -> None:
+    """Atomic YAML write to ``path`` with 0o600 perms set at creation time.
+
+    Sequence:
+    1. ``mkdir`` parent with mode 0o700 if it does not exist (no-op if already
+       present — caller owns existing perms).
+    2. ``os.open`` a PID-tagged temp file with ``O_WRONLY|O_CREAT|O_TRUNC|
+       O_EXCL`` and mode 0o600 (perms applied atomically at creation).
+    3. Write + ``fsync`` to flush data + metadata to disk.
+    4. ``os.replace`` for atomic crash-safe substitution.
+    5. Cleanup the temp file in ``finally`` if replace did not run.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    tmp = path.with_suffix(f"{path.suffix}.tmp.{os.getpid()}")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_EXCL
+    fd = os.open(tmp, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            yaml.safe_dump(data, fh, default_flow_style=False, sort_keys=False, allow_unicode=True)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass

--- a/magma_cycling/config/_yaml_io.py
+++ b/magma_cycling/config/_yaml_io.py
@@ -12,6 +12,13 @@ Security posture:
   left alone — responsibility delegated upstream).
 - Reads silently fall back to ``{}`` on missing / malformed YAML and log a
   short ``warning`` (no traceback) so the file contents are not echoed.
+
+Platform note: POSIX file permission modes (0o600, 0o700) are **not
+enforced on Windows** — the OS ignores the ``mode`` argument of ``os.open``
+and ``Path.mkdir``. On Windows hosts, user data confidentiality relies on
+NTFS ACLs (out of scope here). The hardening applied in this module
+protects macOS and Linux deployments fully; Windows hardening would be a
+separate workstream (see INFRA-001 for the existing skip convention).
 """
 
 from __future__ import annotations

--- a/magma_cycling/config/data_repo.py
+++ b/magma_cycling/config/data_repo.py
@@ -72,6 +72,11 @@ INTELLIGENCE_DATA_DIR_ENV = "INTELLIGENCE_DATA_DIR"
 #: portabilité). Fallback final = ``paths.get_athlete_yaml_path()`` (legacy
 #: user config dir) quand aucune des deux options n'est disponible (boot
 #: initial sans repo, dev sans env).
+#:
+#: ⚠️ ATHLETE_CONFIG_PATH = test / power-user only. Une valeur mal pointée
+#: route TOUTES les écritures `athlete.*` (home_location, priority_objective,
+#: ...) vers ce chemin, sans validation supplémentaire. Ne pas exposer dans
+#: une UI utilisateur ; usage attendu = tests automatisés et debug ciblé.
 ATHLETE_CONFIG_PATH_ENV = "ATHLETE_CONFIG_PATH"
 
 #: Nom du fichier d'index `.operators.yaml` à la racine du repo.

--- a/magma_cycling/config/geo.py
+++ b/magma_cycling/config/geo.py
@@ -19,12 +19,11 @@ Migration noop : if ``home_location`` is absent from the YAML,
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 
-import yaml
 from pydantic import BaseModel, ConfigDict, Field
 
+from magma_cycling.config._yaml_io import atomic_write_yaml, read_yaml
 from magma_cycling.config.data_repo import resolve_athlete_yaml_path
 
 logger = logging.getLogger(__name__)
@@ -43,28 +42,6 @@ class GeoPoint(BaseModel):
     )
 
 
-def _atomic_write_yaml(path: Path, data: dict) -> None:
-    """Atomic YAML write via tmp + replace, preserves perms via 0o600."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with tmp.open("w", encoding="utf-8") as fh:
-        yaml.safe_dump(data, fh, default_flow_style=False, sort_keys=False, allow_unicode=True)
-    os.chmod(tmp, 0o600)
-    tmp.replace(path)
-
-
-def _read_yaml(path: Path) -> dict:
-    if not path.exists():
-        return {}
-    try:
-        with path.open(encoding="utf-8") as fh:
-            data = yaml.safe_load(fh) or {}
-    except yaml.YAMLError:
-        logger.exception("Failed to parse %s", path)
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
 def load_home_location(path: Path | None = None) -> GeoPoint | None:
     """Read ``athlete.home_location`` from the YAML.
 
@@ -72,14 +49,14 @@ def load_home_location(path: Path | None = None) -> GeoPoint | None:
     (migration-noop semantics for pre-MCT-XXX-0 configs).
     """
     yaml_path = path or resolve_athlete_yaml_path()
-    data = _read_yaml(yaml_path)
+    data = read_yaml(yaml_path)
     raw = (data.get("athlete") or {}).get("home_location")
     if not raw:
         return None
     try:
         return GeoPoint.model_validate(raw)
     except Exception:
-        logger.exception("Invalid home_location in %s, ignoring", yaml_path)
+        logger.warning("home_location in %s failed pydantic validation; ignoring", yaml_path)
         return None
 
 
@@ -91,11 +68,11 @@ def save_home_location(location: GeoPoint, path: Path | None = None) -> Path:
     resolved path written.
     """
     yaml_path = path or resolve_athlete_yaml_path()
-    data = _read_yaml(yaml_path)
+    data = read_yaml(yaml_path)
     athlete = data.get("athlete")
     if not isinstance(athlete, dict):
         athlete = {}
         data["athlete"] = athlete
     athlete["home_location"] = location.model_dump(exclude_none=True)
-    _atomic_write_yaml(yaml_path, data)
+    atomic_write_yaml(yaml_path, data)
     return yaml_path

--- a/magma_cycling/config/objectives.py
+++ b/magma_cycling/config/objectives.py
@@ -16,13 +16,12 @@ Migration noop: if ``priority_objective`` is absent from the YAML,
 from __future__ import annotations
 
 import logging
-import os
 from datetime import date
 from pathlib import Path
 
-import yaml
 from pydantic import BaseModel, ConfigDict, Field
 
+from magma_cycling.config._yaml_io import atomic_write_yaml, read_yaml
 from magma_cycling.config.data_repo import resolve_athlete_yaml_path
 
 logger = logging.getLogger(__name__)
@@ -45,39 +44,17 @@ class PriorityObjective(BaseModel):
     notes: str | None = Field(default=None, description="Free-form notes")
 
 
-def _atomic_write_yaml(path: Path, data: dict) -> None:
-    """Atomic YAML write via tmp + replace, preserves perms via 0o600."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with tmp.open("w", encoding="utf-8") as fh:
-        yaml.safe_dump(data, fh, default_flow_style=False, sort_keys=False, allow_unicode=True)
-    os.chmod(tmp, 0o600)
-    tmp.replace(path)
-
-
-def _read_yaml(path: Path) -> dict:
-    if not path.exists():
-        return {}
-    try:
-        with path.open(encoding="utf-8") as fh:
-            data = yaml.safe_load(fh) or {}
-    except yaml.YAMLError:
-        logger.exception("Failed to parse %s", path)
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
 def load_priority_objective(path: Path | None = None) -> PriorityObjective | None:
     """Read ``athlete.priority_objective`` from the user YAML."""
     yaml_path = path or resolve_athlete_yaml_path()
-    data = _read_yaml(yaml_path)
+    data = read_yaml(yaml_path)
     raw = (data.get("athlete") or {}).get("priority_objective")
     if not raw:
         return None
     try:
         return PriorityObjective.model_validate(raw)
     except Exception:
-        logger.exception("Invalid priority_objective in %s, ignoring", yaml_path)
+        logger.warning("priority_objective in %s failed pydantic validation; ignoring", yaml_path)
         return None
 
 
@@ -89,14 +66,14 @@ def save_priority_objective(obj: PriorityObjective, path: Path | None = None) ->
     never touched — only the resolved user file. Returns the path written.
     """
     yaml_path = path or resolve_athlete_yaml_path()
-    data = _read_yaml(yaml_path)
+    data = read_yaml(yaml_path)
     athlete = data.get("athlete")
     if not isinstance(athlete, dict):
         athlete = {}
         data["athlete"] = athlete
     payload = obj.model_dump(mode="json", exclude_none=True)
     athlete["priority_objective"] = payload
-    _atomic_write_yaml(yaml_path, data)
+    atomic_write_yaml(yaml_path, data)
     return yaml_path
 
 
@@ -109,10 +86,10 @@ def clear_priority_objective(path: Path | None = None) -> Path | None:
     yaml_path = path or resolve_athlete_yaml_path()
     if not yaml_path.exists():
         return None
-    data = _read_yaml(yaml_path)
+    data = read_yaml(yaml_path)
     athlete = data.get("athlete")
     if not isinstance(athlete, dict) or "priority_objective" not in athlete:
         return None
     athlete.pop("priority_objective", None)
-    _atomic_write_yaml(yaml_path, data)
+    atomic_write_yaml(yaml_path, data)
     return yaml_path

--- a/magma_cycling/config/objectives.py
+++ b/magma_cycling/config/objectives.py
@@ -1,0 +1,118 @@
+"""Priority training objective stored in the athlete YAML.
+
+Hosts :class:`PriorityObjective` (event-style training goal with target date)
+and the ``priority_objective`` read/write helpers backing the
+``update-athlete-profile`` MCP handler dispatch (see
+``magma_cycling/_mcp/handlers/athlete.py``).
+
+The data lives in the athlete YAML resolved by
+:func:`magma_cycling.config.data_repo.resolve_athlete_yaml_path` — the
+**user-local** YAML, never the bundle. The bundle stays generic/template.
+
+Migration noop: if ``priority_objective`` is absent from the YAML,
+:func:`load_priority_objective` returns ``None``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import date
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+from magma_cycling.config.data_repo import resolve_athlete_yaml_path
+
+logger = logging.getLogger(__name__)
+
+
+class PriorityObjective(BaseModel):
+    """A priority training objective with a target date.
+
+    Mirrors the ``TrainingObjective`` dataclass in ``planning_manager`` but
+    typed as a pydantic model so it can be validated at the MCP boundary.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(min_length=1, description="Event or objective name")
+    type: str = Field(min_length=1, description="granfondo, race, ftp_test, ...")
+    target_date: date = Field(description="Target date (YYYY-MM-DD)")
+    priority: str = Field(default="A", description="A, B, C")
+    distance_km: float | None = Field(default=None, gt=0, description="Optional distance")
+    notes: str | None = Field(default=None, description="Free-form notes")
+
+
+def _atomic_write_yaml(path: Path, data: dict) -> None:
+    """Atomic YAML write via tmp + replace, preserves perms via 0o600."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, default_flow_style=False, sort_keys=False, allow_unicode=True)
+    os.chmod(tmp, 0o600)
+    tmp.replace(path)
+
+
+def _read_yaml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except yaml.YAMLError:
+        logger.exception("Failed to parse %s", path)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_priority_objective(path: Path | None = None) -> PriorityObjective | None:
+    """Read ``athlete.priority_objective`` from the user YAML."""
+    yaml_path = path or resolve_athlete_yaml_path()
+    data = _read_yaml(yaml_path)
+    raw = (data.get("athlete") or {}).get("priority_objective")
+    if not raw:
+        return None
+    try:
+        return PriorityObjective.model_validate(raw)
+    except Exception:
+        logger.exception("Invalid priority_objective in %s, ignoring", yaml_path)
+        return None
+
+
+def save_priority_objective(obj: PriorityObjective, path: Path | None = None) -> Path:
+    """Persist ``obj`` under ``athlete.priority_objective`` in the user YAML.
+
+    Reads the existing YAML (or starts from an empty skeleton), updates the
+    ``athlete.priority_objective`` key, and writes back atomically. Bundle is
+    never touched — only the resolved user file. Returns the path written.
+    """
+    yaml_path = path or resolve_athlete_yaml_path()
+    data = _read_yaml(yaml_path)
+    athlete = data.get("athlete")
+    if not isinstance(athlete, dict):
+        athlete = {}
+        data["athlete"] = athlete
+    payload = obj.model_dump(mode="json", exclude_none=True)
+    athlete["priority_objective"] = payload
+    _atomic_write_yaml(yaml_path, data)
+    return yaml_path
+
+
+def clear_priority_objective(path: Path | None = None) -> Path | None:
+    """Remove ``athlete.priority_objective`` from the user YAML if present.
+
+    Returns the path modified, or ``None`` if the YAML did not exist or had
+    no priority objective set.
+    """
+    yaml_path = path or resolve_athlete_yaml_path()
+    if not yaml_path.exists():
+        return None
+    data = _read_yaml(yaml_path)
+    athlete = data.get("athlete")
+    if not isinstance(athlete, dict) or "priority_objective" not in athlete:
+        return None
+    athlete.pop("priority_objective", None)
+    _atomic_write_yaml(yaml_path, data)
+    return yaml_path

--- a/tests/config/test_objectives.py
+++ b/tests/config/test_objectives.py
@@ -1,0 +1,213 @@
+"""Tests for the priority_objective schema + read/write helpers."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from magma_cycling.config.objectives import (
+    PriorityObjective,
+    clear_priority_objective,
+    load_priority_objective,
+    save_priority_objective,
+)
+
+
+class TestPriorityObjective:
+    def test_minimal_valid(self):
+        obj = PriorityObjective(
+            name="Les Copains 81km",
+            type="granfondo",
+            target_date=date(2026, 7, 4),
+        )
+        assert obj.name == "Les Copains 81km"
+        assert obj.type == "granfondo"
+        assert obj.target_date == date(2026, 7, 4)
+        assert obj.priority == "A"
+        assert obj.distance_km is None
+        assert obj.notes is None
+
+    def test_all_fields(self):
+        obj = PriorityObjective(
+            name="Race",
+            type="race",
+            target_date=date(2026, 7, 4),
+            priority="B",
+            distance_km=81.0,
+            notes="Build + taper",
+        )
+        assert obj.priority == "B"
+        assert obj.distance_km == 81.0
+        assert obj.notes == "Build + taper"
+
+    def test_empty_name_rejected(self):
+        with pytest.raises(ValidationError):
+            PriorityObjective(name="", type="granfondo", target_date=date(2026, 7, 4))
+
+    def test_zero_distance_rejected(self):
+        with pytest.raises(ValidationError):
+            PriorityObjective(
+                name="x", type="granfondo", target_date=date(2026, 7, 4), distance_km=0
+            )
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            PriorityObjective(
+                name="x",
+                type="granfondo",
+                target_date=date(2026, 7, 4),
+                unknown="oops",  # type: ignore[call-arg]
+            )
+
+    def test_frozen_cannot_mutate(self):
+        obj = PriorityObjective(name="x", type="granfondo", target_date=date(2026, 7, 4))
+        with pytest.raises(ValidationError):
+            obj.priority = "C"  # type: ignore[misc]
+
+
+class TestLoadPriorityObjective:
+    def test_returns_none_when_yaml_absent(self, tmp_path: Path):
+        assert load_priority_objective(tmp_path / "absent.yaml") is None
+
+    def test_returns_none_when_key_absent(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text("athlete:\n  name: Test\n", encoding="utf-8")
+        assert load_priority_objective(yaml_path) is None
+
+    def test_returns_none_when_athlete_section_missing(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text("not_athlete: {}\n", encoding="utf-8")
+        assert load_priority_objective(yaml_path) is None
+
+    def test_loads_valid_objective(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text(
+            "athlete:\n"
+            "  priority_objective:\n"
+            "    name: Les Copains 81km\n"
+            "    type: granfondo\n"
+            "    target_date: 2026-07-04\n"
+            "    priority: A\n"
+            "    distance_km: 81\n"
+            "    notes: Build + taper\n",
+            encoding="utf-8",
+        )
+        obj = load_priority_objective(yaml_path)
+        assert obj is not None
+        assert obj.name == "Les Copains 81km"
+        assert obj.target_date == date(2026, 7, 4)
+        assert obj.distance_km == 81.0
+
+    def test_invalid_objective_returns_none(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text(
+            "athlete:\n  priority_objective:\n    name: x\n",  # missing required
+            encoding="utf-8",
+        )
+        assert load_priority_objective(yaml_path) is None
+
+    def test_malformed_yaml_returns_none(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text("not: valid: yaml: [", encoding="utf-8")
+        assert load_priority_objective(yaml_path) is None
+
+
+class TestSavePriorityObjective:
+    def test_creates_yaml_when_absent(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        obj = PriorityObjective(
+            name="Les Copains 81km",
+            type="granfondo",
+            target_date=date(2026, 7, 4),
+            distance_km=81.0,
+        )
+        result = save_priority_objective(obj, yaml_path)
+        assert result == yaml_path
+        assert yaml_path.is_file()
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        po = data["athlete"]["priority_objective"]
+        assert po["name"] == "Les Copains 81km"
+        assert po["target_date"] == "2026-07-04"
+        assert po["distance_km"] == 81.0
+
+    def test_preserves_other_athlete_fields(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text(
+            "athlete:\n  name: Test\n  age: 54\n  home_location:\n    lat: 1.0\n    lon: 2.0\n",
+            encoding="utf-8",
+        )
+        obj = PriorityObjective(name="x", type="granfondo", target_date=date(2026, 7, 4))
+        save_priority_objective(obj, yaml_path)
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        assert data["athlete"]["name"] == "Test"
+        assert data["athlete"]["age"] == 54
+        assert data["athlete"]["home_location"]["lat"] == 1.0
+        assert data["athlete"]["priority_objective"]["name"] == "x"
+
+    def test_overwrites_existing(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        save_priority_objective(
+            PriorityObjective(name="old", type="granfondo", target_date=date(2026, 1, 1)),
+            yaml_path,
+        )
+        save_priority_objective(
+            PriorityObjective(name="new", type="granfondo", target_date=date(2026, 7, 4)),
+            yaml_path,
+        )
+        loaded = load_priority_objective(yaml_path)
+        assert loaded is not None
+        assert loaded.name == "new"
+        assert loaded.target_date == date(2026, 7, 4)
+
+    def test_omits_none_fields(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        save_priority_objective(
+            PriorityObjective(name="x", type="granfondo", target_date=date(2026, 7, 4)),
+            yaml_path,
+        )
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        po = data["athlete"]["priority_objective"]
+        assert "distance_km" not in po
+        assert "notes" not in po
+
+
+class TestClearPriorityObjective:
+    def test_returns_none_when_yaml_absent(self, tmp_path: Path):
+        assert clear_priority_objective(tmp_path / "absent.yaml") is None
+
+    def test_returns_none_when_key_absent(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text("athlete:\n  name: Test\n", encoding="utf-8")
+        assert clear_priority_objective(yaml_path) is None
+
+    def test_removes_existing(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        save_priority_objective(
+            PriorityObjective(name="x", type="granfondo", target_date=date(2026, 7, 4)),
+            yaml_path,
+        )
+        result = clear_priority_objective(yaml_path)
+        assert result == yaml_path
+        assert load_priority_objective(yaml_path) is None
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        assert "priority_objective" not in data["athlete"]
+
+
+class TestRoundTrip:
+    def test_save_then_load(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        original = PriorityObjective(
+            name="Les Copains 81km",
+            type="granfondo",
+            target_date=date(2026, 7, 4),
+            priority="A",
+            distance_km=81.0,
+            notes="Build + taper",
+        )
+        save_priority_objective(original, yaml_path)
+        loaded = load_priority_objective(yaml_path)
+        assert loaded == original

--- a/tests/config/test_yaml_io.py
+++ b/tests/config/test_yaml_io.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 from magma_cycling.config._yaml_io import atomic_write_yaml, read_yaml
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX file permissions are not enforced on Windows (INFRA-001)",
+)
 
 
 class TestReadYaml:
@@ -34,6 +41,7 @@ class TestReadYaml:
 
 
 class TestAtomicWriteYaml:
+    @posix_only
     def test_creates_file_with_0o600_perms(self, tmp_path: Path):
         p = tmp_path / "out.yaml"
         atomic_write_yaml(p, {"foo": "bar"})
@@ -41,6 +49,7 @@ class TestAtomicWriteYaml:
         mode = stat.S_IMODE(p.stat().st_mode)
         assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
 
+    @posix_only
     def test_creates_parent_dir_with_0o700_when_absent(self, tmp_path: Path):
         nested = tmp_path / "newdir" / "deeper"
         p = nested / "out.yaml"
@@ -49,6 +58,7 @@ class TestAtomicWriteYaml:
         mode = stat.S_IMODE(nested.stat().st_mode)
         assert mode == 0o700, f"Expected 0o700 on new parent, got {oct(mode)}"
 
+    @posix_only
     def test_does_not_change_existing_parent_perms(self, tmp_path: Path):
         existing = tmp_path / "preexisting"
         existing.mkdir(mode=0o755)

--- a/tests/config/test_yaml_io.py
+++ b/tests/config/test_yaml_io.py
@@ -1,0 +1,83 @@
+"""Tests for the shared YAML I/O primitives (TOCTOU-safe write helpers)."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import yaml
+
+from magma_cycling.config._yaml_io import atomic_write_yaml, read_yaml
+
+
+class TestReadYaml:
+    def test_missing_file_returns_empty_dict(self, tmp_path: Path):
+        assert read_yaml(tmp_path / "absent.yaml") == {}
+
+    def test_valid_yaml_returns_dict(self, tmp_path: Path):
+        p = tmp_path / "ok.yaml"
+        p.write_text("foo: bar\nbaz: 1\n", encoding="utf-8")
+        assert read_yaml(p) == {"foo": "bar", "baz": 1}
+
+    def test_malformed_yaml_returns_empty_and_warns(self, tmp_path: Path, caplog):
+        p = tmp_path / "bad.yaml"
+        p.write_text("not: valid: yaml: [", encoding="utf-8")
+        with caplog.at_level("WARNING"):
+            assert read_yaml(p) == {}
+        assert any("malformed" in r.message for r in caplog.records)
+
+    def test_non_dict_root_returns_empty_dict(self, tmp_path: Path):
+        p = tmp_path / "list.yaml"
+        p.write_text("- one\n- two\n", encoding="utf-8")
+        assert read_yaml(p) == {}
+
+
+class TestAtomicWriteYaml:
+    def test_creates_file_with_0o600_perms(self, tmp_path: Path):
+        p = tmp_path / "out.yaml"
+        atomic_write_yaml(p, {"foo": "bar"})
+        assert p.is_file()
+        mode = stat.S_IMODE(p.stat().st_mode)
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_creates_parent_dir_with_0o700_when_absent(self, tmp_path: Path):
+        nested = tmp_path / "newdir" / "deeper"
+        p = nested / "out.yaml"
+        atomic_write_yaml(p, {"foo": "bar"})
+        assert nested.is_dir()
+        mode = stat.S_IMODE(nested.stat().st_mode)
+        assert mode == 0o700, f"Expected 0o700 on new parent, got {oct(mode)}"
+
+    def test_does_not_change_existing_parent_perms(self, tmp_path: Path):
+        existing = tmp_path / "preexisting"
+        existing.mkdir(mode=0o755)
+        os.chmod(existing, 0o755)
+        p = existing / "out.yaml"
+        atomic_write_yaml(p, {"foo": "bar"})
+        mode = stat.S_IMODE(existing.stat().st_mode)
+        assert mode == 0o755, f"Existing parent perms must be preserved, got {oct(mode)}"
+
+    def test_content_is_correct(self, tmp_path: Path):
+        p = tmp_path / "out.yaml"
+        atomic_write_yaml(p, {"foo": "bar", "nested": {"k": 1}})
+        loaded = yaml.safe_load(p.read_text(encoding="utf-8"))
+        assert loaded == {"foo": "bar", "nested": {"k": 1}}
+
+    def test_overwrites_existing_file(self, tmp_path: Path):
+        p = tmp_path / "out.yaml"
+        atomic_write_yaml(p, {"v": 1})
+        atomic_write_yaml(p, {"v": 2})
+        assert yaml.safe_load(p.read_text(encoding="utf-8")) == {"v": 2}
+
+    def test_temp_file_cleaned_up_on_success(self, tmp_path: Path):
+        p = tmp_path / "out.yaml"
+        atomic_write_yaml(p, {"v": 1})
+        leftovers = [x for x in tmp_path.iterdir() if ".tmp" in x.name]
+        assert leftovers == [], f"Unexpected temp leftovers: {leftovers}"
+
+    def test_preserves_unicode(self, tmp_path: Path):
+        p = tmp_path / "out.yaml"
+        atomic_write_yaml(p, {"nom": "Les Copains 81km — préparation"})
+        loaded = yaml.safe_load(p.read_text(encoding="utf-8"))
+        assert loaded["nom"] == "Les Copains 81km — préparation"

--- a/tests/test_mcp_new_handlers.py
+++ b/tests/test_mcp_new_handlers.py
@@ -1019,6 +1019,67 @@ class TestHandleUpdateAthleteProfileError:
         assert "error" in data
 
 
+class TestHandleUpdateAthleteProfilePriorityObjective:
+    @pytest.mark.asyncio
+    async def test_save_priority_objective(self, tmp_path, monkeypatch):
+        from magma_cycling.mcp_server import handle_update_athlete_profile
+
+        yaml_path = tmp_path / "athlete.yaml"
+        monkeypatch.setenv("ATHLETE_CONFIG_PATH", str(yaml_path))
+
+        result = await handle_update_athlete_profile(
+            {
+                "updates": {
+                    "priority_objective": {
+                        "name": "Les Copains 81km",
+                        "type": "granfondo",
+                        "target_date": "2026-07-04",
+                        "priority": "A",
+                        "distance_km": 81,
+                        "notes": "Build + taper",
+                    }
+                }
+            }
+        )
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert "priority_objective" in data["updated_fields"]
+        assert data["current_values"]["priority_objective"]["name"] == "Les Copains 81km"
+        assert yaml_path.is_file()
+
+    @pytest.mark.asyncio
+    async def test_clear_priority_objective(self, tmp_path, monkeypatch):
+        from magma_cycling.mcp_server import handle_update_athlete_profile
+
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text(
+            "athlete:\n"
+            "  priority_objective:\n"
+            "    name: x\n"
+            "    type: granfondo\n"
+            "    target_date: 2026-07-04\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ATHLETE_CONFIG_PATH", str(yaml_path))
+
+        result = await handle_update_athlete_profile({"updates": {"priority_objective": None}})
+        data = json.loads(result[0].text)
+        assert data["success"] is True
+        assert "priority_objective" in data["updated_fields"]
+        assert data["current_values"]["priority_objective"] is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_objective_returns_error(self, tmp_path, monkeypatch):
+        from magma_cycling.mcp_server import handle_update_athlete_profile
+
+        monkeypatch.setenv("ATHLETE_CONFIG_PATH", str(tmp_path / "athlete.yaml"))
+        result = await handle_update_athlete_profile(
+            {"updates": {"priority_objective": {"name": "x"}}}  # missing required
+        )
+        data = json.loads(result[0].text)
+        assert "error" in data
+
+
 # =======================
 # TestHandleValidateWeekConsistency
 # =======================


### PR DESCRIPTION
## Contexte

PR #397 a persisté la fondo « Les Copains 81km » dans le bundle `magma_cycling/config/athlete_context.yaml`, qui est embarqué dans le bundle PyInstaller distribué aux beta-testeurs (leak RGPD). PR #398 a reverté immédiatement.

Cette PR ré-introduit la persistance via une route saine : **le user YAML uniquement**, jamais le bundle.

## Architecture (calquée sur `home_location`)

`magma_cycling/config/objectives.py` :
- `PriorityObjective` pydantic model (name, type, target_date, priority, distance_km?, notes?)
- `load_priority_objective(path=None)` — migration-noop, retourne `None` si absent
- `save_priority_objective(obj, path=None)` — atomic write 0o600 dans le user file résolu par `resolve_athlete_yaml_path()`
- `clear_priority_objective(path=None)` — suppression in-place

`_mcp/handlers/athlete.py` :
- `_LOCAL_FIELDS` étendu avec `priority_objective`
- `handle_get_athlete_profile` retourne le champ (None si non set)
- `handle_update_athlete_profile` dispatch save (objet) / clear (null)

`_mcp/schemas/athlete.py` : nouveau champ `priority_objective` dans `updates` (oneOf null | objet structuré, `target_date` format YYYY-MM-DD).

## Usage

```
update-athlete-profile updates={
  "priority_objective": {
    "name": "Les Copains 81km",
    "type": "granfondo",
    "target_date": "2026-07-04",
    "priority": "A",
    "distance_km": 81,
    "notes": "Build S098-S099, taper + race week S100"
  }
}
```

Écrit dans `<resolved>/config/athlete.yaml` (ou override `ATHLETE_CONFIG_PATH`). **Bundle jamais touché.**

## Hors scope

- Injection dans le prompt coach — `priority_objective` est stocké et lisible via `get-athlete-profile` mais n'est pas encore injecté dans `prompt_builder.build_prompt()`. À faire séparément si on veut que le coach AI le voie automatiquement (pour l'instant : coach gère la périodisation manuellement, validé).
- Migration iso-config du profil existant (bundle template anonyme + user file portable) — chantier S093-S096 séparé.

## Tests

- 26 nouveaux dans `tests/config/test_objectives.py` (modèle pydantic + load/save/clear + round-trip + edge cases)
- 3 nouveaux dans `tests/test_mcp_new_handlers.py` (dispatch save / clear / validation error)
- Suite complète liée : 437 verts en local

## Test plan

- [ ] Appeler `update-athlete-profile` avec un `priority_objective` valide → vérifier que le user YAML est créé/patché et le bundle reste inchangé
- [ ] Appeler avec `priority_objective: null` → vérifier suppression
- [ ] Appeler `get-athlete-profile` → vérifier que `priority_objective` apparaît dans la réponse
- [ ] Vérifier qu'aucun fichier `magma_cycling/config/athlete_context.yaml` n'est modifié à la racine du repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)