### PR TITLE
fix(workout-parser): tolerate Intervals.icu textevent prefixes

### DIFF
--- a/magma_cycling/workout_parser.py
+++ b/magma_cycling/workout_parser.py
@@ -86,13 +86,20 @@ def parse_workout_text(text: str) -> list[WorkoutBlock]:
     current_repeat = 1
     repeat_buffer: list[WorkoutBlock] = []
 
-    # Block pattern: - 10m ramp 50-65% 85rpm  OR  - 45m 68-72% 88rpm  OR  - 3m 65% 90rpm
+    # Block payload pattern. Matched anywhere AFTER the leading bullet so any
+    # Intervals.icu native textevent prefix (`NN^ Text …` or `Text1. Text2. …`)
+    # is transparently skipped. Examples that now parse:
+    #   - 10m ramp 50-65% 85rpm
+    #   - 45m 68-72% 88rpm
+    #   - 20^ First 5m 85% 90rpm              (cue with offset/duration)
+    #   - First. Second. Third. 10m 65% 90rpm (multi cues)
     block_re = re.compile(
-        r"^-\s+(\d+)m\s+"  # duration
+        r"(\d+)m\s+"  # duration
         r"(ramp\s+)?"  # optional ramp
         r"(\d+)(?:-(\d+))?%\s+"  # intensity (single or range)
         r"(\d+)rpm"  # cadence
     )
+    bullet_re = re.compile(r"^-\s+")
     # Phase header pattern
     warmup_re = re.compile(r"^Warmup\b", re.IGNORECASE)
     main_re = re.compile(r"^Main\s+set(?:\s+(\d+)x)?", re.IGNORECASE)
@@ -138,8 +145,10 @@ def parse_workout_text(text: str) -> list[WorkoutBlock]:
             current_repeat = 1
             continue
 
-        # Parse block
-        m = block_re.match(line)
+        # Parse block (bullet first, then search anywhere in the body so
+        # native Intervals.icu textevent prefixes are skipped transparently)
+        bullet = bullet_re.match(line)
+        m = block_re.search(line[bullet.end() :]) if bullet else None
         if m and current_phase is not None:
             duration_min = int(m.group(1))
             is_ramp = m.group(2) is not None

--- a/tests/test_workout_parser.py
+++ b/tests/test_workout_parser.py
@@ -145,6 +145,56 @@ Séance reportée à samedi matin (S081-06a)
         blocks = parse_workout_text(text)
         assert blocks == []
 
+    def test_block_with_offset_textevent_prefix(self):
+        """`NN^ Text` cue prefix is skipped, the block payload still parses.
+
+        Intervals.icu native syntax for an anchored cue (display Text for NN
+        seconds at the start of the step) — see reference memory
+        ``reference_intervals_icu_step_text_cue_syntax``.
+        """
+        text = """\
+Cue Demo (15min, 13 TSS)
+
+Warmup
+- 5m ramp 50-65% 85rpm
+
+Main set
+- 20^ First 5m 85% 90rpm
+
+Cooldown
+- 5m ramp 65-50% 85rpm
+"""
+        blocks = parse_workout_text(text)
+        main = [b for b in blocks if b.phase == Phase.MAIN_SET]
+        assert len(main) == 1
+        assert main[0].duration_seconds == 5 * 60
+        assert main[0].intensity_low == 85
+        assert main[0].cadence == 90
+
+    def test_block_with_multi_textevent_prefix(self):
+        """`Text1. Text2. Text3.` cues prefix is skipped, block payload parses.
+
+        Intervals.icu native syntax for multiple cues spread across the step.
+        """
+        text = """\
+Cue Demo (15min, 13 TSS)
+
+Warmup
+- 5m ramp 50-65% 85rpm
+
+Main set
+- First. Second. Third. 10m 65% 90rpm
+
+Cooldown
+- 5m ramp 65-50% 85rpm
+"""
+        blocks = parse_workout_text(text)
+        main = [b for b in blocks if b.phase == Phase.MAIN_SET]
+        assert len(main) == 1
+        assert main[0].duration_seconds == 10 * 60
+        assert main[0].intensity_low == 65
+        assert main[0].cadence == 90
+
 
 class TestClassifyIntervalType:
     """Tests for classify_interval_type()."""


### PR DESCRIPTION
## Summary

`parse_workout_text` used to anchor the block regex at the start of the line via `match`. Any prefix between the bullet and the duration token (Intervals.icu native textevent cues, comments) caused a silent miss → empty block list → `apply-workout-intervals` falsely fell back to *« Workout … is a rest day (no blocks to apply) »*. Observed on a real Coach AI-produced description for S099-03.

The two textevent syntaxes officially supported by Intervals.icu (forum post by David Tinker, https://forum.intervals.icu/t/text-events-are-now-supported-in-the-workout-builder/96016) :

- `- 20^ First 5m 85% 90rpm` — anchored cue with offset/duration
- `- First. Second. Third. 10m 65% 90rpm` — multiple cues spread across the step

Fix: keep the bullet check (`^-\s+`) at the line start, then `search` the block payload anywhere in the rest of the line. Non-block prefixes are now skipped transparently, no `WorkoutBlock` schema change.

Out of scope (separate workstreams):
- Teaching the Coach AI prompts the cue grammar so the LLM emits cues by design (WS-A)
- Tolerating an omitted `Nrpm` cadence token — distinct failure mode

(Re-publication sous identité bot, vault age recipient fixé. Première publication = PR #412 fermée.)

## Test plan
- [x] 2 new tests reproducing both textevent syntaxes (offset cue + multi-cues)
- [x] 22 existing `parse_workout_text` / `classify_interval_type` / `compute_intervals` / `calculate_workout_duration` tests pass unchanged
- [ ] CI green on all 6 required checks