### PR TITLE
fix(hot-reload): guard against module.__file__ = None (namespace pkgs)

### DIFF
--- a/magma_cycling/utils/hot_reload.py
+++ b/magma_cycling/utils/hot_reload.py
@@ -64,11 +64,14 @@ def hot_reload_if_needed(package_name: str = "magma_cycling", verbose: bool = Fa
     """
     reloaded_modules = []
 
-    # Find all loaded modules from our package
+    # Find all loaded modules from our package.
+    # Filter out namespace packages and built-ins where ``__file__`` exists
+    # but is ``None`` — ``Path(None)`` would raise ``TypeError`` (not caught
+    # by the loop's ``except (AttributeError, OSError)``).
     our_modules = {
         name: module
         for name, module in sys.modules.items()
-        if name.startswith(package_name) and hasattr(module, "__file__")
+        if name.startswith(package_name) and getattr(module, "__file__", None) is not None
     }
 
     if not our_modules:
@@ -152,10 +155,11 @@ def mark_modules_loaded(package_name: str = "magma_cycling") -> None:
         >>> mark_modules_loaded()
         >>> # Later calls to hot_reload_if_needed() will detect changes
     """
+    # Same namespace-package guard as ``hot_reload_if_needed`` — see comment there.
     our_modules = {
         name: module
         for name, module in sys.modules.items()
-        if name.startswith(package_name) and hasattr(module, "__file__")
+        if name.startswith(package_name) and getattr(module, "__file__", None) is not None
     }
 
     for module_name, module in our_modules.items():

--- a/tests/utils/test_hot_reload.py
+++ b/tests/utils/test_hot_reload.py
@@ -1,0 +1,66 @@
+"""Tests for ``magma_cycling.utils.hot_reload``.
+
+Regression coverage for the ``__file__ = None`` crash observed in prod
+(daily_sync.main() → mark_modules_loaded() → ``Path(None)`` TypeError
+when a namespace package / built-in slipped into the magma_cycling.*
+filter via ``hasattr(module, "__file__")`` returning True on a None value.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from magma_cycling.utils import hot_reload
+
+
+def _inject_module(
+    monkeypatch: pytest.MonkeyPatch, name: str, file_attr: object
+) -> types.ModuleType:
+    """Inject a synthetic module into sys.modules with the given __file__."""
+    mod = types.ModuleType(name)
+    mod.__file__ = file_attr  # type: ignore[assignment]
+    monkeypatch.setitem(sys.modules, name, mod)
+    return mod
+
+
+def test_mark_modules_loaded_skips_module_with_none_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: a magma_cycling.* module with __file__=None must not crash."""
+    _inject_module(monkeypatch, "magma_cycling._test_synthetic_none", file_attr=None)
+
+    # Must not raise TypeError("argument should be a str or an os.PathLike...")
+    hot_reload.mark_modules_loaded(package_name="magma_cycling")
+
+
+def test_hot_reload_if_needed_skips_module_with_none_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: same guard for hot_reload_if_needed()."""
+    _inject_module(monkeypatch, "magma_cycling._test_synthetic_none2", file_attr=None)
+
+    reloaded = hot_reload.hot_reload_if_needed(package_name="magma_cycling")
+    assert isinstance(reloaded, list)
+
+
+def test_mark_modules_loaded_sets_mtime_on_real_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Happy path: a real magma_cycling module gets __mtime__ set."""
+    # Use the hot_reload module itself — it's loaded with a real __file__.
+    if hasattr(hot_reload, "__mtime__"):
+        monkeypatch.delattr(hot_reload, "__mtime__", raising=False)
+
+    hot_reload.mark_modules_loaded(package_name="magma_cycling")
+
+    assert getattr(hot_reload, "__mtime__", 0) > 0
+
+
+def test_hot_reload_if_needed_returns_empty_when_no_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: no file changes → no reload, returns empty list."""
+    # Force the module's stored mtime to "now" so the file check decides nothing changed.
+    import time
+
+    hot_reload.__mtime__ = time.time() + 3600  # type: ignore[attr-defined]
+
+    reloaded = hot_reload.hot_reload_if_needed(package_name="magma_cycling")
+    assert hot_reload.__name__ not in reloaded


### PR DESCRIPTION
## RCA — daily-sync prod crash depuis v3.58.0 deploy (07/06)

Diagnostic Admin sur logs container prod (09/06 22:00 UTC) :

\`\`\`
Traceback (most recent call last):
  File \"/app/magma_cycling/utils/cli.py\", line 14, in wrapper
    result = func(*args, **kwargs)
  File \"/app/magma_cycling/daily_sync.py\", line 390, in main
    mark_modules_loaded()
  File \"/app/magma_cycling/utils/hot_reload.py\", line 163, in mark_modules_loaded
    module_file = Path(module.__file__)
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'
\`\`\`

**Cause root** : ``hot_reload.py`` filtre les modules par ``hasattr(module, \"__file__\")``, mais ``hasattr`` retourne ``True`` même quand ``__file__ == None`` (namespace packages, certains built-in / C-extension descriptors). ``Path(None)`` raise ``TypeError`` non couvert par le ``except (AttributeError, OSError)`` du loop.

**Impact** : daily-sync = 0% succès depuis 16:00 UTC 07/06 (~150 ticks consécutifs en erreur), mail rapport post-session jamais émis pendant 2 jours. Crash bien avant la couche SMTP.

**Bug latent** : le code existe depuis le rebrand (commit ``55f4ef3``). Révélé par v3.58.0 probablement parce qu'un nouveau module importé dans la chaîne v3.55-v3.58 atterrit dans ``magma_cycling.*`` avec ``__file__=None`` (à confirmer si curiosité, pas bloquant — le fix couvre le cas générique).

## Fix

Remplace ``hasattr(module, \"__file__\")`` par ``getattr(module, \"__file__\", None) is not None`` dans les 2 comprehensions concernées :
- ``hot_reload_if_needed`` (l.71)
- ``mark_modules_loaded`` (l.158)

## Tests

Nouveau fichier ``tests/utils/test_hot_reload.py`` (aucune couverture préexistante — d'où le miss CI) :
- **Regression** : injection d'un module synthétique ``magma_cycling._test_synthetic_none`` avec ``__file__=None`` → ``mark_modules_loaded`` et ``hot_reload_if_needed`` ne crashent plus
- **Happy path** : module réel reçoit bien son ``__mtime__`` / no-change run retourne liste vide

4/4 tests verts local.

## Gap TNR identifié

Le TNR ``T-priority-objective-end-to-end`` (Junior, 07/06) a testé ``_get_priority_objective_window`` direct côté Python (\"runtime local\", documenté honnête en caveat) au lieu d'exercer le wrapper d'entry point cron ``daily_sync.main()`` qui appelle ``mark_modules_loaded()`` AVANT toute logique business. Conséquence : crash invisible en TNR, révélé en prod par l'auto-cron. Lesson posée pour les prochains briefs TNR servo : toujours exercer la commande cron réelle bout-en-bout.

## Suite

- Merge → semantic-release devrait bumper en ``v3.58.1`` (commit type ``fix``)
- Retag ``:stable`` v3.58.1 + redeploy NAS prod → daily-sync repart, mail rapport ce soir