### PR TITLE
feat(config): 6 rich athlete profile fields (BT-017)

### DIFF
--- a/magma_cycling/_mcp/handlers/athlete.py
+++ b/magma_cycling/_mcp/handlers/athlete.py
@@ -13,9 +13,36 @@ from magma_cycling.config.objectives import (
     load_priority_objective,
     save_priority_objective,
 )
+from magma_cycling.config.profile_rich import (
+    AvailabilityPattern,
+    HrvBaseline,
+    InjuryHistory,
+    MacroPlan,
+    NutritionStrategy,
+    SleepBaseline,
+    clear_availability_pattern,
+    clear_hrv_baseline,
+    clear_injury_history,
+    clear_macro_plan,
+    clear_nutrition_strategy,
+    clear_sleep_baseline,
+    load_availability_pattern,
+    load_hrv_baseline,
+    load_injury_history,
+    load_macro_plan,
+    load_nutrition_strategy,
+    load_sleep_baseline,
+    save_availability_pattern,
+    save_hrv_baseline,
+    save_injury_history,
+    save_macro_plan,
+    save_nutrition_strategy,
+    save_sleep_baseline,
+)
 
 if TYPE_CHECKING:
     from mcp.types import TextContent
+    from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +51,29 @@ __all__ = [
     "handle_update_athlete_profile",
 ]
 
+# BT-017 rich profile fields: (pydantic model, save fn, clear fn).
+# Each is dispatched identically — validated, persisted to athlete YAML,
+# or cleared when the update payload sends ``null``.
+_RICH_FIELDS: dict[str, tuple[type["BaseModel"], object, object]] = {
+    "hrv_baseline": (HrvBaseline, save_hrv_baseline, clear_hrv_baseline),
+    "injury_history": (InjuryHistory, save_injury_history, clear_injury_history),
+    "macro_plan": (MacroPlan, save_macro_plan, clear_macro_plan),
+    "nutrition_strategy": (
+        NutritionStrategy,
+        save_nutrition_strategy,
+        clear_nutrition_strategy,
+    ),
+    "sleep_baseline": (SleepBaseline, save_sleep_baseline, clear_sleep_baseline),
+    "availability_pattern": (
+        AvailabilityPattern,
+        save_availability_pattern,
+        clear_availability_pattern,
+    ),
+}
+
 # Local-only fields routed to the athlete YAML (not Intervals.icu).
 # Extend this set as more portable fields land (PR5 iso-config and beyond).
-_LOCAL_FIELDS = frozenset({"home_location", "priority_objective"})
+_LOCAL_FIELDS = frozenset({"home_location", "priority_objective"} | set(_RICH_FIELDS))
 
 
 async def handle_get_athlete_profile(args: dict) -> list[TextContent]:
@@ -87,6 +134,18 @@ async def handle_get_athlete_profile(args: dict) -> list[TextContent]:
             priority.model_dump(mode="json", exclude_none=True) if priority else None
         )
 
+        # BT-017 rich profile fields — all are optional / migration-noop.
+        for field, loader in (
+            ("hrv_baseline", load_hrv_baseline),
+            ("injury_history", load_injury_history),
+            ("macro_plan", load_macro_plan),
+            ("nutrition_strategy", load_nutrition_strategy),
+            ("sleep_baseline", load_sleep_baseline),
+            ("availability_pattern", load_availability_pattern),
+        ):
+            obj = loader()
+            result[field] = obj.model_dump(mode="json", exclude_none=True) if obj else None
+
         return mcp_response(result)
 
     except Exception as e:
@@ -128,6 +187,23 @@ async def handle_update_athlete_profile(args: dict) -> list[TextContent]:
                     current_values["priority_objective"] = objective.model_dump(
                         mode="json", exclude_none=True
                     )
+
+            # BT-017 rich profile fields — same dispatch for the 6 of them.
+            for field, (model_cls, save_fn, clear_fn) in _RICH_FIELDS.items():
+                if field not in local_updates:
+                    continue
+                raw = local_updates[field]
+                if raw is None:
+                    cleared = clear_fn()  # type: ignore[operator]
+                    updated_fields.append(field)
+                    current_values[field] = None
+                    if cleared is None:
+                        logger.debug("%s clear request with no existing value", field)
+                else:
+                    obj = model_cls.model_validate(raw)
+                    save_fn(obj)  # type: ignore[operator]
+                    updated_fields.append(field)
+                    current_values[field] = obj.model_dump(mode="json", exclude_none=True)
 
             # 2. Remote fields (Intervals.icu)
             if remote_updates:

--- a/magma_cycling/_mcp/schemas/athlete.py
+++ b/magma_cycling/_mcp/schemas/athlete.py
@@ -93,6 +93,317 @@ def get_tools() -> list[Tool]:
                                     },
                                 ],
                             },
+                            "hrv_baseline": {
+                                "description": (
+                                    "HRV rMSSD baseline (range, fatigue alert "
+                                    "threshold, documented anomalies, recovery "
+                                    "pattern). Stored in the user athlete YAML. "
+                                    "Pass null to clear."
+                                ),
+                                "oneOf": [
+                                    {"type": "null"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "rmssd_min": {
+                                                "type": "number",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "rmssd_max": {
+                                                "type": "number",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "rmssd_peak": {
+                                                "type": "number",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "alert_threshold": {
+                                                "type": "number",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "anomalies": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "date": {
+                                                            "type": "string",
+                                                            "format": "date",
+                                                        },
+                                                        "value": {
+                                                            "type": "number",
+                                                            "exclusiveMinimum": 0,
+                                                        },
+                                                        "context": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                        },
+                                                        "exclude_from_stats": {
+                                                            "type": "boolean",
+                                                            "default": False,
+                                                        },
+                                                    },
+                                                    "required": [
+                                                        "date",
+                                                        "value",
+                                                        "context",
+                                                    ],
+                                                    "additionalProperties": False,
+                                                },
+                                            },
+                                            "recovery_pattern": {"type": "string"},
+                                        },
+                                        "required": [
+                                            "rmssd_min",
+                                            "rmssd_max",
+                                            "alert_threshold",
+                                        ],
+                                        "additionalProperties": False,
+                                    },
+                                ],
+                            },
+                            "injury_history": {
+                                "description": (
+                                    "Active injuries + standing watch points. "
+                                    "Stored in the user athlete YAML. Pass null "
+                                    "to clear."
+                                ),
+                                "oneOf": [
+                                    {"type": "null"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "active": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "area": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                        },
+                                                        "status": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "active",
+                                                                "monitoring",
+                                                                "healed",
+                                                            ],
+                                                        },
+                                                        "onset_date": {
+                                                            "type": "string",
+                                                            "format": "date",
+                                                        },
+                                                        "last_followup": {
+                                                            "type": "string",
+                                                            "format": "date",
+                                                        },
+                                                        "notes": {"type": "string"},
+                                                    },
+                                                    "required": ["area", "status"],
+                                                    "additionalProperties": False,
+                                                },
+                                            },
+                                            "watch_points": {
+                                                "type": "array",
+                                                "items": {"type": "string"},
+                                            },
+                                        },
+                                        "additionalProperties": False,
+                                    },
+                                ],
+                            },
+                            "macro_plan": {
+                                "description": (
+                                    "Macro training plan (weekly TSS targets, "
+                                    "CTL target, peak event with strategy). "
+                                    "Stored in the user athlete YAML. Pass null "
+                                    "to clear."
+                                ),
+                                "oneOf": [
+                                    {"type": "null"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "weekly_tss": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "week_label": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                        },
+                                                        "tss_target": {
+                                                            "type": "integer",
+                                                            "exclusiveMinimum": 0,
+                                                        },
+                                                        "notes": {"type": "string"},
+                                                    },
+                                                    "required": [
+                                                        "week_label",
+                                                        "tss_target",
+                                                    ],
+                                                    "additionalProperties": False,
+                                                },
+                                            },
+                                            "ctl_target": {
+                                                "type": "number",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "peak_event": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string",
+                                                        "minLength": 1,
+                                                    },
+                                                    "date": {
+                                                        "type": "string",
+                                                        "format": "date",
+                                                    },
+                                                    "ctl_target": {
+                                                        "type": "number",
+                                                        "exclusiveMinimum": 0,
+                                                    },
+                                                    "tsb_target_min": {"type": "number"},
+                                                    "tsb_target_max": {"type": "number"},
+                                                    "strategy": {"type": "string"},
+                                                },
+                                                "required": ["name", "date"],
+                                                "additionalProperties": False,
+                                            },
+                                        },
+                                        "additionalProperties": False,
+                                    },
+                                ],
+                            },
+                            "nutrition_strategy": {
+                                "description": (
+                                    "In-event nutrition strategy (carbs/h range "
+                                    "+ known issues like cramps). Stored in the "
+                                    "user athlete YAML. Pass null to clear."
+                                ),
+                                "oneOf": [
+                                    {"type": "null"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "carbs_per_hour_min": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "carbs_per_hour_max": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "known_issues": {
+                                                "type": "array",
+                                                "items": {"type": "string"},
+                                            },
+                                        },
+                                        "required": [
+                                            "carbs_per_hour_min",
+                                            "carbs_per_hour_max",
+                                        ],
+                                        "additionalProperties": False,
+                                    },
+                                ],
+                            },
+                            "sleep_baseline": {
+                                "description": (
+                                    "Sleep baseline (average duration, nightly "
+                                    "deficit, bedtime target). Stored in the "
+                                    "user athlete YAML. Pass null to clear."
+                                ),
+                                "oneOf": [
+                                    {"type": "null"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "avg_duration_minutes": {
+                                                "type": "integer",
+                                                "exclusiveMinimum": 0,
+                                            },
+                                            "deficit_per_night_minutes": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                            },
+                                            "bedtime_target": {
+                                                "type": "string",
+                                                "pattern": r"^([01]\d|2[0-3]):[0-5]\d$",
+                                                "description": "HH:MM 24h",
+                                            },
+                                        },
+                                        "required": [
+                                            "avg_duration_minutes",
+                                            "deficit_per_night_minutes",
+                                        ],
+                                        "additionalProperties": False,
+                                    },
+                                ],
+                            },
+                            "availability_pattern": {
+                                "description": (
+                                    "Recurring weekly availability (slots with "
+                                    "day, time window, activity). Stored in the "
+                                    "user athlete YAML. Pass null to clear."
+                                ),
+                                "oneOf": [
+                                    {"type": "null"},
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "weekly_slots": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "day_of_week": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "mon",
+                                                                "tue",
+                                                                "wed",
+                                                                "thu",
+                                                                "fri",
+                                                                "sat",
+                                                                "sun",
+                                                            ],
+                                                        },
+                                                        "time_window": {
+                                                            "type": "string",
+                                                            "pattern": (
+                                                                r"^([01]\d|2[0-3]):"
+                                                                r"[0-5]\d-"
+                                                                r"([01]\d|2[0-3]):"
+                                                                r"[0-5]\d$"
+                                                            ),
+                                                            "description": ("HH:MM-HH:MM 24h"),
+                                                        },
+                                                        "activity": {
+                                                            "type": "string",
+                                                            "minLength": 1,
+                                                        },
+                                                        "typical_tss": {
+                                                            "type": "integer",
+                                                            "minimum": 0,
+                                                        },
+                                                    },
+                                                    "required": [
+                                                        "day_of_week",
+                                                        "time_window",
+                                                        "activity",
+                                                    ],
+                                                    "additionalProperties": False,
+                                                },
+                                            },
+                                            "notes": {"type": "string"},
+                                        },
+                                        "additionalProperties": False,
+                                    },
+                                ],
+                            },
                         },
                     },
                 },

--- a/magma_cycling/config/profile_rich.py
+++ b/magma_cycling/config/profile_rich.py
@@ -1,0 +1,403 @@
+"""Rich athlete profile fields stored in the athlete YAML (BT-017).
+
+Hosts the pydantic models and read/write helpers for six structured
+fields that extend the bundled athlete profile beyond Intervals.icu
+training metrics:
+
+* :class:`HrvBaseline` — HRV rMSSD range, fatigue alert threshold and
+  athlete-specific anomalies (each documented with context — kept
+  visible even when excluded from stats so the AI prompts see *why*).
+* :class:`InjuryHistory` — active injuries with status + standing watch
+  points (volume ramp limits, recurring weak areas).
+* :class:`MacroPlan` — weekly TSS targets, CTL target and the peak event
+  with a TSB target range (min/max).
+* :class:`NutritionStrategy` — carbs/h range and known issues (cramps,
+  GI limits) consumed by long-event briefings.
+* :class:`SleepBaseline` — average sleep duration, nightly deficit and
+  bedtime target.
+* :class:`AvailabilityPattern` — recurring weekly slots (commute,
+  cross-training, long rides) used by planning.
+
+Each field follows the same convention as
+:mod:`magma_cycling.config.objectives` : dispatched from the
+``update-athlete-profile`` MCP handler, persisted under
+``athlete.<field>`` of the user YAML resolved by
+:func:`magma_cycling.config.data_repo.resolve_athlete_yaml_path`. The
+bundled ``athlete_context.yaml`` is never touched.
+
+Migration noop: a missing field returns ``None`` from its loader.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from magma_cycling.config._yaml_io import atomic_write_yaml, read_yaml
+from magma_cycling.config.data_repo import resolve_athlete_yaml_path
+
+__all__ = [
+    "HrvAnomaly",
+    "HrvBaseline",
+    "Injury",
+    "InjuryHistory",
+    "WeeklyTssTarget",
+    "PeakEvent",
+    "MacroPlan",
+    "NutritionStrategy",
+    "SleepBaseline",
+    "AvailabilitySlot",
+    "AvailabilityPattern",
+    "load_hrv_baseline",
+    "save_hrv_baseline",
+    "clear_hrv_baseline",
+    "load_injury_history",
+    "save_injury_history",
+    "clear_injury_history",
+    "load_macro_plan",
+    "save_macro_plan",
+    "clear_macro_plan",
+    "load_nutrition_strategy",
+    "save_nutrition_strategy",
+    "clear_nutrition_strategy",
+    "load_sleep_baseline",
+    "save_sleep_baseline",
+    "clear_sleep_baseline",
+    "load_availability_pattern",
+    "save_availability_pattern",
+    "clear_availability_pattern",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# HRV baseline
+# ---------------------------------------------------------------------------
+
+
+class HrvAnomaly(BaseModel):
+    """A documented HRV outlier with the athlete-specific context."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    date: date
+    value: float = Field(gt=0, description="rMSSD value (ms)")
+    context: str = Field(min_length=1, description="Why this point is an outlier")
+    # Per-anomaly opt-in: the sensor works in general — exclusion is a
+    # context-driven decision, not a default policy.
+    exclude_from_stats: bool = Field(default=False)
+
+
+class HrvBaseline(BaseModel):
+    """HRV rMSSD baseline + fatigue alert threshold."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    rmssd_min: float = Field(gt=0, description="Baseline minimum (ms)")
+    rmssd_max: float = Field(gt=0, description="Baseline maximum (ms)")
+    rmssd_peak: float | None = Field(default=None, gt=0, description="Recovery peak ceiling (ms)")
+    alert_threshold: float = Field(gt=0, description="Fatigue alert threshold (ms)")
+    anomalies: list[HrvAnomaly] = Field(default_factory=list)
+    recovery_pattern: str | None = Field(default=None, description="Free-form pattern description")
+
+    @model_validator(mode="after")
+    def _check_range(self) -> "HrvBaseline":
+        if self.rmssd_max < self.rmssd_min:
+            raise ValueError("rmssd_max must be >= rmssd_min")
+        if self.rmssd_peak is not None and self.rmssd_peak < self.rmssd_max:
+            raise ValueError("rmssd_peak must be >= rmssd_max")
+        if self.alert_threshold >= self.rmssd_min:
+            raise ValueError("alert_threshold must be < rmssd_min")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Injury history
+# ---------------------------------------------------------------------------
+
+
+class Injury(BaseModel):
+    """A single injury entry."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    area: str = Field(min_length=1, description="Body area / structure")
+    status: Literal["active", "monitoring", "healed"]
+    onset_date: date | None = None
+    last_followup: date | None = None
+    notes: str | None = None
+
+
+class InjuryHistory(BaseModel):
+    """Active injuries + recurring watch points."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    active: list[Injury] = Field(default_factory=list)
+    watch_points: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Macro plan
+# ---------------------------------------------------------------------------
+
+
+class WeeklyTssTarget(BaseModel):
+    """TSS target for one week of the macro plan."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    week_label: str = Field(min_length=1, description="e.g. 'S003' or '2026-W25'")
+    tss_target: int = Field(gt=0)
+    notes: str | None = None
+
+
+class PeakEvent(BaseModel):
+    """The macro plan's peak event with its readiness window targets."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(min_length=1)
+    date: date
+    ctl_target: float | None = Field(default=None, gt=0)
+    tsb_target_min: float | None = None
+    tsb_target_max: float | None = None
+    strategy: str | None = Field(default=None, description="Free-form race / event strategy notes")
+
+    @model_validator(mode="after")
+    def _check_tsb_range(self) -> "PeakEvent":
+        if (
+            self.tsb_target_min is not None
+            and self.tsb_target_max is not None
+            and self.tsb_target_max < self.tsb_target_min
+        ):
+            raise ValueError("tsb_target_max must be >= tsb_target_min")
+        return self
+
+
+class MacroPlan(BaseModel):
+    """Macro training plan: weekly TSS + CTL target + peak event."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    weekly_tss: list[WeeklyTssTarget] = Field(default_factory=list)
+    ctl_target: float | None = Field(default=None, gt=0)
+    peak_event: PeakEvent | None = None
+
+
+# ---------------------------------------------------------------------------
+# Nutrition strategy
+# ---------------------------------------------------------------------------
+
+
+class NutritionStrategy(BaseModel):
+    """In-event nutrition strategy and known limits."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    carbs_per_hour_min: int = Field(gt=0, description="Lower bound (g/h)")
+    carbs_per_hour_max: int = Field(gt=0, description="Upper bound (g/h)")
+    known_issues: list[str] = Field(default_factory=list, description="e.g. 'cramps on 4h+ rides'")
+
+    @model_validator(mode="after")
+    def _check_range(self) -> "NutritionStrategy":
+        if self.carbs_per_hour_max < self.carbs_per_hour_min:
+            raise ValueError("carbs_per_hour_max must be >= carbs_per_hour_min")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Sleep baseline
+# ---------------------------------------------------------------------------
+
+
+class SleepBaseline(BaseModel):
+    """Sleep duration baseline + nightly deficit + bedtime target."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    avg_duration_minutes: int = Field(gt=0, description="Average nightly sleep (min)")
+    deficit_per_night_minutes: int = Field(ge=0, description="Nightly deficit (min)")
+    bedtime_target: str | None = Field(
+        default=None,
+        pattern=r"^([01]\d|2[0-3]):[0-5]\d$",
+        description="HH:MM 24h",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Availability pattern
+# ---------------------------------------------------------------------------
+
+
+class AvailabilitySlot(BaseModel):
+    """One recurring weekly slot (commute, cross-training, long ride...)."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    day_of_week: Literal["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+    time_window: str = Field(
+        pattern=r"^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$",
+        description="HH:MM-HH:MM 24h",
+    )
+    activity: str = Field(min_length=1, description="e.g. 'velocommute', 'aviron'")
+    typical_tss: int | None = Field(default=None, ge=0)
+
+
+class AvailabilityPattern(BaseModel):
+    """Recurring weekly availability — informs planning's slot allocation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    weekly_slots: list[AvailabilitySlot] = Field(default_factory=list)
+    notes: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# YAML I/O — generic helpers + per-field public wrappers
+# ---------------------------------------------------------------------------
+
+
+_FIELDS: dict[str, type[BaseModel]] = {
+    "hrv_baseline": HrvBaseline,
+    "injury_history": InjuryHistory,
+    "macro_plan": MacroPlan,
+    "nutrition_strategy": NutritionStrategy,
+    "sleep_baseline": SleepBaseline,
+    "availability_pattern": AvailabilityPattern,
+}
+
+
+def _load(field: str, path: Path | None) -> BaseModel | None:
+    yaml_path = path or resolve_athlete_yaml_path()
+    data = read_yaml(yaml_path)
+    raw = (data.get("athlete") or {}).get(field)
+    if not raw:
+        return None
+    try:
+        return _FIELDS[field].model_validate(raw)
+    except Exception:
+        logger.warning("%s in %s failed pydantic validation; ignoring", field, yaml_path)
+        return None
+
+
+def _save(field: str, obj: BaseModel, path: Path | None) -> Path:
+    yaml_path = path or resolve_athlete_yaml_path()
+    data = read_yaml(yaml_path)
+    athlete = data.get("athlete")
+    if not isinstance(athlete, dict):
+        athlete = {}
+        data["athlete"] = athlete
+    athlete[field] = obj.model_dump(mode="json", exclude_none=True)
+    atomic_write_yaml(yaml_path, data)
+    return yaml_path
+
+
+def _clear(field: str, path: Path | None) -> Path | None:
+    yaml_path = path or resolve_athlete_yaml_path()
+    if not yaml_path.exists():
+        return None
+    data = read_yaml(yaml_path)
+    athlete = data.get("athlete")
+    if not isinstance(athlete, dict) or field not in athlete:
+        return None
+    athlete.pop(field, None)
+    atomic_write_yaml(yaml_path, data)
+    return yaml_path
+
+
+def load_hrv_baseline(path: Path | None = None) -> HrvBaseline | None:
+    """Read ``athlete.hrv_baseline`` from the user YAML."""
+    return _load("hrv_baseline", path)  # type: ignore[return-value]
+
+
+def save_hrv_baseline(obj: HrvBaseline, path: Path | None = None) -> Path:
+    """Persist ``obj`` under ``athlete.hrv_baseline``."""
+    return _save("hrv_baseline", obj, path)
+
+
+def clear_hrv_baseline(path: Path | None = None) -> Path | None:
+    """Remove ``athlete.hrv_baseline`` if present."""
+    return _clear("hrv_baseline", path)
+
+
+def load_injury_history(path: Path | None = None) -> InjuryHistory | None:
+    """Read ``athlete.injury_history`` from the user YAML."""
+    return _load("injury_history", path)  # type: ignore[return-value]
+
+
+def save_injury_history(obj: InjuryHistory, path: Path | None = None) -> Path:
+    """Persist ``obj`` under ``athlete.injury_history``."""
+    return _save("injury_history", obj, path)
+
+
+def clear_injury_history(path: Path | None = None) -> Path | None:
+    """Remove ``athlete.injury_history`` if present."""
+    return _clear("injury_history", path)
+
+
+def load_macro_plan(path: Path | None = None) -> MacroPlan | None:
+    """Read ``athlete.macro_plan`` from the user YAML."""
+    return _load("macro_plan", path)  # type: ignore[return-value]
+
+
+def save_macro_plan(obj: MacroPlan, path: Path | None = None) -> Path:
+    """Persist ``obj`` under ``athlete.macro_plan``."""
+    return _save("macro_plan", obj, path)
+
+
+def clear_macro_plan(path: Path | None = None) -> Path | None:
+    """Remove ``athlete.macro_plan`` if present."""
+    return _clear("macro_plan", path)
+
+
+def load_nutrition_strategy(path: Path | None = None) -> NutritionStrategy | None:
+    """Read ``athlete.nutrition_strategy`` from the user YAML."""
+    return _load("nutrition_strategy", path)  # type: ignore[return-value]
+
+
+def save_nutrition_strategy(obj: NutritionStrategy, path: Path | None = None) -> Path:
+    """Persist ``obj`` under ``athlete.nutrition_strategy``."""
+    return _save("nutrition_strategy", obj, path)
+
+
+def clear_nutrition_strategy(path: Path | None = None) -> Path | None:
+    """Remove ``athlete.nutrition_strategy`` if present."""
+    return _clear("nutrition_strategy", path)
+
+
+def load_sleep_baseline(path: Path | None = None) -> SleepBaseline | None:
+    """Read ``athlete.sleep_baseline`` from the user YAML."""
+    return _load("sleep_baseline", path)  # type: ignore[return-value]
+
+
+def save_sleep_baseline(obj: SleepBaseline, path: Path | None = None) -> Path:
+    """Persist ``obj`` under ``athlete.sleep_baseline``."""
+    return _save("sleep_baseline", obj, path)
+
+
+def clear_sleep_baseline(path: Path | None = None) -> Path | None:
+    """Remove ``athlete.sleep_baseline`` if present."""
+    return _clear("sleep_baseline", path)
+
+
+def load_availability_pattern(
+    path: Path | None = None,
+) -> AvailabilityPattern | None:
+    """Read ``athlete.availability_pattern`` from the user YAML."""
+    return _load("availability_pattern", path)  # type: ignore[return-value]
+
+
+def save_availability_pattern(obj: AvailabilityPattern, path: Path | None = None) -> Path:
+    """Persist ``obj`` under ``athlete.availability_pattern``."""
+    return _save("availability_pattern", obj, path)
+
+
+def clear_availability_pattern(path: Path | None = None) -> Path | None:
+    """Remove ``athlete.availability_pattern`` if present."""
+    return _clear("availability_pattern", path)

--- a/tests/config/test_profile_rich.py
+++ b/tests/config/test_profile_rich.py
@@ -1,0 +1,411 @@
+"""Tests for the BT-017 rich athlete profile fields."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from magma_cycling.config.profile_rich import (
+    AvailabilityPattern,
+    AvailabilitySlot,
+    HrvAnomaly,
+    HrvBaseline,
+    Injury,
+    InjuryHistory,
+    MacroPlan,
+    NutritionStrategy,
+    PeakEvent,
+    SleepBaseline,
+    WeeklyTssTarget,
+    clear_hrv_baseline,
+    load_availability_pattern,
+    load_hrv_baseline,
+    load_injury_history,
+    load_macro_plan,
+    load_nutrition_strategy,
+    load_sleep_baseline,
+    save_availability_pattern,
+    save_hrv_baseline,
+    save_injury_history,
+    save_macro_plan,
+    save_nutrition_strategy,
+    save_sleep_baseline,
+)
+
+# ---------------------------------------------------------------------------
+# HrvBaseline + HrvAnomaly
+# ---------------------------------------------------------------------------
+
+
+class TestHrvBaseline:
+    def test_minimal_valid(self):
+        obj = HrvBaseline(rmssd_min=50, rmssd_max=53, alert_threshold=46)
+        assert obj.rmssd_min == 50
+        assert obj.rmssd_peak is None
+        assert obj.anomalies == []
+
+    def test_with_peak_and_anomaly(self):
+        obj = HrvBaseline(
+            rmssd_min=50,
+            rmssd_max=53,
+            rmssd_peak=61,
+            alert_threshold=46,
+            anomalies=[
+                HrvAnomaly(
+                    date=date(2026, 4, 26),
+                    value=25,
+                    context="insolation post-LBL",
+                    exclude_from_stats=True,
+                ),
+            ],
+            recovery_pattern="rebond 1-2 jours apres creux",
+        )
+        assert obj.rmssd_peak == 61
+        assert obj.anomalies[0].exclude_from_stats is True
+
+    def test_max_below_min_rejected(self):
+        with pytest.raises(ValidationError, match="rmssd_max"):
+            HrvBaseline(rmssd_min=60, rmssd_max=50, alert_threshold=46)
+
+    def test_peak_below_max_rejected(self):
+        with pytest.raises(ValidationError, match="rmssd_peak"):
+            HrvBaseline(rmssd_min=50, rmssd_max=53, rmssd_peak=52, alert_threshold=46)
+
+    def test_alert_above_min_rejected(self):
+        with pytest.raises(ValidationError, match="alert_threshold"):
+            HrvBaseline(rmssd_min=50, rmssd_max=53, alert_threshold=60)
+
+    def test_negative_rmssd_rejected(self):
+        with pytest.raises(ValidationError):
+            HrvBaseline(rmssd_min=-1, rmssd_max=53, alert_threshold=46)
+
+    def test_extra_field_rejected(self):
+        with pytest.raises(ValidationError):
+            HrvBaseline(
+                rmssd_min=50,
+                rmssd_max=53,
+                alert_threshold=46,
+                unknown="oops",  # type: ignore[call-arg]
+            )
+
+    def test_anomaly_empty_context_rejected(self):
+        with pytest.raises(ValidationError):
+            HrvAnomaly(date=date(2026, 4, 26), value=25, context="")
+
+
+# ---------------------------------------------------------------------------
+# InjuryHistory
+# ---------------------------------------------------------------------------
+
+
+class TestInjuryHistory:
+    def test_empty_defaults(self):
+        obj = InjuryHistory()
+        assert obj.active == []
+        assert obj.watch_points == []
+
+    def test_with_active_injury(self):
+        obj = InjuryHistory(
+            active=[
+                Injury(
+                    area="genou droit, insertion quadri",
+                    status="active",
+                    onset_date=date(2026, 6, 13),
+                    notes="apparu Ardechoise J3",
+                ),
+            ],
+            watch_points=["ne pas negliger muscu"],
+        )
+        assert obj.active[0].status == "active"
+        assert obj.watch_points == ["ne pas negliger muscu"]
+
+    def test_invalid_status_rejected(self):
+        with pytest.raises(ValidationError):
+            Injury(area="x", status="invalid")  # type: ignore[arg-type]
+
+    def test_empty_area_rejected(self):
+        with pytest.raises(ValidationError):
+            Injury(area="", status="active")
+
+
+# ---------------------------------------------------------------------------
+# MacroPlan + PeakEvent
+# ---------------------------------------------------------------------------
+
+
+class TestPeakEvent:
+    def test_minimal_valid(self):
+        ev = PeakEvent(name="La Marmotte", date=date(2026, 6, 28))
+        assert ev.tsb_target_min is None
+        assert ev.tsb_target_max is None
+
+    def test_tsb_range(self):
+        ev = PeakEvent(
+            name="La Marmotte",
+            date=date(2026, 6, 28),
+            ctl_target=64,
+            tsb_target_min=10,
+            tsb_target_max=15,
+            strategy="68-72% FTP en montee, 70-80g glucides/h",
+        )
+        assert ev.tsb_target_min == 10
+
+    def test_tsb_range_inverted_rejected(self):
+        with pytest.raises(ValidationError, match="tsb_target_max"):
+            PeakEvent(
+                name="x",
+                date=date(2026, 6, 28),
+                tsb_target_min=20,
+                tsb_target_max=10,
+            )
+
+
+class TestMacroPlan:
+    def test_empty_defaults(self):
+        obj = MacroPlan()
+        assert obj.weekly_tss == []
+        assert obj.peak_event is None
+
+    def test_full(self):
+        obj = MacroPlan(
+            weekly_tss=[
+                WeeklyTssTarget(week_label="S010", tss_target=550),
+                WeeklyTssTarget(week_label="S011", tss_target=400, notes="taper"),
+            ],
+            ctl_target=64,
+            peak_event=PeakEvent(name="La Marmotte", date=date(2026, 6, 28)),
+        )
+        assert obj.weekly_tss[1].notes == "taper"
+
+    def test_zero_tss_rejected(self):
+        with pytest.raises(ValidationError):
+            WeeklyTssTarget(week_label="S001", tss_target=0)
+
+
+# ---------------------------------------------------------------------------
+# NutritionStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestNutritionStrategy:
+    def test_minimal_valid(self):
+        obj = NutritionStrategy(carbs_per_hour_min=70, carbs_per_hour_max=80)
+        assert obj.known_issues == []
+
+    def test_with_issues(self):
+        obj = NutritionStrategy(
+            carbs_per_hour_min=70,
+            carbs_per_hour_max=80,
+            known_issues=["crampes d'estomac sur 4h+"],
+        )
+        assert "crampes" in obj.known_issues[0]
+
+    def test_inverted_range_rejected(self):
+        with pytest.raises(ValidationError, match="carbs_per_hour_max"):
+            NutritionStrategy(carbs_per_hour_min=90, carbs_per_hour_max=60)
+
+
+# ---------------------------------------------------------------------------
+# SleepBaseline
+# ---------------------------------------------------------------------------
+
+
+class TestSleepBaseline:
+    def test_minimal_valid(self):
+        obj = SleepBaseline(avg_duration_minutes=446, deficit_per_night_minutes=34)
+        assert obj.bedtime_target is None
+
+    def test_with_bedtime(self):
+        obj = SleepBaseline(
+            avg_duration_minutes=446,
+            deficit_per_night_minutes=34,
+            bedtime_target="23:00",
+        )
+        assert obj.bedtime_target == "23:00"
+
+    def test_invalid_bedtime_format_rejected(self):
+        with pytest.raises(ValidationError):
+            SleepBaseline(
+                avg_duration_minutes=446,
+                deficit_per_night_minutes=34,
+                bedtime_target="2300",
+            )
+
+    def test_negative_deficit_rejected(self):
+        with pytest.raises(ValidationError):
+            SleepBaseline(avg_duration_minutes=446, deficit_per_night_minutes=-1)
+
+
+# ---------------------------------------------------------------------------
+# AvailabilityPattern
+# ---------------------------------------------------------------------------
+
+
+class TestAvailabilityPattern:
+    def test_minimal_valid(self):
+        obj = AvailabilityPattern()
+        assert obj.weekly_slots == []
+
+    def test_with_slots(self):
+        obj = AvailabilityPattern(
+            weekly_slots=[
+                AvailabilitySlot(
+                    day_of_week="mon",
+                    time_window="12:00-13:30",
+                    activity="velocommute",
+                    typical_tss=16,
+                ),
+                AvailabilitySlot(
+                    day_of_week="sat",
+                    time_window="08:00-12:00",
+                    activity="sortie longue",
+                ),
+            ],
+        )
+        assert obj.weekly_slots[0].typical_tss == 16
+
+    def test_invalid_day_rejected(self):
+        with pytest.raises(ValidationError):
+            AvailabilitySlot(
+                day_of_week="monday",  # type: ignore[arg-type]
+                time_window="12:00-13:30",
+                activity="velocommute",
+            )
+
+    def test_invalid_time_window_rejected(self):
+        with pytest.raises(ValidationError):
+            AvailabilitySlot(
+                day_of_week="mon",
+                time_window="12h-13h30",
+                activity="velocommute",
+            )
+
+
+# ---------------------------------------------------------------------------
+# YAML I/O — using HrvBaseline + InjuryHistory as representatives.
+# The save/load/clear helpers share the same generic backend, so per-field
+# duplication would be redundant; we still spot-check the round trip on each
+# field below.
+# ---------------------------------------------------------------------------
+
+
+class TestHrvBaselineYamlIo:
+    def test_load_returns_none_when_yaml_absent(self, tmp_path: Path):
+        assert load_hrv_baseline(tmp_path / "absent.yaml") is None
+
+    def test_load_returns_none_when_key_absent(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text("athlete:\n  name: Test\n", encoding="utf-8")
+        assert load_hrv_baseline(yaml_path) is None
+
+    def test_invalid_payload_returns_none(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text(
+            "athlete:\n  hrv_baseline:\n    rmssd_min: 50\n",  # missing required
+            encoding="utf-8",
+        )
+        assert load_hrv_baseline(yaml_path) is None
+
+    def test_save_creates_yaml(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        obj = HrvBaseline(rmssd_min=50, rmssd_max=53, alert_threshold=46)
+        save_hrv_baseline(obj, yaml_path)
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        assert data["athlete"]["hrv_baseline"]["rmssd_min"] == 50
+
+    def test_save_preserves_other_athlete_fields(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        yaml_path.write_text("athlete:\n  name: Test\n  age: 54\n", encoding="utf-8")
+        save_hrv_baseline(HrvBaseline(rmssd_min=50, rmssd_max=53, alert_threshold=46), yaml_path)
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        assert data["athlete"]["name"] == "Test"
+        assert data["athlete"]["age"] == 54
+        assert data["athlete"]["hrv_baseline"]["rmssd_min"] == 50
+
+    def test_clear_returns_none_when_absent(self, tmp_path: Path):
+        assert clear_hrv_baseline(tmp_path / "absent.yaml") is None
+
+    def test_clear_removes_existing(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        save_hrv_baseline(HrvBaseline(rmssd_min=50, rmssd_max=53, alert_threshold=46), yaml_path)
+        clear_hrv_baseline(yaml_path)
+        assert load_hrv_baseline(yaml_path) is None
+
+
+class TestRoundTripAllFields:
+    def test_injury_history(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        original = InjuryHistory(
+            active=[Injury(area="genou droit", status="monitoring")],
+            watch_points=["volume montee progressif"],
+        )
+        save_injury_history(original, yaml_path)
+        assert load_injury_history(yaml_path) == original
+
+    def test_macro_plan(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        original = MacroPlan(
+            weekly_tss=[WeeklyTssTarget(week_label="S010", tss_target=550)],
+            ctl_target=64,
+            peak_event=PeakEvent(
+                name="La Marmotte",
+                date=date(2026, 6, 28),
+                tsb_target_min=10,
+                tsb_target_max=15,
+            ),
+        )
+        save_macro_plan(original, yaml_path)
+        assert load_macro_plan(yaml_path) == original
+
+    def test_nutrition_strategy(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        original = NutritionStrategy(
+            carbs_per_hour_min=70,
+            carbs_per_hour_max=80,
+            known_issues=["crampes d'estomac sur 4h+"],
+        )
+        save_nutrition_strategy(original, yaml_path)
+        assert load_nutrition_strategy(yaml_path) == original
+
+    def test_sleep_baseline(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        original = SleepBaseline(
+            avg_duration_minutes=446,
+            deficit_per_night_minutes=34,
+            bedtime_target="23:00",
+        )
+        save_sleep_baseline(original, yaml_path)
+        assert load_sleep_baseline(yaml_path) == original
+
+    def test_availability_pattern(self, tmp_path: Path):
+        yaml_path = tmp_path / "athlete.yaml"
+        original = AvailabilityPattern(
+            weekly_slots=[
+                AvailabilitySlot(
+                    day_of_week="mon",
+                    time_window="12:00-13:30",
+                    activity="velocommute",
+                    typical_tss=16,
+                ),
+            ],
+        )
+        save_availability_pattern(original, yaml_path)
+        assert load_availability_pattern(yaml_path) == original
+
+    def test_clear_keeps_other_rich_fields(self, tmp_path: Path):
+        """Clearing one field must not touch the others."""
+        yaml_path = tmp_path / "athlete.yaml"
+        save_hrv_baseline(HrvBaseline(rmssd_min=50, rmssd_max=53, alert_threshold=46), yaml_path)
+        save_sleep_baseline(
+            SleepBaseline(avg_duration_minutes=446, deficit_per_night_minutes=34),
+            yaml_path,
+        )
+        clear_hrv_baseline(yaml_path)
+        assert load_hrv_baseline(yaml_path) is None
+        sleep = load_sleep_baseline(yaml_path)
+        assert sleep is not None
+        assert sleep.avg_duration_minutes == 446


### PR DESCRIPTION
## Summary

Adds 6 new typed fields to the user athlete YAML, dispatched from `update-athlete-profile`:

- `hrv_baseline` — rMSSD range + fatigue alert threshold + documented anomalies (with per-anomaly `exclude_from_stats` flag) + recovery pattern
- `injury_history` — active injuries (area / status / dates / notes) + standing watch points
- `macro_plan` — weekly TSS targets + CTL target + peak event (with TSB target range)
- `nutrition_strategy` — carbs/h range + known issues
- `sleep_baseline` — avg duration + nightly deficit + bedtime target (HH:MM)
- `availability_pattern` — recurring weekly slots (day / time window / activity / typical TSS)

All follow the existing `priority_objective` convention: pydantic model with `extra="forbid"` + `frozen=True`, save/load/clear helpers via `magma_cycling.config._yaml_io`, stored under `athlete.<field>` of the user YAML (bundle never touched). Each field is migration-noop (missing key → `None`).

Cross-field validators reject inconsistent payloads (rmssd range, TSB range, carbs range, etc.).

`get-athlete-profile` returns the 6 new fields alongside the existing payload.

JSON Schema MCP describes each field's structure (required keys, enums, regex patterns for HH:MM / HH:MM-HH:MM).

Out of scope intentionally:
- Coach AI prompts/missions consumption of these fields (separate workstream once Max validates the structure)
- FTP / FC zones / max_hr / resting_hr — already handled via Intervals.icu

## Test plan
- [x] 42 unit tests in `tests/config/test_profile_rich.py` (pydantic validation, validators, YAML I/O round-trips, isolation between fields)
- [x] 10 existing handler tests pass unchanged
- [ ] CI green on all 6 required checks
- [ ] Manual smoke check via MCP client once merged